### PR TITLE
Additional syntactic sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python tests/grid_peninsula.py <xdim> <ydim>
 where `xdim` and `ydim` are the numbers of grid cells in each
 dimension. The particle advection example can then be run with:
 ```
-python tests/test_peninsula.py -p <npart> --output
+python tests/test_peninsula.py -p <npart>
 ```
 where `npart` is the number of evenly initialised particles. The
 resulting particle trajectories can be visualised using Parcel's

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -1,5 +1,6 @@
 from netCDF4 import Dataset
 from parcels.field import Field
+from parcels.particle import ParticleSet
 from py import path
 from glob import glob
 
@@ -73,6 +74,9 @@ class NEMOGrid(object):
         u = fields.pop('U')
         v = fields.pop('V')
         return cls(u, v, u.depth, u.time, fields=fields)
+
+    def ParticleSet(self, *args, **kwargs):
+        return ParticleSet(*args, grid=self, **kwargs)
 
     def eval(self, x, y):
         u = self.U.eval(x, y)

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -114,7 +114,8 @@ class ParticleSet(object):
     :param lat: List of initial latitude values for particles
     """
 
-    def __init__(self, size, grid, pclass=JITParticle, lon=None, lat=None):
+    def __init__(self, size, grid, pclass=JITParticle,
+                 lon=None, lat=None, start=None, finish=None):
         self.grid = grid
         self.particles = np.empty(size, dtype=pclass)
         self.ptype = ParticleType(pclass)
@@ -129,6 +130,12 @@ class ParticleSet(object):
         else:
             def cptr(i):
                 return None
+
+        if start is not None and finish is not None:
+            # Initialise from start/finish coordinates with equidistant spacing
+            assert(lon is None and lat is None)
+            lon = np.linspace(start[0], finish[0], size, dtype=np.float32)
+            lat = np.linspace(start[1], finish[1], size, dtype=np.float32)
 
         if lon is not None and lat is not None:
             # Initialise from lists of lon/lat coordinates

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -181,7 +181,7 @@ class ParticleSet(object):
 
 class ParticleFile(object):
 
-    def __init__(self, name, particleset):
+    def __init__(self, name, particleset, initial_dump=True):
         """Initialise netCDF4.Dataset for trajectory output.
 
         The output follows the format outlined in the Discrete
@@ -194,6 +194,10 @@ class ParticleFile(object):
         Developer note: We cannot use xray.Dataset here, since it does
         not yet allow incremental writes to disk:
         https://github.com/xray/xray/issues/199
+
+        :param name: Basename of the output file
+        :param particlset: ParticleSet to output
+        :param initial_dump: Perform initial output at time 0.
         """
         self.dataset = netCDF4.Dataset("%s.nc" % name, "w", format="NETCDF4")
         self.dataset.createDimension("obs", None)
@@ -235,6 +239,9 @@ class ParticleFile(object):
         self.z.positive = "down"
 
         self.idx = 0
+
+        if initial_dump:
+            self.write(particleset, 0.)
 
     def __del__(self):
         self.dataset.close()

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -204,6 +204,9 @@ class ParticleSet(object):
             if output_file:
                 output_file.write(self, current)
 
+    def ParticleFile(self, *args, **kwargs):
+        return ParticleFile(*args, particleset=self, **kwargs)
+
 
 class ParticleFile(object):
 

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -41,35 +41,6 @@ class Particle(object):
         return "P(%f, %f)[%d, %d]" % (self.lon, self.lat, self.xi, self.yi)
 
 
-class ParticleType(object):
-    """Class encapsulating the type information for custom particles
-
-    :param user: Optional list of (name, dtype) tuples for custom variables
-    """
-
-    def __init__(self, pclass):
-        if not isinstance(pclass, type):
-            raise TypeError("Class object required to derive ParticleType")
-        if not issubclass(pclass, Particle):
-            raise TypeError("Class object does not inherit from parcels.Particle")
-
-        self.name = pclass.__name__
-        self.uses_jit = issubclass(pclass, JITParticle)
-        if self.uses_jit:
-            self.var_types = pclass.base_vars
-            self.var_types.update(pclass.user_vars)
-        else:
-            self.var_types = None
-
-    def __repr__(self):
-        return self.name
-
-    @property
-    def dtype(self):
-        """Numpy.dtype object that defines the C struct"""
-        return np.dtype(list(self.var_types.items()))
-
-
 class JITParticle(Particle):
     """Particle class for JIT-based Particle objects
 
