### PR TITLE
JIT compilation and separate execution modes

### DIFF
--- a/include/parcels.h
+++ b/include/parcels.h
@@ -1,0 +1,70 @@
+#include <stdio.h>
+
+/* Grid dimension to be defined during the JIT process */
+extern const int GRID_XDIM;
+extern const int GRID_YDIM;
+
+/* Default definition of Particle type structure */
+#ifndef PARCELS_PTYPE
+#define PARCELS_PTYPE
+typedef struct
+{
+  float lon, lat;
+  int xi, yi;
+} Particle;
+#endif
+
+
+/* Local search to update grid index */
+static inline int advance_index(float x, int i, int size, float *xvals)
+{
+    while (i < size-1 && x > xvals[i+1]) ++i;
+    while (i > 0 && x < xvals[i]) --i;
+    return i;
+}
+
+
+/* Bilinear interpolation routine for 2D grid */
+static inline float interpolate_bilinear(float x, float y, int xi, int yi,
+                                        float xvals[GRID_XDIM], float yvals[GRID_YDIM],
+                                        float qvals[GRID_YDIM][GRID_XDIM])
+{
+  int i = xi, j = yi;
+  i = advance_index(x, i, GRID_XDIM, xvals);
+  j = advance_index(y, j, GRID_YDIM, yvals);
+  return (qvals[i][j] * (xvals[i+1] - x) * (yvals[j+1] - y)
+        + qvals[i+1][j] * (x - xvals[i]) * (yvals[j+1] - y)
+        + qvals[i][j+1] * (xvals[i+1] - x) * (y - yvals[j])
+        + qvals[i+1][j+1] * (x - xvals[i]) * (y - yvals[j]))
+        / ((xvals[i+1] - xvals[i]) * (yvals[j+1] - yvals[j]));
+}
+
+
+/* 4th-order Runge-Kutta algorithm for 2D grid */
+static inline void runge_kutta4(Particle *p, float dt,
+                                float lon_u[GRID_XDIM], float lat_u[GRID_YDIM],
+                                float lon_v[GRID_XDIM], float lat_v[GRID_YDIM],
+                                float u[GRID_YDIM][GRID_XDIM], float v[GRID_YDIM][GRID_XDIM])
+{
+  float f, u1, v1, u2, v2, u3, v3, u4, v4;
+  float lon1, lat1, lon2, lat2, lon3, lat3;
+
+  f = dt / 1000. / 1.852 / 60.;
+  u1 = interpolate_bilinear(p->lat, p->lon, p->yi, p->xi, lat_u, lon_u, u);
+  v1 = interpolate_bilinear(p->lat, p->lon, p->yi, p->xi, lat_v, lon_v, v);
+  lon1 = p->lon + u1*.5*f; lat1 = p->lat + v1*.5*f;
+  u2 = interpolate_bilinear(lat1, lon1, p->yi, p->xi, lat_u, lon_u, u);
+  v2 = interpolate_bilinear(lat1, lon1, p->yi, p->xi, lat_v, lon_v, v);
+  lon2 = p->lon + u2*.5*f; lat2 = p->lat + v2*.5*f;
+  u3 = interpolate_bilinear(lat2, lon2, p->yi, p->xi, lat_u, lon_u, u);
+  v3 = interpolate_bilinear(lat2, lon2, p->yi, p->xi, lat_v, lon_v, v);
+  lon3 = p->lon + u3*f; lat3 = p->lat + v3*f;
+  u4 = interpolate_bilinear(lat3, lon3, p->yi, p->xi, lat_u, lon_u, u);
+  v4 = interpolate_bilinear(lat3, lon3, p->yi, p->xi, lat_v, lon_v, v);
+
+  // Advance particle position in space and on the grid
+  p->lon += (u1 + 2*u2 + 2*u3 + u4) / 6. * f;
+  p->lat += (v1 + 2*v2 + 2*v3 + v4) / 6. * f;
+  p->xi = advance_index(p->lon, p->xi, GRID_XDIM, lon_u);
+  p->yi = advance_index(p->lat, p->yi, GRID_YDIM, lat_u);
+}

--- a/parcels/__init__.py
+++ b/parcels/__init__.py
@@ -1,2 +1,3 @@
 from parcels.nemo_grid import *
 from parcels.particle import *
+from parcels.cython_particle import *

--- a/parcels/cython_particle.pyx
+++ b/parcels/cython_particle.pyx
@@ -25,7 +25,7 @@ class CythonParticleSet(ParticleSet):
             np.ndarray[np.float32_t, ndim=1, mode="c"] lat_v = self._grid.V.lat,
             np.ndarray[np.float32_t, ndim=2, mode="c"] V = self._grid.V.data
         print "Parcels::CythonParticleSet: Advecting %d particles for %d timesteps" \
-            % (self._npart, timesteps)
+            % (len(self), timesteps)
 
         for t in range(tsteps):
             for p in self._particles:
@@ -38,9 +38,12 @@ cdef class CythonParticle(object):
     cdef public np.float32_t lon, lat  # Particle position in (lon, lat)
     cdef public np.int32_t xi, yi      # Current indices on the underlying grid
 
-    def __cinit__(self, np.float32_t lon, np.float32_t lat):
+    def __cinit__(self, np.float32_t lon, np.float32_t lat, grid):
         self.lon = lon
         self.lat = lat
+
+        self.xi = np.where(self.lon > grid.U.lon)[0][-1]
+        self.yi = np.where(self.lat > grid.U.lat)[0][-1]
 
     def __repr__(self):
         return "P(%f, %f)[%d, %d]" % (self.lon, self.lat, self.xi, self.yi)

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -43,13 +43,13 @@ class Field(object):
 
         # Create DataArray objects for file I/O
         x, y = (self.lon.size, self.lat.size)
