### PR TITLE
Extended math in JIT kernels

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -191,6 +191,15 @@ class KernelGenerator(ast.NodeVisitor):
         body = c.Block([stmt.ccode for stmt in node.body])
         node.ccode = c.FunctionBody(c.FunctionDeclaration(decl, args), body)
 
+    def visit_Call(self, node):
+        """Generate C code for simple C-style function calls. Please
+        note that starred and keyword arguments are currently not
+        supported."""
+        for a in node.args:
+            self.visit(a)
+        ccode_args = ", ".join([a.ccode for a in node.args])
+        node.ccode = "%s(%s)" % (node.func.ccode, ccode_args)
+
     def visit_Name(self, node):
         """Catches any mention of intrinsic variable names, such as
         'particle' or 'grid' and inserts our placeholder objects"""

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -1,5 +1,6 @@
 from parcels.codegenerator import KernelGenerator, LoopGenerator
 from py import path
+import math  # NOQA get flake8 to ignore unused import.
 import numpy.ctypeslib as npct
 from ctypes import c_int, c_float, c_double, c_void_p, byref
 from ast import parse, FunctionDef, Module
@@ -30,9 +31,8 @@ class Kernel(object):
             self.funcvars = funcvars
             # Compile and generate Python function from AST
             py_mod = Module(body=[self.py_ast])
-            py_ctx = {}
-            exec(compile(py_mod, "<ast>", "exec"), py_ctx)
-            self.pyfunc = py_ctx[self.funcname]
+            exec(compile(py_mod, "<ast>", "exec"), globals())
+            self.pyfunc = globals()[self.funcname]
 
         self.name = "%s%s" % (ptype.name, funcname)
 

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -83,7 +83,11 @@ class Kernel(object):
                       py_ast=func_ast, funcvars=self.funcvars + kernel.funcvars)
 
     def __add__(self, kernel):
+        if not isinstance(kernel, Kernel):
+            kernel = Kernel(self.grid, self.ptype, pyfunc=kernel)
         return self.merge(kernel)
 
     def __radd__(self, kernel):
+        if not isinstance(kernel, Kernel):
+            kernel = Kernel(self.grid, self.ptype, pyfunc=kernel)
         return kernel.merge(self)


### PR DESCRIPTION
This merge adds the basic infrastructure to use math functions like `math.pi`, `math.sin(x)` and `math.log(x)` in Python and JIT kernels. Unfortunately there aren't any detailed tests of this yet,
but most functions in the python modules `math` should be covered.

Please note that this also adds the capability of performing function calls in auto-generated JIT kernels,
although these will ignore advanced Pythonic features, such as starred and keyword arguments.

This merge addresses issue #24 and also builds on PR #25, so please merge that one first. 