@@ -99,6 +70,35 @@ class JITParticle(Particle):
             super(JITParticle, self).__setattr__(key, value)
         else:
             self._cptr.__setitem__(key, value)
+
+
+class ParticleType(object):
+    """Class encapsulating the type information for custom particles
+
+    :param user: Optional list of (name, dtype) tuples for custom variables
+    """
+
+    def __init__(self, pclass):
+        if not isinstance(pclass, type):
+            raise TypeError("Class object required to derive ParticleType")
+        if not issubclass(pclass, Particle):
+            raise TypeError("Class object does not inherit from parcels.Particle")
+
+        self.name = pclass.__name__
+        self.uses_jit = issubclass(pclass, JITParticle)
+        if self.uses_jit:
+            self.var_types = pclass.base_vars
+            self.var_types.update(pclass.user_vars)
+        else:
+            self.var_types = None
+
+    def __repr__(self):
+        return self.name
+
+    @property
+    def dtype(self):
+        """Numpy.dtype object that defines the C struct"""
+        return np.dtype(list(self.var_types.items()))
 
 
 class ParticleSet(object):

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -150,6 +150,9 @@ class ParticleSet(object):
     def size(self):
         return self.particles.size
 
+    def __repr__(self):
+        return "\n".join([str(p) for p in self])
+
     def __len__(self):
         return self.size
 

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -80,7 +80,6 @@ def moving_eddies_example(grid, npart=2, mode='jit', verbose=False):
         print("Initial particle positions:\n%s" % pset)
 
     out = ParticleFile(name="EddyParticle", particleset=pset)
-    out.write(pset, 0.)
 
     # 25 days, with 5min timesteps and hourly output
     hours = 24 * 25

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -1,5 +1,4 @@
-from parcels import Particle, ParticleSet, JITParticle
-from parcels import NEMOGrid, ParticleFile, AdvectionRK4
+from parcels import NEMOGrid, Particle, JITParticle, AdvectionRK4
 from argparse import ArgumentParser
 import numpy as np
 import math
@@ -73,21 +72,20 @@ def moving_eddies_example(grid, npart=2, mode='jit', verbose=False):
     # Determine particle class according to mode
     ParticleClass = JITParticle if mode == 'jit' else Particle
 
-    pset = ParticleSet(npart, grid, pclass=ParticleClass,
-                       start=(3.3, 46.), finish=(3.3, 47.8))
+    pset = grid.ParticleSet(size=npart, pclass=ParticleClass,
+                            start=(3.3, 46.), finish=(3.3, 47.8))
 
     if verbose:
         print("Initial particle positions:\n%s" % pset)
-
-    out = ParticleFile(name="EddyParticle", particleset=pset)
 
     # Execte for 25 days, with 5min timesteps and hourly output
     hours = 25*24
     substeps = 12
     print("MovingEddies: Advecting %d particles for %d timesteps"
           % (npart, hours * substeps))
-    pset.execute(AdvectionRK4, time=0., timesteps=hours*substeps,
-                 dt=300., output_file=out, output_steps=substeps)
+    pset.execute(AdvectionRK4, timesteps=hours*substeps, dt=300.,
+                 output_file=pset.ParticleFile(name="EddyParticle"),
+                 output_steps=substeps)
 
     if verbose:
         print("Final particle positions:\n%s" % pset)

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -77,9 +77,7 @@ def moving_eddies_example(grid, npart=2, mode='jit', verbose=False):
                        start=(3.3, 46.), finish=(3.3, 47.8))
 
     if verbose:
