### PR TITLE
A few small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,18 @@ A basic example of particle advection around an idealised peninsula
 Runge-Kutta scheme is provided in the `tests` directory. The necessary
 grid files are generated (using NEMO conventions) with:
 ```
-python tests/grid_peninsula.py <xdim> <ydim>
+python tests/test_peninsula.py --grid <xdim> <ydim> -p <npart>
 ```
 where `xdim` and `ydim` are the numbers of grid cells in each
-dimension. The particle advection example can then be run with:
-```
-python tests/test_peninsula.py -p <npart>
-```
-where `npart` is the number of evenly initialised particles. The
-resulting particle trajectories can be visualised using Parcel's
-utility plotting script:
+dimension and `npart` is the number of evenly initialised
+particles. The resulting particle trajectories can be visualised using
+Parcel's utility plotting script:
 ```
 python scripts/plotParticles.py 2d -p MyParticle.nc
 ```
 An alternative execution mode that utilises SciPy's interpolator
 functions for spatial interpolation can be utilised with:
 ```
-python tests/test_peninsula.py scipy -p <npart> --degree <deg> --output
+python tests/test_peninsula.py scipy -p <npart> --degree <deg>
 ```
 where `deg` is the degree of spatial interpoaltion to use.

--- a/include/parcels.h
+++ b/include/parcels.h
@@ -52,7 +52,7 @@ static inline float temporal_interpolation_linear(float x, float y, int xi, int 
   j = search_linear_float(y, j, f->ydim, f->lat);
   /* Find time index for temporal interpolation */
   f->tidx = search_linear_double(time, f->tidx, f->tdim, f->time);
-  if (f->tidx < f->tdim-1) {
+  if (f->tidx < f->tdim-1 && time > f->time[f->tidx]) {
     t0 = f->time[f->tidx]; t1 = f->time[f->tidx+1];
     f0 = spatial_interpolation_bilinear(x, y, i, j, f->ydim, f->lon, f->lat, (float**)(data[f->tidx]));
     f1 = spatial_interpolation_bilinear(x, y, i, j, f->ydim, f->lon, f->lat, (float**)(data[f->tidx+1]));

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -22,7 +22,7 @@ class Field(object):
     """
 
     def __init__(self, name, data, lon, lat, depth=None, time=None,
-                 transpose=False):
+                 transpose=False, vmin=None, vmax=None):
         self.name = name
         self.data = data
         self.lon = lon
@@ -40,8 +40,12 @@ class Field(object):
             self.data = np.transpose(self.data).copy()
         self.data = self.data.reshape((time.size, lat.size, lon.size))
 
-        # Hack around the fact that NaN values
+        # Hack around the fact that NaN and ridiculously large values
         # propagate in SciPy's interpolators
+        if vmin is not None:
+            self.data[self.data < vmin] = 0.
+        if vmax is not None:
+            self.data[self.data > vmax] = 0.
         self.data[np.isnan(self.data)] = 0.
 
         # Variable names in JIT code
@@ -53,7 +57,7 @@ class Field(object):
         self.time_index_cache = LRUCache(maxsize=2)
 
     @classmethod
-    def from_netcdf(cls, name, varname, datasets):
+    def from_netcdf(cls, name, varname, datasets, **kwargs):
         """Create field from netCDF file using NEMO conventions
 
         :param name: Name of the field to create
@@ -79,7 +83,7 @@ class Field(object):
         for tslice, dset in zip(timeslices, datasets):
             data[tidx:, 0, :, :] = dset[varname][:, 0, :, :]
             tidx += tslice.size
-        return cls(name, data, lon, lat, depth=depth, time=time)
+        return cls(name, data, lon, lat, depth=depth, time=time, **kwargs)
 
     def __getitem__(self, key):
         return self.eval(*key)

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -137,10 +137,18 @@ class Field(object):
                          self.data.ctypes.data_as(POINTER(POINTER(c_float))))
         return cstruct
 
-    def show(self):
+    def show(self, **kwargs):
         import matplotlib.pyplot as plt
-        plt.contourf(self.lon, self.lat, np.squeeze(self.data), 256)
-        plt.colorbar()
+        t = kwargs.get('t', 0)
+        data = np.squeeze(self.data[t, :])
+        vmin = kwargs.get('vmin', data.min())
+        vmax = kwargs.get('vmax', data.max())
+        cs = plt.contourf(self.lon, self.lat, data,
+                          levels=np.linspace(vmin, vmax, 256))
+        cs.cmap.set_over('k')
+        cs.cmap.set_under('w')
+        cs.set_clim(vmin, vmax)
+        plt.colorbar(cs)
         plt.xlabel('Longitude')
         plt.ylabel('Latitude')
         plt.title(self.name)

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -71,7 +71,7 @@ class NEMOGrid(object):
             for fp in paths:
                 if not fp.exists():
                     raise IOError("Grid file not found: %s" % str(fp))
-            dsets = [Dataset(str(fp), 'r', format="NETCDF4") for fpath in paths]
+            dsets = [Dataset(str(fp), 'r', format="NETCDF4") for fp in paths]
             fields[var] = Field.from_netcdf(var, vname, dsets, **kwargs)
         u = fields.pop('U')
         v = fields.pop('V')

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -30,7 +30,7 @@ class NEMOGrid(object):
 
     @classmethod
     def from_data(cls, data_u, lon_u, lat_u, data_v, lon_v, lat_v,
-                  depth, time, field_data={}, transpose=True):
+                  depth, time, field_data={}, transpose=True, **kwargs):
         """Initialise Grid object from raw data
 
         :param data_u: Zonal velocity data
@@ -43,18 +43,20 @@ class NEMOGrid(object):
         :param time: Time coordinates of the grid
         """
         # Create velocity fields
-        ufield = Field('U', data_u, lon_u, lat_u, depth=depth, time=time, transpose=transpose)
-        vfield = Field('V', data_v, lon_v, lat_v, depth=depth, time=time, transpose=transpose)
+        ufield = Field('U', data_u, lon_u, lat_u, depth=depth,
+                       time=time, transpose=transpose, **kwargs)
+        vfield = Field('V', data_v, lon_v, lat_v, depth=depth,
+                       time=time, transpose=transpose, **kwargs)
         # Create additional data fields
         fields = {}
         for name, data in field_data.items():
             fields[name] = Field(name, data, lon_v, lat_u, depth=depth,
-                                 time=time, transpose=transpose)
+                                 time=time, transpose=transpose, **kwargs)
         return cls(ufield, vfield, depth, time, fields=fields)
 
     @classmethod
     def from_file(cls, filename, uvar='vozocrtx', vvar='vomecrty',
-                  extra_vars={}):
+                  extra_vars={}, **kwargs):
         """Initialises grid data from files using NEMO conventions.
 
         :param filename: Base name of the file(s); may contain
@@ -70,7 +72,7 @@ class NEMOGrid(object):
                 if not fp.exists():
                     raise IOError("Grid file not found: %s" % str(fp))
             dsets = [Dataset(str(fp), 'r', format="NETCDF4") for fpath in paths]
-            fields[var] = Field.from_netcdf(var, vname, dsets)
+            fields[var] = Field.from_netcdf(var, vname, dsets, **kwargs)
         u = fields.pop('U')
         v = fields.pop('V')
         return cls(u, v, u.depth, u.time, fields=fields)

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -162,7 +162,7 @@ class ParticleSet(object):
     def __setitem__(self, key, value):
         self.particles[key] = value
 
-    def execute(self, pyfunc=AdvectionRK4, time=0., dt=1., timesteps=1,
+    def execute(self, pyfunc=AdvectionRK4, time=None, dt=1., timesteps=1,
                 output_file=None, output_steps=-1):
         """Execute a given kernel function over the particle set for
         multiple timesteps. Optionally also provide sub-timestepping
