### PR TITLE
Attempt to kernelize py-functions when merging kernels

### DIFF
--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -83,7 +83,11 @@ class Kernel(object):
                       py_ast=func_ast, funcvars=self.funcvars + kernel.funcvars)
 
     def __add__(self, kernel):
+        if not isinstance(kernel, Kernel):
+            kernel = Kernel(self.grid, self.ptype, pyfunc=kernel)
         return self.merge(kernel)
 
     def __radd__(self, kernel):
+        if not isinstance(kernel, Kernel):
+            kernel = Kernel(self.grid, self.ptype, pyfunc=kernel)
         return kernel.merge(self)


### PR DESCRIPTION
This merge adds automatic conversion of Python functions to `parcels.Kernel` objects when concatenating kernel chains. Note though, that at least one kernel in the chain needs to be manually created, either via `ParticleSet.Kernel(pyfunc)` or `Kernel(grid, ptype, pyfunc)`, for this to work. 