-        print("Initial particle positions:")
-        for p in pset:
-            print(p)
+        print("Initial particle positions:\n%s" % pset)
 
     out = ParticleFile(name="EddyParticle", particleset=pset)
     out.write(pset, 0.)
@@ -98,9 +96,7 @@ def moving_eddies_example(grid, npart=2, mode='jit', verbose=False):
         current += timesteps * dt
 
     if verbose:
-        print("Final particle positions:")
-        for p in pset:
-            print(p)
+        print("Final particle positions:\n%s" % pset)
 
     return pset
 

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -1,13 +1,9 @@
-from parcels import Particle, ParticleSet, JITParticle, JITParticleSet
+from parcels import Particle, ParticleSet, JITParticle
 from parcels import NEMOGrid, ParticleFile, AdvectionRK4
 from argparse import ArgumentParser
 import numpy as np
 import math
 import pytest
-
-
-pclasses = {'scipy': (Particle, ParticleSet),
-            'jit': (JITParticle, JITParticleSet)}
 
 
 def moving_eddies_grid(xdim=200, ydim=350):
@@ -74,12 +70,12 @@ def moving_eddies_example(grid, npart=2, mode='jit', verbose=False):
     :arg grid: :class NEMOGrid: that defines the flow field
     :arg npart: Number of particles to intialise"""
 
-    # Determine particle and set classes according to mode
-    ParticleClass, ParticleSetClass = pclasses[mode]
+    # Determine particle class according to mode
+    ParticleClass = JITParticle if mode == 'jit' else Particle
 
     lon = 3.3 * np.ones(npart, dtype=np.float)
     lat = np.linspace(46., 47.8, npart, dtype=np.float)
-    pset = ParticleSetClass(npart, grid, lon=lon, lat=lat)
+    pset = ParticleSet(npart, grid, lon=lon, lat=lat, pclass=ParticleClass)
 
     if verbose:
         print("Initial particle positions:")

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -73,9 +73,8 @@ def moving_eddies_example(grid, npart=2, mode='jit', verbose=False):
     # Determine particle class according to mode
     ParticleClass = JITParticle if mode == 'jit' else Particle
 
-    lon = 3.3 * np.ones(npart, dtype=np.float)
-    lat = np.linspace(46., 47.8, npart, dtype=np.float)
-    pset = ParticleSet(npart, grid, lon=lon, lat=lat, pclass=ParticleClass)
+    pset = ParticleSet(npart, grid, pclass=ParticleClass,
+                       start=(3.3, 46.), finish=(3.3, 47.8))
 
     if verbose:
         print("Initial particle positions:")

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -81,18 +81,13 @@ def moving_eddies_example(grid, npart=2, mode='jit', verbose=False):
 
     out = ParticleFile(name="EddyParticle", particleset=pset)
 
-    # 25 days, with 5min timesteps and hourly output
-    hours = 24 * 25
-    timesteps = 12
-    dt = 300.
-    current = 0.
+    # Execte for 25 days, with 5min timesteps and hourly output
+    hours = 25*24
+    substeps = 12
     print("MovingEddies: Advecting %d particles for %d timesteps"
-          % (npart, hours * timesteps))
-    for _ in range(hours):
-        pset.execute(AdvectionRK4, time=current,
-                     timesteps=timesteps, dt=dt)
-        out.write(pset, current)
-        current += timesteps * dt
+          % (npart, hours * substeps))
+    pset.execute(AdvectionRK4, time=0., timesteps=hours*substeps,
+                 dt=300., output_file=out, output_steps=substeps)
 
     if verbose:
         print("Final particle positions:\n%s" % pset)

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -65,7 +65,7 @@ def peninsula_grid(xdim, ydim):
 
 
 def pensinsula_example(grid, npart, mode='jit', degree=1,
-                       verbose=False, output=False):
+                       verbose=False, output=True):
     """Example configuration of particle flow around an idealised Peninsula
 
     :arg filename: Basename of the input grid file set