@@ -197,7 +197,7 @@ class ParticleSet(object):
             output_steps = timesteps
         timeleaps = int(timesteps / output_steps)
         # Execute kernel in sub-stepping intervals (leaps)
-        current = 0.
+        current = time or self.grid.time[0]
         for _ in range(timeleaps):
             execute(self, output_steps, current, dt)
             current += output_steps * dt

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -204,15 +204,16 @@ class ParticleSet(object):
             if output_file:
                 output_file.write(self, current)
 
-    def show(self, field=None):
+    def show(self, **kwargs):
         import matplotlib.pyplot as plt
+        field = kwargs.get('field', None)
         lon = [p.lon for p in self]
         lat = [p.lat for p in self]
         plt.plot(np.transpose(lon), np.transpose(lat), 'ko')
         if field is None:
             plt.show()
         else:
-            field.show()
+            field.show(**kwargs)
 
     def ParticleFile(self, *args, **kwargs):
         return ParticleFile(*args, particleset=self, **kwargs)


### PR DESCRIPTION
A set of bug fixes and simplifications that make dealing with real NEMO data a little bit easier. Include:
* Fix to path derivation for multi-file grids
* Fix for time interpolation in JIT mode
* Updates to the README for the peninsula test
* Ability to enforce value range in `field.show()`
* Value range safe-guards for fields to avoid Fortran `huge` values skewing SciPy interpolators
* in `PSet.execute()` auto-derive starting time from grid if not given