### PR TITLE
Honour user context in kernel merge

### DIFF
--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -29,9 +29,17 @@ class Kernel(object):
             self.funcname = funcname
             self.py_ast = py_ast
             self.funcvars = funcvars
+            # Extract user context by inspecting the call stack
+            stack = inspect.stack()
+            try:
+                user_ctx = stack[-1][0].f_globals
+            except:
+                print("Warning: Could not access user context when merging kernels")
+                user_ctx = globals()
+            finally:
+                del stack  # Remove cyclic references
             # Compile and generate Python function from AST
             py_mod = Module(body=[self.py_ast])
-            user_ctx = inspect.stack()[-1][0].f_globals
             exec(compile(py_mod, "<ast>", "exec"), user_ctx)
             self.pyfunc = user_ctx[self.funcname]
 

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -31,8 +31,9 @@ class Kernel(object):
             self.funcvars = funcvars
             # Compile and generate Python function from AST
             py_mod = Module(body=[self.py_ast])
-            exec(compile(py_mod, "<ast>", "exec"), globals())
-            self.pyfunc = globals()[self.funcname]
+            user_ctx = inspect.stack()[-1][0].f_globals
+            exec(compile(py_mod, "<ast>", "exec"), user_ctx)
+            self.pyfunc = user_ctx[self.funcname]
 
         self.name = "%s%s" % (ptype.name, funcname)
 


### PR DESCRIPTION
Previously we were throwing away the user's context when merging kernel functions at the Python AST level, which meant that global imports were not accessible from within fused kernels. This merge fixes this by utilising some of Python's dark magic.

Fixes issue #28.