### PR TITLE
Generic netCF grids and examples submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples"]
+	path = examples
+	url = https://github.com/OceanPARCELS/parcels-examples.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
     - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy netcdf4 pandas
     - pip install --upgrade pip
     - pip install -r requirements.txt
-    - python setup.py build_ext --inplace
+    - git submodule update --init --recursive
 
 script:
     - export PYTHONPATH=`pwd`:$PYTHONPATH
@@ -35,3 +35,4 @@ script:
     - flake8 tests
     - python tests/test_peninsula.py --grid 20 10
     - py.test -v -s tests/
+    - py.test -v -s examples/

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ script:
     - export PYTHONPATH=`pwd`:$PYTHONPATH
     - flake8 parcels
     - flake8 tests
+    - flake8 examples
     - python tests/test_peninsula.py --grid 20 10
     - py.test -v -s tests/
     - py.test -v -s examples/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-## PARCELS
+## Parcels
 
-PARCELS (acronym to be decided) is an experimental prototype code aimed at exploring novel approaches for Lagrangian tracking of virtual ocean particles in the petascale age.
+**Parcels** (**P**robably **A** **R**eally **C**omputationally
+**E**fficient **L**agrangian **S**imulator) is an experimental
+prototype code aimed at exploring novel approaches for Lagrangian
+tracking of virtual ocean particles in the petascale age.
 
 ### Motivation
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,25 @@ In this project, we will scope out and develop a new generic, open-source commun
 
 ### Installation
 
-The easiest way to install the latest realease of PARCELS is through pip:
+The latest version of Parcels, including tests adn examples, can be
+obtained directly from github via:
 ```
-pip install git+https://github.com/OceanPARCELS/parcels.git
-```
-Alternatively, the latest version of Parcels can be checked out locally with:
-```
-git clone https://github.com/OceanPARCELS/PARCELScode.git parcels
+git clone --recursive https://github.com/OceanPARCELS/parcels.git
 cd parcels; pip install -r requirements.txt
 export PYTHONPATH="$PYTHONPATH:$PWD"
 ```
+For a lighter checkout that does not include example data please omit
+the `--recursive` flag from the above command. As an alternatively,
+Parcels can also be installed directly via pip:
+```
+pip install git+https://github.com/OceanPARCELS/parcels.git
+```
+The above assumes that all dependencies are met, which can be achieved with:
+```
+curl -O https://raw.githubusercontent.com/OceanPARCELS/parcels/master/requirements.txt
+pip install -r requirements.txt
+```
+In both cases a functional netCDF install is required.
 
 ### Example
 A basic example of particle advection around an idealised peninsula

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -68,8 +68,10 @@ class Field(object):
         """
         if not isinstance(datasets, Iterable):
             datasets = [datasets]
-        lon = datasets[0][dimensions['lon']][0, :]
-        lat = datasets[0][dimensions['lat']][:, 0]
+        lon = datasets[0][dimensions['lon']]
+        lon = lon[0, :] if len(lon.shape) > 1 else lon[:]
+        lat = datasets[0][dimensions['lat']]
+        lat = lat[:, 0] if len(lat.shape) > 1 else lat[:]
         # Default depth to zeros until we implement 3D grids properly
         depth = np.zeros(1, dtype=np.float32)
         # Concatenate time variable to determine overall dimension

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -64,7 +64,9 @@ class NEMOGrid(object):
         """
         fields = {}
         extra_vars.update({'U': uvar, 'V': vvar})
-        for var, vname in extra_vars.items():
+        vnames = {'lon': 'nav_lon', 'lat': 'nav_lat',
+                  'depth': 'depth', 'time': 'time_counter'}
+        for var, name in extra_vars.items():
             # Resolve all matching paths for the current variable
             basepath = path.local("%s%s.nc" % (filename, var))
             paths = [path.local(fp) for fp in glob(str(basepath))]
@@ -72,7 +74,8 @@ class NEMOGrid(object):
                 if not fp.exists():
                     raise IOError("Grid file not found: %s" % str(fp))
             dsets = [Dataset(str(fp), 'r', format="NETCDF4") for fp in paths]
-            fields[var] = Field.from_netcdf(var, vname, dsets, **kwargs)
+            vnames['data'] = name
+            fields[var] = Field.from_netcdf(var, vnames, dsets, **kwargs)
         u = fields.pop('U')
         v = fields.pop('V')
         return cls(u, v, u.depth, u.time, fields=fields)

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -5,10 +5,10 @@ from py import path
 from glob import glob
 
 