@@ -156,8 +156,8 @@ Example of particle advection around an idealised peninsula""")
                    help='Degree of spatial interpolation')
     p.add_argument('-v', '--verbose', action='store_true', default=False,
                    help='Print particle information before and after execution')
-    p.add_argument('-o', '--output', action='store_true', default=False,
-                   help='Output trajectory data to file')
+    p.add_argument('-o', '--nooutput', action='store_true', default=False,
+                   help='Suppress trajectory output')
     p.add_argument('--profiling', action='store_true', default=False,
                    help='Print profiling information after run')
     p.add_argument('-g', '--grid', type=int, nargs=2, default=None,
@@ -177,10 +177,10 @@ Example of particle advection around an idealised peninsula""")
         from pstats import Stats
         runctx("pensinsula_example(grid, args.particles, mode=args.mode,\
                                    degree=args.degree, verbose=args.verbose,\
-                                   output=args.output)",
+                                   output=not args.nooutput)",
                globals(), locals(), "Profile.prof")
         Stats("Profile.prof").strip_dirs().sort_stats("time").print_stats(10)
     else:
         pensinsula_example(grid, args.particles, mode=args.mode,
                            degree=args.degree, verbose=args.verbose,
-                           output=args.output)
+                           output=not args.nooutput)

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -100,9 +100,7 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
         particle.p = grid.P[0., particle.lon, particle.lat]
 
     if verbose:
-        print("Initial particle positions:")
-        for p in pset:
-            print(p)
+        print("Initial particle positions:\n%s" % pset)
 
     # Write initial output to file
     if output:

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -102,10 +102,8 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
     if verbose:
         print("Initial particle positions:\n%s" % pset)
 
-    # Write initial output to file
     if output:
         out = ParticleFile(name="MyParticle", particleset=pset)
-        out.write(pset, 0.)
 
     # Advect the particles for 24h
     time = 24 * 3600.

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -93,12 +93,9 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
             return "P(%.4f, %.4f)[p=%.5f]" % (self.lon, self.lat, self.p)
 
     # Initialise particles
-    km2deg = 1. / 1.852 / 60
-    min_y = grid.U.lat[0] + 3. * km2deg
-    max_y = grid.U.lat[-1] - 3. * km2deg
-    lon = 3. * km2deg * np.ones(npart)
-    lat = np.linspace(min_y, max_y, npart, dtype=np.float)
-    pset = ParticleSet(npart, grid, pclass=MyParticle, lon=lon, lat=lat)
+    x = 3. * (1. / 1.852 / 60)  # 3 km offset from boundary
+    y = (grid.U.lat[0] + x, grid.U.lat[-1] - x)  # latitude range, including offsets
+    pset = ParticleSet(npart, grid, pclass=MyParticle, start=(x, y[0]), finish=(x, y[1]))
     for particle in pset:
         particle.p = grid.P[0., particle.lon, particle.lat]
 

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -1,4 +1,4 @@
-from parcels import Particle, ParticleSet, JITParticle, JITParticleSet
+from parcels import Particle, ParticleSet, JITParticle
 from parcels import NEMOGrid, ParticleFile, AdvectionRK4
 from argparse import ArgumentParser
 import numpy as np