-        nav_lon = DataArray(self.lon + np.zeros((y, x)),
+        nav_lon = DataArray(self.lon + np.zeros((y, x), dtype=np.float32),
                             coords=[('y', self.lat), ('x', self.lon)])
-        nav_lat = DataArray(self.lat.reshape(y, 1) + np.zeros(x),
+        nav_lat = DataArray(self.lat.reshape(y, 1) + np.zeros(x, dtype=np.float32),
                             coords=[('y', self.lat), ('x', self.lon)])
         vardata = DataArray(self.data.reshape((1, 1, y, x)),
                             coords=[('time_counter', np.zeros(1, dtype=np.float64)),
-                                    (vname_depth, np.zeros(1, dtype=np.float)),
+                                    (vname_depth, np.zeros(1, dtype=np.float32)),
                                     ('y', self.lat), ('x', self.lon)])
         # Create xray Dataset and output to netCDF format
         dset = Dataset({varname: vardata}, coords={'nav_lon': nav_lon,

--- a/parcels/jit_module.py
+++ b/parcels/jit_module.py
@@ -18,17 +18,14 @@ class Kernel(object):
         self.log_file = str(path.local("%s.log" % self.filename))
         self._lib = None
 
-    def generate_code(self, grid):
-        parameters = dict(xdim=grid.U.lon.size, ydim=grid.U.lat.size)
+    def generate_code(self, grid, ptype):
+        parameters = dict(xdim=grid.U.lon.size, ydim=grid.U.lat.size,
+                          ptype=ptype.code)
         self.code = """
 #include <stdio.h>
 
 
-typedef struct
-{
-    float lon, lat;
-    int xi, yi;
-} Particle;
+%(ptype)s
 
 
 static inline int advance_index(float x, int i, int size, float *xvals)
@@ -111,7 +108,7 @@ void particle_loop(int num_particles, Particle *particles,
 
     def execute(self, pset, timesteps, dt):
         grid = pset._grid
-        self._function(c_int(len(pset)), pset._p_array.ctypes.data_as(c_void_p),
+        self._function(c_int(len(pset)), pset._particle_data.ctypes.data_as(c_void_p),
                        c_int(timesteps), c_float(dt),
                        grid.U.lon.ctypes.data_as(c_void_p), grid.U.lat.ctypes.data_as(c_void_p),
                        grid.V.lon.ctypes.data_as(c_void_p), grid.V.lat.ctypes.data_as(c_void_p),

--- a/parcels/jit_module.py
+++ b/parcels/jit_module.py
@@ -1,0 +1,88 @@
+from py import path
+import subprocess
+from os import environ
+
+
+class Kernel(object):
+    """Kernel object that encapsulates auto-generated code.
+
+    :arg filename: Basename for kernel files to generate"""
+
+    def __init__(self, filename):
+        self.code = ""
+        self.filename = filename
+        self.src_file = str(path.local("%s.c" % self.filename))
+        self.lib_file = str(path.local("%s.so" % self.filename))
+        self.log_file = str(path.local("%s.log" % self.filename))
+
+    def generate_code(self):
+        self.code = """
+#include <stdio.h>
+
+typedef struct
+{
+    float lon, lat;
+    int xi, yi;
+} Particle;
+
+void particle_kernel(Particle p)
+{
+    printf("Particle: P(%f, %f)[%d, %d]\\n", p.lon, p.lat, p.xi, p.yi);
+}
+"""
+
+    def compile(self, compiler):
+        """ Writes kernel code to file and compiles it."""
+        with file(self.src_file, 'w') as f:
+            f.write(self.code)
+        compiler.compile(self.src_file, self.lib_file, self.log_file)
+
+
+class Compiler(object):
+    """A compiler object for creating and loading shared libraries.
+
+    :arg cc: C compiler executable (can be overriden by exporting the
+        environment variable ``CC``).
+    :arg ld: Linker executable (optional, if ``None``, we assume the compiler
+        can build object files and link in a single invocation, can be
+        overridden by exporting the environment variable ``LDSHARED``).
+    :arg cppargs: A list of arguments to the C compiler (optional).
+    :arg ldargs: A list of arguments to the linker (optional)."""
+
+    def __init__(self, cc, ld=None, cppargs=[], ldargs=[]):
+        self._cc = environ.get('CC', cc)
+        self._ld = environ.get('LDSHARED', ld)
+        self._cppargs = cppargs
+        self._ldargs = ldargs
+
+
+    def compile(self, src, obj, log):
+        cc = [self._cc] + self._cppargs + ['-o', obj, src] + self._ldargs
+        with file(log, 'w') as logfile:
+            logfile.write("Compiling: %s\n" % " ".join(cc))
+            try:
+                subprocess.check_call(cc, stdout=logfile, stderr=logfile)
+            except OSError:
+                err = """OSError during compilation
+Please check if compiler exists: %s""" % self._cc
+                raise RuntimeError(err)
+            except subprocess.CalledProcessError:
+                err = """Error during compilation:
+Compilation command: %s
+Source file: %s
+Log file: %s""" % (" ".join(cc), src, logfile.name)
+                raise RuntimeError(err)
+        print "Compiled:", obj
+
+
+class GNUCompiler(Compiler):
+    """A compiler object for the GNU Linux toolchain.
+
+    :arg cppargs: A list of arguments to pass to the C compiler
+         (optional).
+    :arg ldargs: A list of arguments to pass to the linker (optional)."""
+    def __init__(self, cppargs=[], ldargs=[]):
+        opt_flags = ['-g', '-O3']
+        cppargs = ['-Wall', '-fPIC'] + opt_flags + cppargs
+        ldargs = ['-shared'] + ldargs
+        super(GNUCompiler, self).__init__("gcc", cppargs=cppargs, ldargs=ldargs)

--- a/parcels/jit_module.py
+++ b/parcels/jit_module.py
@@ -111,7 +111,7 @@ void particle_loop(int num_particles, Particle *particles,
 
     def execute(self, pset, timesteps, dt):
         grid = pset._grid
-        self._function(c_int(pset._npart), pset._p_array.ctypes.data_as(c_void_p),
+        self._function(c_int(len(pset)), pset._p_array.ctypes.data_as(c_void_p),
                        c_int(timesteps), c_float(dt),
                        grid.U.lon.ctypes.data_as(c_void_p), grid.U.lat.ctypes.data_as(c_void_p),
                        grid.V.lon.ctypes.data_as(c_void_p), grid.V.lat.ctypes.data_as(c_void_p),

--- a/parcels/nemo_grid.py
+++ b/parcels/nemo_grid.py
@@ -31,8 +31,11 @@ class NEMOGrid(object):
 
         # Velocity data
         if transpose:
-            U = np.transpose(U)
-            V = np.transpose(V)
+            # Make a copy of the transposed array to enforce
+            # C-contiguous memory layout. This is required
+            # for Cython and JIT mode.
+            U = np.transpose(U).copy()
+            V = np.transpose(V).copy()
         self.U = Field('U', U, lon_u, lat_u)
         self.V = Field('V', V, lon_v, lat_v)
 

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -75,12 +75,6 @@ class JITParticleSet(ParticleSet):
     :param size: Initial size of particle set
     :param grid: Grid object from which to sample velocity"""
 
-    def generate_jit_kernel(self, filename):
-        self._kernel = Kernel(filename)
-        self._kernel.generate_code(self._grid)
-        self._kernel.compile(compiler=GNUCompiler())
-        self._kernel.load_lib()
-
     def advect(self, timesteps=1, dt=None):
         # Particle array for JIT kernel
         self._kernel = None
@@ -99,7 +93,10 @@ class JITParticleSet(ParticleSet):
             self._p_array[i]['yi'] = p.yi
 
         # Generate, compile and execute JIT kernel
-        self.generate_jit_kernel("particle_kernel")
+        self._kernel = Kernel("particle_kernel")
+        self._kernel.generate_code(self._grid)
+        self._kernel.compile(compiler=GNUCompiler())
+        self._kernel.load_lib()
         self._kernel.execute(self, timesteps, dt)
 
         # Transferrring particle data back onto original array

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -83,7 +83,8 @@ class ParticleType(object):
     def code(self, name='Particle'):
         """Type definition for the corresponding C struct"""
         tdef = '\n'.join(['  %s %s;' % (ctype[t], v) for v, t in self.base + self.user])
-        return """typedef struct
+        return """#define PARCELS_PTYPE
+typedef struct
 {
 %s
 } %s;""" % (tdef, name)
@@ -136,7 +137,7 @@ class JITParticleSet(ParticleSet):
 
         # Generate, compile and execute JIT kernel
         self._kernel = Kernel("particle_kernel")
-        self._kernel.generate_code(self._grid, self.ptype)
+        self._kernel.generate_code(self._grid, ptype=self.ptype)
         self._kernel.compile(compiler=GNUCompiler())
         self._kernel.load_lib()
         self._kernel.execute(self, timesteps, dt)

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -7,7 +7,12 @@ ctype = {np.int32: 'int', np.float32: 'float'}
 
 
 class Particle(object):
-    """Class encapsualting the basic attributes of a particle"""
+    """Class encapsualting the basic attributes of a particle
+
+    :param lon: Initial longitude of particle
+    :param lat: Initial latitude of particle
+    :param grid: :Class Grid: object to track this particle on
+    """
 
     def __init__(self, lon, lat, grid):
         self.lon = lon
@@ -68,7 +73,10 @@ class ParticleSet(object):
 
 
 class ParticleType(object):
-    """Class encapsulating the type information for custom particles"""
+    """Class encapsulating the type information for custom particles
+
+    :param user: Optional list of (name, dtype) tuples for custom variables
+    """
 
     def __init__(self, user=[]):
         self.base = [('lon', np.float32), ('lat', np.float32),
@@ -77,6 +85,7 @@ class ParticleType(object):
 
     @property
     def dtype(self):
+        """Numpy.dtype object that defines the C struct"""
         return np.dtype(self.base + self.user)
 
     @property
@@ -91,6 +100,14 @@ typedef struct
 
 
 class JITParticle(Particle):
+    """Particle class for JIT-based Particle objects
+
+    Users should extend this type for custom particles with fast
+    advection computation. Additional variables need to be defined
+    via the :user_vars: list of (name, dtype) tuples.
+
+    :param user_vars: Class variable that defines additional particle variables
+    """
 
     user_vars = []
 
@@ -113,13 +130,17 @@ class JITParticle(Particle):
 
 class JITParticleSet(ParticleSet):
     """Container class for storing and executing over sets of
-    particles using Just-in-Time (JIT) compialtion techniques.
+    particles using Just-in-Time (JIT) compilation techniques.
 
     Please note that this currently only supports fixed size particle
     sets.
 
     :param size: Initial size of particle set
-    :param grid: Grid object from which to sample velocity"""
+    :param grid: Grid object from which to sample velocity
+    :param pclass: Optional class object that defines custom particle
+    :param lon: List of initial longitude values for particles
+    :param lat: List of initial latitude values for particles
+    """
 
     def __init__(self, size, grid, pclass=JITParticle, lon=None, lat=None):
         self._grid = grid

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -37,9 +37,9 @@ class ParticleSet(object):
     :param size: Initial size of particle set
     :param grid: Grid object from which to sample velocity"""
 
-    def __init__(self, size, grid):
+    def __init__(self, size, grid, pclass=Particle):
         self._grid = grid
-        self._particles = np.empty(size, dtype=Particle)
+        self._particles = np.empty(size, dtype=pclass)
         self._npart = 0
 
     def add_particle(self, p):
@@ -66,9 +66,9 @@ class JITParticleSet(object):
     :param size: Initial size of particle set
     :param grid: Grid object from which to sample velocity"""
 
-    def __init__(self, size, grid):
+    def __init__(self, size, grid, pclass=Particle):
         self._grid = grid
-        self._particles = np.empty(size, dtype=Particle)
+        self._particles = np.empty(size, dtype=pclass)
         self._npart = 0
 
         # Particle array for JIT kernel

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -38,9 +38,15 @@ class ParticleSet(object):
     :param size: Initial size of particle set
     :param grid: Grid object from which to sample velocity"""
 
-    def __init__(self, size, grid, pclass=Particle):
+    def __init__(self, size, grid, pclass=Particle, lon=None, lat=None):
         self._grid = grid
         self._particles = np.empty(size, dtype=pclass)
+
+        if lon is not None and lat is not None:
+            for i in range(size):
+                self._particles[i] = pclass(lon=lon[i], lat=lat[i], grid=grid)
+        else:
+            raise ValueError("Latitude and longitude required for generating ParticleSet")
 
     def __len__(self):
         return self._particles.size

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -1,0 +1,112 @@
+import numpy as np
+from parcels.jit_module import Kernel, GNUCompiler
+
+__all__ = ['Particle', 'ParticleSet', 'JITParticleSet']
+
+
+class Particle(object):
+    """Class encapsualting the basic attributes of a particle"""
+
+    def __init__(self, lon, lat):
+        self.lon = lon
+        self.lat = lat
+        self.xi = None
+        self.yi = None
+
+    def __repr__(self):
+        return "P(%f, %f)[%d, %d]" % (self.lon, self.lat, self.xi, self.yi)
+
+    def advect_rk4(self, grid, dt):
+        f = dt / 1000. / 1.852 / 60.
+        u1, v1 = grid.eval(self.lon, self.lat)
+        lon1, lat1 = (self.lon + u1*.5*f, self.lat + v1*.5*f)
+        u2, v2 = grid.eval(lon1, lat1)
+        lon2, lat2 = (self.lon + u2*.5*f, self.lat + v2*.5*f)
+        u3, v3 = grid.eval(lon2, lat2)
+        lon3, lat3 = (self.lon + u3*f, self.lat + v3*f)
+        u4, v4 = grid.eval(lon3, lat3)
+        self.lon += (u1 + 2*u2 + 2*u3 + u4) / 6. * f
+        self.lat += (v1 + 2*v2 + 2*v3 + v4) / 6. * f
+
+
+class ParticleSet(object):
+    """Container class for storing and executing over sets of particles.
+
+    Please note that this currently only supports fixed size particle sets.
+
+    :param size: Initial size of particle set
+    :param grid: Grid object from which to sample velocity"""
+
+    def __init__(self, size, grid):
+        self._grid = grid
+        self._particles = np.empty(size, dtype=Particle)
+        self._npart = 0
+
+    def add_particle(self, p):
+        p.xi = np.where(p.lon > self._grid.U.lon)[0][-1]
+        p.yi = np.where(p.lat > self._grid.U.lat)[0][-1]
+        self._particles[self._npart] = p
+        self._npart += 1
+
+    def advect(self, timesteps=1, dt=None):
+        print "Parcels::ParticleSet: Advecting %d particles for %d timesteps" \
+            % (self._npart, timesteps)
+        for t in range(timesteps):
+            for p in self._particles:
+                p.advect_rk4(self._grid, dt)
+
+
+class JITParticleSet(object):
+    """Container class for storing and executing over sets of
+    particles using Just-in-Time (JIT) compialtion techniques.
+
+    Please note that this currently only supports fixed size particle
+    sets.
+
+    :param size: Initial size of particle set
+    :param grid: Grid object from which to sample velocity"""
+
+    def __init__(self, size, grid):
+        self._grid = grid
+        self._particles = np.empty(size, dtype=Particle)
+        self._npart = 0
+
+        # Particle array for JIT kernel
+        self._kernel = None
+        self._p_dtype = np.dtype([('lon', np.float32), ('lat', np.float32),
+                                  ('xi', np.int32), ('yi', np.int32)])
+        self._p_array = np.empty(size, dtype=self._p_dtype)
+
+    def add_particle(self, p):
+        p.xi = np.where(p.lon > self._grid.U.lon)[0][-1]
+        p.yi = np.where(p.lat > self._grid.U.lat)[0][-1]
+        self._particles[self._npart] = p
+
+        # Populate the partcile's struct
+        self._p_array[self._npart]['lon'] = p.lon
+        self._p_array[self._npart]['lat'] = p.lat
+        self._p_array[self._npart]['xi'] = p.xi
+        self._p_array[self._npart]['yi'] = p.yi
+
+        self._npart += 1
+
+    def generate_jit_kernel(self, filename):
+        self._kernel = Kernel(filename)
+        self._kernel.generate_code(self._grid)
+        self._kernel.compile(compiler=GNUCompiler())
+        self._kernel.load_lib()
+
+    def advect(self, timesteps=1, dt=None):
+        print "Parcels::JITParticleSet: Advecting %d particles for %d timesteps" \
+            % (self._npart, timesteps)
+
+        # Generate, compile and execute JIT kernel
+        self.generate_jit_kernel("particle_kernel")
+        self._kernel.execute(self, timesteps, dt)
+
+        # Transferrring particle data back onto original array
+        for i, p in enumerate(self._particles):
+            p.lon = self._p_array[i]['lon']
+            p.lat = self._p_array[i]['lat']
+            p.xi = self._p_array[i]['xi']
+            p.yi = self._p_array[i]['yi']

--- a/parcels/particle.pyx
+++ b/parcels/particle.pyx
@@ -40,7 +40,7 @@ class ParticleSet(object):
 
     def generate_jit_kernel(self, filename):
         self._kernel = Kernel(filename)
-        self._kernel.generate_code()
+        self._kernel.generate_code(self._grid)
         self._kernel.compile(compiler=GNUCompiler())
         self._kernel.load_lib()
 
@@ -58,7 +58,7 @@ class ParticleSet(object):
             for p in self._particles:
                 p.advect_rk4_cython(self._grid, dt)
 
-        self._kernel.execute(self)
+        self._kernel.execute(self, timesteps, dt)
 
 
 cdef class Particle(object):

--- a/parcels/particle.pyx
+++ b/parcels/particle.pyx
@@ -66,6 +66,13 @@ class ParticleSet(object):
         self.generate_jit_kernel("particle_kernel")
         self._kernel.execute(self, timesteps, dt)
 
+        # Transferrring particle data back onto original array
+        for i, p in enumerate(self._particles):
+            p.lon = self._p_array[i]['lon']
+            p.lat = self._p_array[i]['lat']
+            p.xi = self._p_array[i]['xi']
+            p.yi = self._p_array[i]['yi']
+
 
 cdef class Particle(object):
     """Classe encapsualting the basic attributes of a particle"""

--- a/parcels/particle.pyx
+++ b/parcels/particle.pyx
@@ -32,6 +32,13 @@ class ParticleSet(object):
             for p in self._particles:
                 p.advect_rk4(self._grid, dt)
 
+    def advect_cython(self, timesteps=1, dt=None):
+        print "Parcels::ParticleSet: Advecting %d particles for %d timesteps" \
+            % (self._npart, timesteps)
+        for t in range(timesteps):
+            for p in self._particles:
+                p.advect_rk4_cython(self._grid, dt)
+
 
 cdef class Particle(object):
     """Classe encapsualting the basic attributes of a particle"""
@@ -62,3 +69,63 @@ cdef class Particle(object):
         u4, v4 = grid.eval(lon3, lat3)
         self.lon += (u1 + 2*u2 + 2*u3 + u4) / 6. * f
         self.lat += (v1 + 2*v2 + 2*v3 + v4) / 6. * f
+
+
+    def advect_rk4_cython(self, grid, np.float32_t dt):
+        cdef:
+            np.float32_t f, u1, v1, u2, v2, u3, v3, u4, v4
+            np.float32_t lon1, lat1, lon2, lat2, lon3, lat3
+        f = dt / 1000. / 1.852 / 60.
+        u1 = interpolate_bilinear(self.lat, self.lon, self.yi, self.xi,
+                                  grid.U.lat, grid.U.lon, grid.U.data)
+        v1 = interpolate_bilinear(self.lat, self.lon, self.yi, self.xi,
+                                  grid.V.lat, grid.V.lon, grid.V.data)
+        lon1, lat1 = (self.lon + u1*.5*f, self.lat + v1*.5*f)
+        u2 = interpolate_bilinear(lat1, lon1, self.yi, self.xi,
+                                  grid.U.lat, grid.U.lon, grid.U.data)
+        v2 = interpolate_bilinear(lat1, lon1, self.yi, self.xi,
+                                  grid.V.lat, grid.V.lon, grid.V.data)
+        lon2, lat2 = (self.lon + u2*.5*f, self.lat + v2*.5*f)
+        u3 = interpolate_bilinear(lat2, lon2, self.yi, self.xi,
+                                  grid.U.lat, grid.U.lon, grid.U.data)
+        v3 = interpolate_bilinear(lat2, lon2, self.yi, self.xi,
+                                  grid.V.lat, grid.V.lon, grid.V.data)
+        lon3, lat3 = (self.lon + u3*f, self.lat + v3*f)
+        u4 = interpolate_bilinear(lat3, lon3, self.yi, self.xi,
+                                  grid.U.lat, grid.U.lon, grid.U.data)
+        v4 = interpolate_bilinear(lat3, lon3, self.yi, self.xi,
+                                  grid.V.lat, grid.V.lon, grid.V.data)
+
+        # Advance particle position in space and on the grid
+        self.lon += (u1 + 2*u2 + 2*u3 + u4) / 6. * f
+        self.lat += (v1 + 2*v2 + 2*v3 + v4) / 6. * f
+        self.xi = advance_index(self.lon, self.xi, grid.U.lon)
+        self.yi = advance_index(self.lat, self.yi, grid.U.lat)
+
+cdef np.int32_t advance_index(np.float32_t x, np.int32_t i,
+                              np.ndarray[np.float32_t, ndim=1, mode="c"] xvals) except? -1:
+    while i < xvals.size-1 and x > xvals[i+1]:
+        i += 1
+    while i > 0 and x < xvals[i]:
+        i -= 1
+    return i
+
+cdef np.float32_t interpolate_bilinear(np.float32_t x, np.float32_t y,
+                                       np.int32_t xi, np.int32_t yi,
+                                       np.ndarray[np.float32_t, ndim=1, mode="c"] xvals,
+                                       np.ndarray[np.float32_t, ndim=1, mode="c"] yvals,
+                                       np.ndarray[np.float32_t, ndim=2, mode="c"] qvals) except? -1:
+    """Bilinear interpolation function
+
+    Computes f(x, y), given f(x0, y0), f(x0, y1), f(x1, y0) and f(x1, y1)
+    where x0 <= x <= x1 and y0 <= y <= y1
+
+    See https://en.wikipedia.org/wiki/Bilinear_interpolation
+    """
+    cdef np.int32_t i = xi, j = yi
+    i = advance_index(x, i, xvals)
+    j = advance_index(y, j, yvals)
+    return (qvals[i, j] * (xvals[i+1] - x) * (yvals[j+1] - y)
+        + qvals[i+1, j] * (x - xvals[i]) * (yvals[j+1] - y)
+        + qvals[i, j+1] * (xvals[i+1] - x) * (y - yvals[j])
+        + qvals[i+1, j+1] * (x - xvals[i]) * (y - yvals[j])) / ((xvals[i+1] - xvals[i]) * (yvals[j+1] - yvals[j]))

--- a/parcels/particle.pyx
+++ b/parcels/particle.pyx
@@ -58,6 +58,12 @@ class ParticleSet(object):
             for p in self._particles:
                 p.advect_rk4_cython(self._grid, dt)
 
+    def advect_jit(self, timesteps=1, dt=None):
+        print "Parcels::ParticleSet: Advecting %d particles for %d timesteps" \
+            % (self._npart, timesteps)
+
+        # Generate, compile and execute JIT kernel
+        self.generate_jit_kernel("particle_kernel")
         self._kernel.execute(self, timesteps, dt)
 
 

--- a/parcels/particle.pyx
+++ b/parcels/particle.pyx
@@ -18,8 +18,11 @@ class ParticleSet(object):
         self._particles = np.empty(size, dtype=Particle)
         self._npart = 0
 
-    def add_particle(self, particle):
-        self._particles[self._npart] = particle
+    def add_particle(self, p):
+        p.xi = np.where(p.lon > self._grid.U.lon)[0][-1]
+        p.yi = np.where(p.lat > self._grid.U.lat)[0][-1]
+
+        self._particles[self._npart] = p
         self._npart += 1
 
     def advect(self, timesteps=1, dt=None):
@@ -33,14 +36,15 @@ class ParticleSet(object):
 cdef class Particle(object):
     """Classe encapsualting the basic attributes of a particle"""
 
-    cdef public np.float32_t lon, lat
+    cdef public np.float32_t lon, lat  # Particle position in (lon, lat)
+    cdef public np.int32_t xi, yi      # Current indices on the underlying grid
 
     def __cinit__(self, np.float32_t lon, np.float32_t lat):
         self.lon = lon
         self.lat = lat
 
     def __repr__(self):
-        return "P(%f, %f)" % (self.lon, self.lat)
+        return "P(%f, %f)[%d, %d]" % (self.lon, self.lat, self.xi, self.yi)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/parcels/particle.pyx
+++ b/parcels/particle.pyx
@@ -1,6 +1,7 @@
 import numpy as np
 cimport numpy as np
 import cython
+from parcels.jit_module import Kernel, GNUCompiler
 
 __all__ = ['Particle', 'ParticleSet']
 
@@ -18,12 +19,19 @@ class ParticleSet(object):
         self._particles = np.empty(size, dtype=Particle)
         self._npart = 0
 
+        self._kernel = None
+
     def add_particle(self, p):
         p.xi = np.where(p.lon > self._grid.U.lon)[0][-1]
         p.yi = np.where(p.lat > self._grid.U.lat)[0][-1]
 
         self._particles[self._npart] = p
         self._npart += 1
+
+    def generate_jit_kernel(self, filename):
+        self._kernel = Kernel(filename)
+        self._kernel.generate_code()
+        self._kernel.compile(compiler=GNUCompiler())
 
     def advect(self, timesteps=1, dt=None):
         print "Parcels::ParticleSet: Advecting %d particles for %d timesteps" \

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 import numpy as np
 
 numpy_includes = [np.get_include()]
-particle_sources = ['parcels/particle.pyx']
+particle_sources = ['parcels/cython_particle.pyx']
 
 setup(name='parcels',
       version = '0.0.1',
@@ -14,6 +14,6 @@ setup(name='parcels',
       ocean particles in the petascale age.""",
       author = "Imperial College London",
       packages = ['parcels'],
-      ext_modules=[Extension('parcels.particle', particle_sources,
+      ext_modules=[Extension('parcels.cython_particle', particle_sources,
                              include_dirs=numpy_includes),]
 )

--- a/tests/grid_peninsula.py
+++ b/tests/grid_peninsula.py
@@ -32,15 +32,15 @@ class PeninsulaGrid(NEMOGrid):
         # Generate the original test setup on A-grid in km
         dx = 100. / xdim / 2.
         dy = 50. / ydim / 2.
-        La = np.linspace(dx, 100.-dx, xdim, dtype=np.float)
-        Wa = np.linspace(dy, 50.-dy, ydim, dtype=np.float)
+        La = np.linspace(dx, 100.-dx, xdim, dtype=np.float32)
+        Wa = np.linspace(dy, 50.-dy, ydim, dtype=np.float32)
 
         # Define arrays U (zonal), V (meridional), W (vertical) and P (sea
         # surface height) all on A-grid
-        U = np.zeros((xdim, ydim), dtype=np.float)
-        V = np.zeros((xdim, ydim), dtype=np.float)
-        W = np.zeros((xdim, ydim), dtype=np.float)
-        P = np.zeros((xdim, ydim), dtype=np.float)
+        U = np.zeros((xdim, ydim), dtype=np.float32)
+        V = np.zeros((xdim, ydim), dtype=np.float32)
+        W = np.zeros((xdim, ydim), dtype=np.float32)
+        P = np.zeros((xdim, ydim), dtype=np.float32)
 
         u0 = 1
         x0 = 50.

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -33,6 +33,9 @@ def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
         for p in pset._particles:
             print p
 
+    # Prepare JIT execution
+    pset.generate_jit_kernel("particle_kernel")
+
     # Advect the particles for 24h
     time = 86400.
     dt = 36.

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -26,10 +26,10 @@ def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
     # First, we define a custom Particle class to which we add a
     # custom variable, the initial stream function value p
     class MyParticle(ParticleClass):
-        def __init__(self, lon, lat):
+        def __init__(self, lon, lat, grid):
             """Custom initialisation function which calls the base
             initialisation and adds the instance variable p"""
-            super(MyParticle, self).__init__(lon, lat)
+            super(MyParticle, self).__init__(lon, lat, grid)
             self.p = None
 
         def __repr__(self):
@@ -43,11 +43,10 @@ def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
     km2deg = 1. / 1.852 / 60
     min_y = grid.U.lat[0] + 3. * km2deg
     max_y = grid.U.lat[-1] - 3. * km2deg
-    for lat in np.linspace(min_y, max_y, npart, dtype=np.float):
+    for i, lat in enumerate(np.linspace(min_y, max_y, npart, dtype=np.float)):
         lon = 3. * km2deg
-        particle = MyParticle(lon=lon, lat=lat)
-        particle.p = grid.P.eval(lon, lat)
-        pset.add_particle(particle)
+        pset[i] = MyParticle(lon=lon, lat=lat, grid=grid)
+        pset[i].p = grid.P.eval(lon, lat)
 
     if verbose:
         print "Initial particle positions:"
@@ -66,7 +65,7 @@ def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
             p_local = grid.P.eval(p.lon, p.lat)
             print p, "\tP(final)%.5f \tdelta(P): %0.5g" % (p_local, p_local - p.p)
 
-    return np.array([abs(p.p - grid.P.eval(p.lon, p.lat)) for p in pset._particles])
+    return np.array([abs(p.p - grid.P.eval(p.lon, p.lat)) for p in pset])
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'cython', 'jit'])

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -33,14 +33,13 @@ def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
         for p in pset._particles:
             print p
 
-    # Prepare JIT execution
-    pset.generate_jit_kernel("particle_kernel")
-
     # Advect the particles for 24h
     time = 86400.
     dt = 36.
     timesteps = int(time / dt)
-    if mode == 'cython':
+    if mode == 'jit':
+        pset.advect_jit(timesteps=timesteps, dt=dt)
+    elif mode == 'cython':
         pset.advect_cython(timesteps=timesteps, dt=dt)
     else:
         pset.advect(timesteps=timesteps, dt=dt)
@@ -76,7 +75,7 @@ def test_peninsula_file():
 if __name__ == "__main__":
     p = ArgumentParser(description="""
 Example of particle advection around an idealised peninsula""")
-    p.add_argument('mode', choices=('scipy', 'cython'), nargs='?', default='cython',
+    p.add_argument('mode', choices=('scipy', 'cython', 'jit'), nargs='?', default='jit',
                    help='Execution mode for performing RK4 computation')
     p.add_argument('-p', '--particles', type=int, default=20,
                    help='Number of particles to advect')

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -1,4 +1,4 @@
-from parcels import NEMOGrid, Particle, ParticleSet, JITParticleSet
+from parcels import NEMOGrid, Particle, ParticleSet, JITParticle, JITParticleSet
 from parcels import CythonParticle, CythonParticleSet
 from grid_peninsula import PeninsulaGrid
 from argparse import ArgumentParser
@@ -14,7 +14,7 @@ def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
 
     # Determine particle and set classes according to mode
     if mode == 'jit':
-        ParticleClass = Particle
+        ParticleClass = JITParticle
         PSetClass = JITParticleSet
     elif mode == 'cython':
         ParticleClass = CythonParticle
@@ -26,10 +26,14 @@ def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
     # First, we define a custom Particle class to which we add a
     # custom variable, the initial stream function value p
     class MyParticle(ParticleClass):
-        def __init__(self, lon, lat, grid):
+        # JIT compilation requires a-priori knowledge of the particle
+        # data structure, so we define additional variables here.
+        user_vars = [('p', np.float32)]
+
+        def __init__(self, *args, **kwargs):
             """Custom initialisation function which calls the base
             initialisation and adds the instance variable p"""
-            super(MyParticle, self).__init__(lon, lat, grid)
+            super(MyParticle, self).__init__(*args, **kwargs)
             self.p = None
 
         def __repr__(self):

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -36,21 +36,19 @@ def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
             """Custom print function which overrides the built-in"""
             return "P(%.4f, %.4f)[p=%.5f]" % (self.lon, self.lat, self.p)
 
-    # Build particle set according to execution mode
-    pset = PSetClass(npart, grid, pclass=MyParticle)
-
     # Initialise particles
     km2deg = 1. / 1.852 / 60
     min_y = grid.U.lat[0] + 3. * km2deg
     max_y = grid.U.lat[-1] - 3. * km2deg
-    for i, lat in enumerate(np.linspace(min_y, max_y, npart, dtype=np.float)):
-        lon = 3. * km2deg
-        pset[i] = MyParticle(lon=lon, lat=lat, grid=grid)
-        pset[i].p = grid.P.eval(lon, lat)
+    lon = 3. * km2deg * np.ones(npart)
+    lat = np.linspace(min_y, max_y, npart, dtype=np.float)
+    pset = PSetClass(npart, grid, pclass=MyParticle, lon=lon, lat=lat)
+    for particle in pset:
+        particle.p = grid.P.eval(particle.lon, particle.lat)
 
     if verbose:
         print "Initial particle positions:"
-        for p in pset._particles:
+        for p in pset:
             print p
 
     # Advect the particles for 24h
@@ -61,7 +59,7 @@ def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
 
     if verbose:
         print "Final particle positions:"
-        for p in pset._particles:
+        for p in pset:
             p_local = grid.P.eval(p.lon, p.lat)
             print p, "\tP(final)%.5f \tdelta(P): %0.5g" % (p_local, p_local - p.p)
 

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -11,7 +11,7 @@ class MyParticle(Particle):
         return "P(%.4f, %.4f)[p=%.5f]" % (self.lon, self.lat, self.p)
 
 
-def pensinsula_example(grid, npart, degree=3, verbose=False):
+def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
     """Example configuration of particle flow around an idealised Peninsula
 
     :arg filename: Basename of the input grid file set
@@ -37,7 +37,10 @@ def pensinsula_example(grid, npart, degree=3, verbose=False):
     time = 86400.
     dt = 36.
     timesteps = int(time / dt)
-    pset.advect(timesteps=timesteps, dt=dt)
+    if mode == 'cython':
+        pset.advect_cython(timesteps=timesteps, dt=dt)
+    else:
+        pset.advect(timesteps=timesteps, dt=dt)
 
     if verbose:
         print "Final particle positions:"
@@ -70,6 +73,8 @@ def test_peninsula_file():
 if __name__ == "__main__":
     p = ArgumentParser(description="""
 Example of particle advection around an idealised peninsula""")
+    p.add_argument('mode', choices=('scipy', 'cython'), nargs='?', default='cython',
+                   help='Execution mode for performing RK4 computation')
     p.add_argument('-p', '--particles', type=int, default=20,
                    help='Number of particles to advect')
     p.add_argument('-d', '--degree', type=int, default=3,
@@ -86,9 +91,10 @@ Example of particle advection around an idealised peninsula""")
     if args.profiling:
         from cProfile import runctx
         from pstats import Stats
-        runctx("pensinsula_example(grid, args.particles, degree=args.degree, verbose=args.verbose)",
+        runctx("pensinsula_example(grid, args.particles, mode=args.mode,\
+                                   degree=args.degree, verbose=args.verbose)",
                globals(), locals(), "Profile.prof")
         Stats("Profile.prof").strip_dirs().sort_stats("time").print_stats(10)
     else:
-        pensinsula_example(grid, args.particles, degree=args.degree,
-                           verbose=args.verbose)
+        pensinsula_example(grid, args.particles, mode=args.mode,
+                           degree=args.degree, verbose=args.verbose)

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -12,10 +12,20 @@ def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
     :arg filename: Basename of the input grid file set
     :arg npart: Number of particles to intialise"""
 
+    # Determine particle and set classes according to mode
+    if mode == 'jit':
+        ParticleClass = Particle
+        PSetClass = JITParticleSet
+    elif mode == 'cython':
+        ParticleClass = CythonParticle
+        PSetClass = CythonParticleSet
+    else:
+        ParticleClass = Particle
+        PSetClass = ParticleSet
+
     # First, we define a custom Particle class to which we add a
     # custom variable, the initial stream function value p
-    BaseClass = CythonParticle if mode=='cython' else Particle
-    class MyParticle(BaseClass):
+    class MyParticle(ParticleClass):
         def __init__(self, lon, lat):
             """Custom initialisation function which calls the base
             initialisation and adds the instance variable p"""
@@ -27,12 +37,7 @@ def pensinsula_example(grid, npart, mode='cython', degree=3, verbose=False):
             return "P(%.4f, %.4f)[p=%.5f]" % (self.lon, self.lat, self.p)
 
     # Build particle set according to execution mode
-    if mode == 'jit':
-        pset = JITParticleSet(npart, grid)
-    elif mode == 'cython':
-        pset = CythonParticleSet(npart, grid)
-    else:
-        pset = ParticleSet(npart, grid)
+    pset = PSetClass(npart, grid, pclass=MyParticle)
 
     # Initialise particles
     km2deg = 1. / 1.852 / 60


### PR DESCRIPTION
This merge adds the basic infrastructure for Just-In-Time (JIT) compilation and separates the three supported execution modes:
* `scipy`: Pure Python uses SciPy interpolation for evaluating fields on the grid
* `cython`: Speeds up execution significantly through pre-compilation at install time
* `jit`: Even greater speedup by compiling custom kernels at run-time, allowing us to insert constant array bounds and acting directly on the raw data under the numpy arrays (uses `JITParticle` and `JITParticleSet` classes). It also allows addition of custom particle variables to the underlying data type (C struct) at run-time and in-lining grid search and interpolation routines from our own header files.

All three modes are supported **for now** to do some performance testing. To do this use the `--profiling` flag on the peninsula test case.