-__all__ = ['NEMOGrid']
+__all__ = ['Grid']
 
 
-class NEMOGrid(object):
+class Grid(object):
     """Grid class used to generate and read NEMO output files
 
     :param U: :class:`Field` for zonal velocity component

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -1,4 +1,4 @@
-from parcels import NEMOGrid, Particle, JITParticle, AdvectionRK4
+from parcels import Grid, Particle, JITParticle, AdvectionRK4
 from argparse import ArgumentParser
 import numpy as np
 import math
@@ -59,14 +59,14 @@ def moving_eddies_grid(xdim=200, ydim=350):
         U[:, :-1, t] = np.diff(P[:, :, t], axis=1) / dy / corio_0 * g
         V[:, -1, t] = U[:, -2, t]  # Fill in the last row
 
-    return NEMOGrid.from_data(U, lon, lat, V, lon, lat,
-                              depth, time, field_data={'P': P})
+    return Grid.from_data(U, lon, lat, V, lon, lat,
+                          depth, time, field_data={'P': P})
 
 
 def moving_eddies_example(grid, npart=2, mode='jit', verbose=False):
     """Configuration of a particle set that follows two moving eddies
 
-    :arg grid: :class NEMOGrid: that defines the flow field
+    :arg grid: :class Grid: that defines the flow field
     :arg npart: Number of particles to intialise"""
 
     # Determine particle class according to mode
@@ -123,7 +123,7 @@ Example of particle advection around an idealised peninsula""")
         grid.write(filename)
 
     # Open grid files
-    grid = NEMOGrid.from_nemo(filename)
+    grid = Grid.from_nemo(filename)
 
     if args.profiling:
         from cProfile import runctx

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -123,7 +123,7 @@ Example of particle advection around an idealised peninsula""")
         grid.write(filename)
 
     # Open grid files
-    grid = NEMOGrid.from_file(filename)
+    grid = NEMOGrid.from_nemo(filename)
 
     if args.profiling:
         from cProfile import runctx

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -150,7 +150,7 @@ def gridfile():
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_peninsula_file(gridfile, mode):
     """Open grid files and execute"""
-    grid = NEMOGrid.from_file(gridfile, extra_vars={'P': 'P'})
+    grid = NEMOGrid.from_nemo(gridfile, extra_vars={'P': 'P'})
     pset = pensinsula_example(grid, 100, mode=mode, degree=1)
     # Test advection accuracy by comparing streamline values
     err_adv = np.array([abs(p.p_start - p.p) for p in pset])

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -1,4 +1,4 @@
-from parcels import NEMOGrid, Particle, JITParticle, AdvectionRK4
+from parcels import Grid, Particle, JITParticle, AdvectionRK4
 from argparse import ArgumentParser
 import numpy as np
 import pytest
@@ -60,8 +60,8 @@ def peninsula_grid(xdim, ydim):
     lon = La / 1.852 / 60.
     lat = Wa / 1.852 / 60.
 
-    return NEMOGrid.from_data(U, lon, lat, V, lon, lat,
-                              depth, time, field_data={'P': P})
+    return Grid.from_data(U, lon, lat, V, lon, lat,
+                          depth, time, field_data={'P': P})
 
 
 def UpdateP(particle, grid, time, dt):
@@ -150,7 +150,7 @@ def gridfile():
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_peninsula_file(gridfile, mode):
     """Open grid files and execute"""
-    grid = NEMOGrid.from_nemo(gridfile, extra_vars={'P': 'P'})
+    grid = Grid.from_nemo(gridfile, extra_vars={'P': 'P'})
     pset = pensinsula_example(grid, 100, mode=mode, degree=1)
     # Test advection accuracy by comparing streamline values
     err_adv = np.array([abs(p.p_start - p.p) for p in pset])
@@ -185,7 +185,7 @@ Example of particle advection around an idealised peninsula""")
         grid.write(filename)
 
     # Open grid file set
-    grid = NEMOGrid.from_file('peninsula', extra_vars={'P': 'P'})
+    grid = Grid.from_nemo('peninsula', extra_vars={'P': 'P'})
 
     if args.profiling:
         from cProfile import runctx


### PR DESCRIPTION
This merge brings two features at the same time:
* And `examples` sub-module that contains data-intensive example scripts, as well as a few extra tests. It is hosted under `OceanParcels/parcels-examples` and still small, but it allows us to separate demonstrative examples with real data from more low-level feature tests. More re-shuffling of the test infrastructure is needed though.
* Adds generic grid initialisation from netCDF files, as demonstrated by the OFAM example grid. This also includes:
  * Rename `NEMOGrid` to `Grid`
  * Add `Grid.from_netcdf()` that allows specific initialisation from a set of netCDF files with specified variable and dimension names.
  * Replace `NEMOGrid.from_file()` with `Grid.from_nemo()`, which encapsulates some explicit assumptions about NEMO naming conventions.

The two features are landed together in order to activate testing the `examples` subdirectory straight away. Many thanks go to @Jacketless for providing the test and doing all the groundwork for this merge. The merge supersedes some of the core parts of PR #35, so @Jacketless can you please have a thorough look at this before we merge?