@@ -72,13 +72,8 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
     :arg filename: Basename of the input grid file set
     :arg npart: Number of particles to intialise"""
 
-    # Determine particle and set classes according to mode
-    if mode == 'jit':
-        ParticleClass = JITParticle
-        PSetClass = JITParticleSet
-    else:
-        ParticleClass = Particle
-        PSetClass = ParticleSet
+    # Determine particle class according to mode
+    ParticleClass = JITParticle if mode == 'jit' else Particle
 
     # First, we define a custom Particle class to which we add a
     # custom variable, the initial stream function value p
@@ -103,7 +98,7 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
     max_y = grid.U.lat[-1] - 3. * km2deg
     lon = 3. * km2deg * np.ones(npart)
     lat = np.linspace(min_y, max_y, npart, dtype=np.float)
-    pset = PSetClass(npart, grid, pclass=MyParticle, lon=lon, lat=lat)
+    pset = ParticleSet(npart, grid, pclass=MyParticle, lon=lon, lat=lat)
     for particle in pset:
         particle.p = grid.P[0., particle.lon, particle.lat]
 

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -102,27 +102,15 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
     if verbose:
         print("Initial particle positions:\n%s" % pset)
 
-    if output:
-        out = ParticleFile(name="MyParticle", particleset=pset)
-
     # Advect the particles for 24h
     time = 24 * 3600.
     dt = 36.
+    substeps = 100 if output else -1
+    out = ParticleFile(name="MyParticle", particleset=pset) if output else None
     print("Peninsula: Advecting %d particles for %d timesteps"
           % (npart, int(time / dt)))
-    if output:
-        # Use sub-timesteps when doing trajectory I/O
-        substeps = 100
-        timesteps = int(time / substeps / dt)
-        current = 0.
-        for _ in range(timesteps):
-            pset.execute(AdvectionRK4, timesteps=substeps, dt=dt)
-            current += substeps * dt
-            out.write(pset, current)
-    else:
-        # Execution without I/O for performance benchmarks
-        timesteps = int(time / dt)
-        pset.execute(AdvectionRK4, timesteps=timesteps, dt=dt)
+    pset.execute(AdvectionRK4, timesteps=int(time / dt), dt=dt,
+                 output_file=out, output_steps=substeps)
 
     if verbose:
         print("Final particle positions:")

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -1,5 +1,4 @@
-from parcels import Particle, ParticleSet, JITParticle
-from parcels import NEMOGrid, ParticleFile, AdvectionRK4
+from parcels import NEMOGrid, Particle, JITParticle, AdvectionRK4
 from argparse import ArgumentParser
 import numpy as np
 import pytest
@@ -95,7 +94,7 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
     # Initialise particles
     x = 3. * (1. / 1.852 / 60)  # 3 km offset from boundary
     y = (grid.U.lat[0] + x, grid.U.lat[-1] - x)  # latitude range, including offsets
-    pset = ParticleSet(npart, grid, pclass=MyParticle, start=(x, y[0]), finish=(x, y[1]))
+    pset = grid.ParticleSet(npart, pclass=MyParticle, start=(x, y[0]), finish=(x, y[1]))
     for particle in pset:
         particle.p = grid.P[0., particle.lon, particle.lat]
 
@@ -106,7 +105,7 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
     time = 24 * 3600.
     dt = 36.
     substeps = 100 if output else -1
-    out = ParticleFile(name="MyParticle", particleset=pset) if output else None
+    out = pset.ParticleFile(name="MyParticle") if output else None
     print("Peninsula: Advecting %d particles for %d timesteps"
           % (npart, int(time / dt)))
     pset.execute(AdvectionRK4, timesteps=int(time / dt), dt=dt,


### PR DESCRIPTION
This merge aims to make the test examples simpler and more readable by providing various little syntax improvements and shortcuts. In particular, we now have:
* Only one `ParticleSet` class that determines JIT execution mode strictly from the given `pclass` argument.
* Printable `ParticleSet` objects that know how to output themselves
* Automatic initial dumps when creating output files (can be disabled, of course)
* `ParticleSet` object initialisation that will put particles equidistant between `start`/`finish` coordinates
* Automated output sub-timestepping in `ParticleSet.execute()`, which can be driven by supplying an output file and a sub-stepping interval
* Switch output on by default for the Peninsula test example