### PR TITLE
Generic netcdf grids

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -164,7 +164,7 @@ class Field(object):
         if varname is None:
             varname = self.name
         # Derive name of 'depth' variable for NEMO convention
-        vname_depth = 'depth%s' % self.name.lower()
+        vname_depth = 'depth'
 
         # Create DataArray objects for file I/O
         t, d, x, y = (self.time.size, self.depth.size,

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -57,7 +57,7 @@ class Field(object):
         self.time_index_cache = LRUCache(maxsize=2)
 
     @classmethod
-    def from_netcdf(cls, name, varname, datasets, **kwargs):
+    def from_netcdf(cls, name, varname, datasets, dimensions={}, **kwargs):
         """Create field from netCDF file using NEMO conventions
 
         :param name: Name of the field to create
@@ -68,13 +68,14 @@ class Field(object):
         """
         if not isinstance(datasets, Iterable):
             datasets = [datasets]
-        lon = datasets[0]['nav_lon'][0, :]
-        lat = datasets[0]['nav_lat'][:, 0]
+        lon = datasets[0].variables[dimensions["long"]]
+        lat = datasets[0].variables[dimensions["lat"]]
+        #lat = datasets[0][dimensions["lat"]][:, 0]
         # Default depth to zeros until we implement 3D grids properly
         depth = np.zeros(1, dtype=np.float32)
         # Concatenate time variable to determine overall dimension
         # across multiple files
-        timeslices = [dset['time_counter'][:] for dset in datasets]
+        timeslices = [dset[dimensions["time"]][:] for dset in datasets]
         time = np.concatenate(timeslices)
 
         # Pre-allocate grid data before reading files into buffer

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -68,9 +68,9 @@ class Field(object):
         """
         if not isinstance(datasets, Iterable):
             datasets = [datasets]
-        lon = datasets[0].variables[dimensions["long"]]
+        lon = datasets[0].variables[dimensions["lon"]]
         lat = datasets[0].variables[dimensions["lat"]]
-        #lat = datasets[0][dimensions["lat"]][:, 0]
+        # lat = datasets[0][dimensions["lat"]][:, 0]
         # Default depth to zeros until we implement 3D grids properly
         depth = np.zeros(1, dtype=np.float32)
         # Concatenate time variable to determine overall dimension

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -63,6 +63,8 @@ class NEMOGrid(object):
         wildcards to indicate multiple files.
         """
         fields = {}
+        # Hacked for (some) NEMO file conventions, and those used in test_peninsula
+        dimensions = {'lat': 'nav_lat', 'lon': 'nav_lon', 'time': 'time_counter'}
         extra_vars.update({'U': uvar, 'V': vvar})
         for var, vname in extra_vars.items():
             # Resolve all matching paths for the current variable
@@ -72,7 +74,7 @@ class NEMOGrid(object):
                 if not fp.exists():
                     raise IOError("Grid file not found: %s" % str(fp))
             dsets = [Dataset(str(fp), 'r', format="NETCDF4") for fp in paths]
-            fields[var] = Field.from_netcdf(var, vname, dsets, **kwargs)
+            fields[var] = Field.from_netcdf(var, vname, dsets, dimensions=dimensions, **kwargs)
         u = fields.pop('U')
         v = fields.pop('V')
         return cls(u, v, u.depth, u.time, fields=fields)
@@ -117,7 +119,7 @@ class NetCDF_Grid(object):
             setattr(self, name, field)
 
     @classmethod
-    def from_file(cls, loc, filenames={}, vars={}, dimensions={}, **kwargs):
+    def from_file(cls, loc=None, filenames={}, vars={}, dimensions={}, **kwargs):
         """Initialises grid data from files using NEMO conventions.
 
             :param filenames: Dictionary of filenames for each variable stored within
@@ -125,6 +127,8 @@ class NetCDF_Grid(object):
             :param dimensions: Dictionary of dimensions used and the naming convention within the netcdf file
             """
         fields = {}
+        if loc is None:
+            loc = str(path.local())+'/'
         for var, vname in vars.items():  # Cycle through files and variables loading netcdf data
             # Resolve all matching paths for the current variable
             filename = filenames[var]

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -4,7 +4,6 @@ from parcels.particle import ParticleSet
 from py import path
 from glob import glob
 
-
 __all__ = ['NEMOGrid']
 
 
@@ -17,6 +16,7 @@ class NEMOGrid(object):
     :param time: Time coordinates of the grid
     :param fields: Dictionary of additional fields
     """
+
     def __init__(self, U, V, depth, time, fields={}):
         self.U = U
         self.V = V
@@ -99,19 +99,19 @@ class NEMOGrid(object):
             field.write(filename)
 
 
-
 class NetCDF_Grid(object):
     """Grid class used to generate and read NetCDF files
-        
+
         :param depth: Depth coordinates of the grid
         :param time: Time coordinates of the grid
         :param fields: Dictionary of fields variables across these coordinates
         """
+
     def __init__(self, depth, time, fields={}):
         self.depth = depth
         self.time = time
         self.fields = fields.keys()
-        
+
         # Add additional fields as attributes
         for name, field in fields.items():
             setattr(self, name, field)
@@ -119,44 +119,42 @@ class NetCDF_Grid(object):
     @classmethod
     def from_file(cls, loc, filenames={}, vars={}, dimensions={}, **kwargs):
         """Initialises grid data from files using NEMO conventions.
-            
+
             :param filenames: Dictionary of filenames for each variable stored within
             :param vars: Dictionary of variables and the corresponding naming convention within the netcdf file
             :param dimensions: Dictionary of dimensions used and the naming convention within the netcdf file
             """
         fields = {}
-        for var, vname in vars.items(): #Cycle through files and variables loading netcdf data
+        for var, vname in vars.items():  # Cycle through files and variables loading netcdf data
             # Resolve all matching paths for the current variable
             filename = filenames[var]
-            fp = path.local(loc+"/"+filename)
+            fp = path.local(loc + "/" + filename)
             if not fp.exists():
                 raise IOError("Grid file not found: %s" % str(fp))
             dset = Dataset(str(fp), 'r', format="NETCDF4")
             print("Loading %s data from %s" % (var, str(fp)))
             fields[var] = Field.from_netcdf(var, vname, dset, dimensions, **kwargs)
-        
-        #Assumes depth and time dimensions are the same size across separate NetCDF loaded fields
+
+        # Assumes depth and time dimensions are the same size across separate NetCDF loaded fields
         return cls(fields[fields.keys()[0]].depth, fields[fields.keys()[0]].time, fields=fields)
-    
+
     def ParticleSet(self, *args, **kwargs):
         return ParticleSet(*args, grid=self, **kwargs)
-    
+
     def eval(self, x, y):
         u = self.U.eval(x, y)
         v = self.V.eval(x, y)
         return u, v
-    
+
     def write(self, filename):
         """Write only the flow field components of the grid to NetCDF file using a simple convention
-            
+
             :param filename: Basename of the output fileset"""
         print("Generating NetCDF grid output with basename: %s" % filename)
-        
+
         self.U.write(filename, varname='U')
         self.V.write(filename, varname='V')
-        
+
         for f in self.fields:
             field = getattr(self, f)
             field.write(filename)
-
-

--- a/scripts/plotParticles.py
+++ b/scripts/plotParticles.py
@@ -18,10 +18,10 @@ def particleplotting(filename,tracerfile, mode):
     fig, ax = plt.subplots()
     if tracerfile != 'none':
       tfile = Dataset(tracerfile,'r')
-      X = tfile.variables['x']
-      Y = tfile.variables['y']
-      P = tfile.variables['P']
-      plt.contourf(np.squeeze(X),np.squeeze(Y),np.squeeze(P))
+      X = tfile.variables['xu_ocean']
+      Y = tfile.variables['yu_ocean']
+      P = tfile.variables['u']
+      plt.contourf(np.squeeze(X[:]),np.squeeze(Y[:]),np.squeeze(P[0,0,:,:]))
 
     if mode == '3d':
       ax = fig.gca(projection='3d')

--- a/scripts/plotParticles.py
+++ b/scripts/plotParticles.py
@@ -1,64 +1,70 @@
 #!/usr/bin/env python
 from netCDF4 import Dataset
 import numpy as np
-import matplotlib as mpl
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 from argparse import ArgumentParser
 import matplotlib.animation as animation
 
-def particleplotting(filename,tracerfile, mode):
+
+def particleplotting(filename, tracerfile, mode, tracer_vars={}):
     """Quick and simple plotting of PARCELS trajectories"""
 
-    pfile=Dataset(filename,'r')
+    pfile = Dataset(filename, 'r')
     lon = pfile.variables['lon']
     lat = pfile.variables['lat']
     z = pfile.variables['z']
 
     fig, ax = plt.subplots()
     if tracerfile != 'none':
-      tfile = Dataset(tracerfile,'r')
-      X = tfile.variables['xu_ocean']
-      Y = tfile.variables['yu_ocean']
-      P = tfile.variables['u']
-      plt.contourf(np.squeeze(X[:]),np.squeeze(Y[:]),np.squeeze(P[0,0,:,:]))
+        tfile = Dataset(tracerfile, 'r')
+        X = tfile.variables[tracer_vars['X']]
+        Y = tfile.variables[tracer_vars['Y']]
+        V = tfile.variables[tracer_vars['V']]
+        plt.contourf(np.squeeze(X[:]), np.squeeze(Y[:]), np.squeeze(V[0, 0, :, :]))
 
     if mode == '3d':
-      ax = fig.gca(projection='3d')
-      for p in range(len(lon)):
-        ax.plot(lon[p,:],lat[p,:],z[p,:],'.-')
-      ax.set_xlabel('Longitude')
-      ax.set_ylabel('Latitude')
-      ax.set_zlabel('Depth')
+        ax = fig.gca(projection='3d')
+        for p in range(len(lon)):
+            ax.plot(lon[p, :], lat[p, :], z[p, :], '.-')
+        ax.set_xlabel('Longitude')
+        ax.set_ylabel('Latitude')
+        ax.set_zlabel('Depth')
     elif mode == '2d':
-      plt.plot(np.transpose(lon),np.transpose(lat),'.-')
-      plt.xlabel('Longitude')
-      plt.ylabel('Latitude')    
-    elif mode =='movie2d':
+        plt.plot(np.transpose(lon), np.transpose(lat), '.-')
+        plt.xlabel('Longitude')
+        plt.ylabel('Latitude')
+    elif mode == 'movie2d':
 
-      line, = ax.plot(lon[:,0], lat[:,0],'ow')
-      if tracerfile == 'none': # need to set ax limits
-        plt.axis((np.amin(lon),np.amax(lon),np.amin(lat),np.amax(lat)))
-        
-      def animate(i):
-          line.set_xdata(lon[:,i])
-          line.set_ydata(lat[:,i])
-          return line,
+        line, = ax.plot(lon[:, 0], lat[:, 0], 'ow')
+        if tracerfile == 'none':  # need to set ax limits
+            plt.axis((np.amin(lon), np.amax(lon), np.amin(lat), np.amax(lat)))
 
-      ani = animation.FuncAnimation(fig, animate, np.arange(1, lon.shape[1]),
-          interval=100, blit=False)
-      plt.show()
+        def animate(i):
+            line.set_xdata(lon[:, i])
+            line.set_ydata(lat[:, i])
+            return line,
+
+        animation.FuncAnimation(fig, animate, np.arange(1, lon.shape[1]),
+                                interval=100, blit=False)
+        plt.show()
 
     plt.show()
 
+
 if __name__ == "__main__":
     p = ArgumentParser(description="""Quick and simple plotting of PARCELS trajectories""")
-    p.add_argument('mode', choices=('2d', '3d','movie2d'), nargs='?', default='2d',
+    p.add_argument('mode', choices=('2d', '3d', 'movie2d'), nargs='?', default='2d',
                    help='Type of display')
     p.add_argument('-p', '--particlefile', type=str, default='MyParticle.nc',
                    help='Name of particle file')
     p.add_argument('-f', '--tracerfile', type=str, default='none',
                    help='Name of tracer file to display underneath particle trajectories')
+    p.add_argument('-v', '--variables', type=str, nargs=3, default=['x', 'y', 'vozocrtx'],
+                   help='Name of tracer file to display underneath particle trajectories')
     args = p.parse_args()
 
-    particleplotting(args.particlefile, args.tracerfile, mode=args.mode)
+    variables = {'X': args.variables[0],
+                 'Y': args.variables[1],
+                 'V': args.variables[2]}
+
+    particleplotting(args.particlefile, args.tracerfile, mode=args.mode, tracer_vars=variables)

--- a/tests/test_generic_netcdf_grid.py
+++ b/tests/test_generic_netcdf_grid.py
@@ -1,5 +1,4 @@
 from parcels import Particle, JITParticle, AdvectionRK4
-from parcels.particle import ParticleSet
 from parcels.grid import NetCDF_Grid
 from argparse import ArgumentParser
 from py import path
@@ -10,42 +9,43 @@ if __name__ == "__main__":
     p.add_argument('mode', choices=('scipy', 'jit'), nargs='?', default='scipy',
                    help='Execution mode for performing RK4 computation')
     p.add_argument('-p', '--particles', type=int, default=10,
-                                  help='Number of particles to advect')
+                   help='Number of particles to advect')
     p.add_argument('--profiling', action='store_true', default=False,
-                                  help='Print profiling information after run')
+                   help='Print profiling information after run')
     p.add_argument('-l', '--location', default=None,
-                                  help='Location folder path of input NetCDF files')
+                   help='Location folder path of input NetCDF files')
     p.add_argument('-f', '--files', default=['OFAM_Simple_U.nc', 'OFAM_Simple_V.nc'],
-                                  help='List of NetCDF files to load')
-    p.add_argument('-v', '--variables', default=['U','V'],
-                                  help='List of field variables to extract, using PARCELS naming convention')
-    p.add_argument('-n', '--netcdf_vars', default=['u','v'],
-                                  help='List of field variable names, as given in the NetCDF file. Order must match --variables args')
+                   help='List of NetCDF files to load')
+    p.add_argument('-v', '--variables', default=['U', 'V'],
+                   help='List of field variables to extract, using PARCELS naming convention')
+    p.add_argument('-n', '--netcdf_vars', default=['u', 'v'],
+                   help='List of field variable names, as given in the NetCDF file. Order must match --variables args')
     p.add_argument('-d', '--dimensions', default=['lat', 'long', 'time'],
-                                  help='List of PARCELS convention named dimensions across which field variables occur')
+                   help='List of PARCELS convention named dimensions across which field variables occur')
     p.add_argument('-m', '--map_dimensions', default=['yu_ocean', 'xu_ocean', 'Time'],
-                                  help='List of dimensions across which field variables occur, as given in the NetCDF files, to map to the --dimensions args')
-    p.add_argument('-o', '--output_file', default='NetCDF_Particles', help='Name of output NetCDF file for particle data')
+                   help='List of dimensions across which field variables occur, as given in the NetCDF files, to map to the --dimensions args')
+    p.add_argument('-o', '--output_file', default='NetCDF_Particles',
+                   help='Name of output NetCDF file for particle data')
     args = p.parse_args()
-    
+
     ParticleClass = JITParticle if args.mode == 'jit' else Particle
-    
-    if args.location == None:
+
+    if args.location is None:
         datadir = path.local().dirpath()
-        datadir = str(datadir)+'/'+'parcels-examples/OFAM_example_data'
+        datadir = str(datadir) + '/' + 'parcels-examples/OFAM_example_data'
     else:
         datadir = args.location
-    
-    #Build required dictionaries for NETCDF_Grid from cmd arguments
+
+    # Build required dictionaries for NETCDF_Grid from cmd arguments
     filenames = {}
     for vars, var_files in zip(args.variables, args.files):
-        filenames.update({vars:var_files})
+        filenames.update({vars: var_files})
     variables = {}
     for vars, net_vars in zip(args.variables, args.netcdf_vars):
-        variables.update({vars:net_vars})
+        variables.update({vars: net_vars})
     dimensions = {}
     for dims, net_dims in zip(args.dimensions, args.map_dimensions):
-        dimensions.update({dims:net_dims})
+        dimensions.update({dims: net_dims})
 
     grid = NetCDF_Grid.from_file(loc=datadir, filenames=filenames, vars=variables, dimensions=dimensions)
 
@@ -55,14 +55,11 @@ if __name__ == "__main__":
     lon_max = max(getattr(grid, grid.fields[0]).lon)
 
     pset = grid.ParticleSet(size=args.particles, pclass=ParticleClass,
-                            start=((lon_min+lon_max)/2, lat_min), finish=((lon_min+lon_max)/2, lat_max))
+                            start=((lon_min + lon_max) / 2, lat_min), finish=((lon_min + lon_max) / 2, lat_max))
 
-    hours = 25*24
+    hours = 25 * 24
     substeps = 60
 
-    pset.execute(AdvectionRK4, timesteps=hours*substeps, dt=300.,
-                       output_file=pset.ParticleFile(name=args.output_file),
-                       output_steps=substeps)
-          
-
-    
+    pset.execute(AdvectionRK4, timesteps=hours * substeps, dt=300.,
+                 output_file=pset.ParticleFile(name=args.output_file),
+                 output_steps=substeps)

--- a/tests/test_generic_netcdf_grid.py
+++ b/tests/test_generic_netcdf_grid.py
@@ -1,0 +1,112 @@
+from netCDF4 import Dataset
+from parcels import NEMOGrid, Particle, JITParticle, AdvectionRK4
+from parcels.field import Field
+from parcels.particle import ParticleSet
+from argparse import ArgumentParser
+from py import path
+from glob import glob
+import numpy as np
+import math
+import pytest
+
+class NetCDF_Grid(object):
+    """Grid class used to generate and read NetCDF files
+        
+        :param depth: Depth coordinates of the grid
+        :param time: Time coordinates of the grid
+        :param fields: Dictionary of fields variables across these coordinates
+        """
+    def __init__(self, depth, time, fields={}):
+        self.depth = depth
+        self.time = time
+        self.fields = fields.keys()
+        
+        # Add additional fields as attributes
+        for name, field in fields.items():
+            setattr(self, name, field)
+    
+
+    @classmethod
+    def from_file(cls, loc, filenames={}, vars={}, dimensions={}, **kwargs):
+        """Initialises grid data from files using NEMO conventions.
+        
+        :param filename: Base name of the file(s); may contain
+        wildcards to indicate multiple files.
+        """
+        fields = {}
+        for var, vname in vars.items():
+            # Resolve all matching paths for the current variable
+            filename = filenames[var]
+            fp = path.local(loc+"/"+filename)
+            #paths = [path.local(fp) for fp in glob(str(filename))]
+            if not fp.exists():
+                raise IOError("Grid file not found: %s" % str(fp))
+            dset = Dataset(str(fp), 'r', format="NETCDF4")
+            print("Loading %s data from %s" % (var, str(fp)))
+            fields[var] = Field.from_netcdf(var, vname, dset, dimensions, **kwargs)
+                #u = fields.pop('U')
+        print(fields.keys())
+        #v = fields.pop('V')
+        return cls(fields[fields.keys()[0]].depth, fields[fields.keys()[0]].time, fields=fields)
+    
+    def ParticleSet(self, *args, **kwargs):
+        return ParticleSet(*args, grid=self, **kwargs)
+    
+    def eval(self, x, y):
+        u = self.U.eval(x, y)
+        v = self.V.eval(x, y)
+        return u, v
+    
+    def write(self, filename):
+        """Write flow field to NetCDF file using NEMO convention
+            
+            :param filename: Basename of the output fileset"""
+        print("Generating NEMO grid output with basename: %s" % filename)
+        
+        self.U.write(filename, varname='vozocrtx')
+        self.V.write(filename, varname='vomecrty')
+        
+        for f in self.fields:
+            field = getattr(self, f)
+            field.write(filename)
+
+
+
+if __name__ == "__main__":
+    p = ArgumentParser(description="""
+        Example of particle advection around an idealised peninsula""")
+    p.add_argument('mode', choices=('scipy', 'jit'), nargs='?', default='jit',
+                   help='Execution mode for performing RK4 computation')
+    p.add_argument('-p', '--particles', type=int, default=2,
+                                  help='Number of particles to advect')
+    p.add_argument('-v', '--verbose', action='store_true', default=False,
+                                  help='Print particle information before and after execution')
+    p.add_argument('--profiling', action='store_true', default=False,
+                                  help='Print profiling information after run')
+    p.add_argument('-g', '--grid', type=int, nargs=2, default=None,
+                                  help='Generate grid file with given dimensions')
+
+    # Open grid files
+    filenames = {"U":"ocean_u_1993_01.TropPac.nc",
+                 "V" : "ocean_v_1993_01.TropPac.nc"}
+    dimensions = {'lat':'yu_ocean',
+                  'long':'xu_ocean',
+                  'time':'Time'}
+    datadir = "/Volumes/4TB SAMSUNG/Ocean_Model_Data/OFAM_month1"
+    grid = NetCDF_Grid.from_file(loc=datadir, filenames=filenames, vars={'U': 'u', 'V': 'v'}, dimensions=dimensions)
+
+    ParticleClass = JITParticle
+    npart = 10
+    
+    pset = grid.ParticleSet(size=npart, pclass=ParticleClass,
+                            start=(180, -5), finish=(180, 5))
+
+    hours = 25*24
+    substeps = 6
+
+    pset.execute(AdvectionRK4, timesteps=hours*substeps, dt=300.,
+                       output_file=pset.ParticleFile(name="GenericGridParticle"),
+                       output_steps=substeps)
+          
+
+    

--- a/tests/test_generic_netcdf_grid.py
+++ b/tests/test_generic_netcdf_grid.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
                    help='List of field variables to extract, using PARCELS naming convention')
     p.add_argument('-n', '--netcdf_vars', default=['u', 'v'],
                    help='List of field variable names, as given in the NetCDF file. Order must match --variables args')
-    p.add_argument('-d', '--dimensions', default=['lat', 'long', 'time'],
+    p.add_argument('-d', '--dimensions', default=['lat', 'lon', 'time'],
                    help='List of PARCELS convention named dimensions across which field variables occur')
     p.add_argument('-m', '--map_dimensions', default=['yu_ocean', 'xu_ocean', 'Time'],
                    help='List of dimensions across which field variables occur, as given in the NetCDF files, to map to the --dimensions args')

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -1,4 +1,5 @@
 from parcels import NEMOGrid, Particle, JITParticle, AdvectionRK4
+from parcels.grid import NetCDF_Grid
 from argparse import ArgumentParser
 import numpy as np
 import math
@@ -123,7 +124,14 @@ Example of particle advection around an idealised peninsula""")
         grid.write(filename)
 
     # Open grid files
