### PR TITLE
Handling more advanced operations in JIT kernel

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -218,6 +218,25 @@ class KernelGenerator(ast.NodeVisitor):
                                                 node.op.ccode,
                                                 node.value.ccode))
 
+    def visit_If(self, node):
+        self.visit(node.test)
+        for b in node.body:
+            self.visit(b)
+        for b in node.orelse:
+            self.visit(b)
+        body = c.Block([b.ccode for b in node.body])
+        orelse = c.Block([b.ccode for b in node.orelse]) if len(node.orelse) > 0 else None
+        node.ccode = c.If(node.test.ccode, body, orelse)
+
+    def visit_Compare(self, node):
+        self.visit(node.left)
+        assert(len(node.ops) == 1)
+        self.visit(node.ops[0])
+        assert(len(node.comparators) == 1)
+        self.visit(node.comparators[0])
+        node.ccode = "%s %s %s" % (node.left.ccode, node.ops[0].ccode,
+                                   node.comparators[0].ccode)
+
     def visit_Index(self, node):
         self.visit(node.value)
         node.ccode = node.value.ccode
@@ -263,6 +282,21 @@ class KernelGenerator(ast.NodeVisitor):
 
     def visit_Num(self, node):
         node.ccode = str(node.n)
+
+    def visit_Eq(self, node):
+        node.ccode = "=="
+
+    def visit_Lt(self, node):
+        node.ccode = "<"
+
+    def visit_LtE(self, node):
+        node.ccode = "<="
+
+    def visit_Gt(self, node):
+        node.ccode = ">"
+
+    def visit_GtE(self, node):
+        node.ccode = ">="
 
     def visit_FieldNode(self, node):
         """Record intrinsic fields used in kernel"""

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -227,6 +227,11 @@ class KernelGenerator(ast.NodeVisitor):
             self.visit(e)
         node.ccode = tuple([e.ccode for e in node.elts])
 
+    def visit_List(self, node):
+        for e in node.elts:
+            self.visit(e)
+        node.ccode = "{" + ", ".join([e.ccode for e in node.elts]) + "}"
+
     def visit_Subscript(self, node):
         self.visit(node.value)
         self.visit(node.slice)
@@ -235,6 +240,8 @@ class KernelGenerator(ast.NodeVisitor):
         elif isinstance(node.value, IntrinsicNode):
             raise NotImplementedError("Subscript not implemented for object type %s"
                                       % type(node.value).__name__)
+        else:
+            node.ccode = "%s[%s]" % (node.value.ccode, node.slice.ccode)
 
     def visit_BinOp(self, node):
         self.visit(node.left)


### PR DESCRIPTION
This merge enhances our code generation capabilities for JIT kernel by handling various advanced language features during translation to C code. In detail we are adding:
* Accessing basic Python lists
* Creating multi-dimensional in-place initialized arrays from Python lists
* Simple while loops (without else clause!)
* Unary and boolen operators, like `and`, `or` and `not`
* Treat boolean values as integers using standard C conventions (`True`: `1`, `False`: `0`)