-    grid = NEMOGrid.from_file(filename)
+    # grid = NEMOGrid.from_file(filename)
+    vars = ['U', 'V', 'P']
+    files = dict(zip(vars, ['moving_eddiesU.nc', 'moving_eddiesV.nc', 'moving_eddiesP.nc']))
+    dimensions = dict(zip(['lat', 'lon', 'depth', 'time'], ['y', 'x', 'depth', 'time_counter']))
+    variables = dict(zip(vars, ['vozocrtx', 'vomecrty', 'P']))
+    print(files)
+
+    grid = NetCDF_Grid.from_file(filenames=files, vars=variables, dimensions=dimensions)
 
     if args.profiling:
         from cProfile import runctx

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -1,4 +1,5 @@
 from parcels import NEMOGrid, Particle, JITParticle, AdvectionRK4
+from parcels.grid import NetCDF_Grid
 from argparse import ArgumentParser
 import numpy as np
 import pytest
@@ -185,7 +186,15 @@ Example of particle advection around an idealised peninsula""")
         grid.write(filename)
 
     # Open grid file set
-    grid = NEMOGrid.from_file('peninsula', extra_vars={'P': 'P'})
+    # grid = NEMOGrid.from_file('peninsula', extra_vars={'P': 'P'})
+
+    vars = ['U', 'V', 'P']
+    files = dict(zip(vars, ['peninsulaU.nc', 'peninsulaV.nc', 'peninsulaP.nc']))
+    dimensions = dict(zip(['lat', 'lon', 'depth', 'time'], ['y', 'x', 'depth', 'time_counter']))
+    variables = dict(zip(vars, ['vozocrtx', 'vomecrty', 'P']))
+    print(files)
+
+    grid = NetCDF_Grid.from_file(filenames=files, vars=variables, dimensions=dimensions)
 
     if args.profiling:
         from cProfile import runctx


### PR DESCRIPTION
Wrote an example script to test with defaults that should work with the
simple OFAM data now pushed to the parcels-examples repository.
NetCDF_grid class now moved to grid.py
Slight edit to plotParticles.py to allow loading of single OFAM grid data (currently hardcoded, so will need generalising at some point).

Still an issue with running under jit mode, not sure why. Default is scipy. 