### PR TITLE
Particle sampling

### DIFF
--- a/scripts/plotParticles.py
+++ b/scripts/plotParticles.py
@@ -1,64 +1,68 @@
 #!/usr/bin/env python
 from netCDF4 import Dataset
 import numpy as np
-import matplotlib as mpl
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 from argparse import ArgumentParser
 import matplotlib.animation as animation
 
-def particleplotting(filename,tracerfile, mode):
+
+def particleplotting(filename, tracerfile, recordedvar, mode):
     """Quick and simple plotting of PARCELS trajectories"""
 
-    pfile=Dataset(filename,'r')
+    pfile = Dataset(filename, 'r')
     lon = pfile.variables['lon']
     lat = pfile.variables['lat']
     z = pfile.variables['z']
 
-    fig, ax = plt.subplots()
+    if(recordedvar is not 'none'):
+        record = pfile.variables[recordedvar]
+
     if tracerfile != 'none':
-      tfile = Dataset(tracerfile,'r')
-      X = tfile.variables['x']
-      Y = tfile.variables['y']
-      P = tfile.variables['P']
-      plt.contourf(np.squeeze(X),np.squeeze(Y),np.squeeze(P))
+        tfile = Dataset(tracerfile, 'r')
+        X = tfile.variables['x']
+        Y = tfile.variables['y']
+        P = tfile.variables['P']
+        plt.contourf(np.squeeze(X), np.squeeze(Y), np.squeeze(P))
 
     if mode == '3d':
-      ax = fig.gca(projection='3d')
-      for p in range(len(lon)):
-        ax.plot(lon[p,:],lat[p,:],z[p,:],'.-')
-      ax.set_xlabel('Longitude')
-      ax.set_ylabel('Latitude')
-      ax.set_zlabel('Depth')
+        fig = plt.figure(1)
+        ax = fig.gca(projection='3d')
+        for p in range(len(lon)):
+            ax.plot(lon[p, :], lat[p, :], z[p, :], '.-')
+        ax.set_xlabel('Longitude')
+        ax.set_ylabel('Latitude')
+        ax.set_zlabel('Depth')
     elif mode == '2d':
-      plt.plot(np.transpose(lon),np.transpose(lat),'.-')
-      plt.xlabel('Longitude')
-      plt.ylabel('Latitude')    
-    elif mode =='movie2d':
+        plt.plot(np.transpose(lon), np.transpose(lat), '.-')
+        plt.xlabel('Longitude')
+        plt.ylabel('Latitude')
+    elif mode == 'movie2d':
 
-      line, = ax.plot(lon[:,0], lat[:,0],'ow')
-      if tracerfile == 'none': # need to set ax limits
-        plt.axis((np.amin(lon),np.amax(lon),np.amin(lat),np.amax(lat)))
-        
-      def animate(i):
-          line.set_xdata(lon[:,i])
-          line.set_ydata(lat[:,i])
-          return line,
+        fig = plt.figure(1)
+        ax = plt.axes(xlim=(np.amin(lon), np.amax(lon)), ylim=(np.amin(lat), np.amax(lat)))
+        scat = ax.scatter(lon[:, 0], lat[:, 0], s=60, cmap=plt.get_cmap('autumn'))  # cmaps not working?
 
-      ani = animation.FuncAnimation(fig, animate, np.arange(1, lon.shape[1]),
-          interval=100, blit=False)
-      plt.show()
+        def animate(i):
+            scat.set_offsets(np.matrix((lon[:, i], lat[:, i])).transpose())
+            if recordedvar is not 'none':
+                scat.set_array(record[:, i])
+            return scat,
+
+        anim = animation.FuncAnimation(fig, animate, frames=np.arange(1, lon.shape[1]),
+                                       interval=100, blit=False)
 
     plt.show()
 
 if __name__ == "__main__":
     p = ArgumentParser(description="""Quick and simple plotting of PARCELS trajectories""")
-    p.add_argument('mode', choices=('2d', '3d','movie2d'), nargs='?', default='2d',
+    p.add_argument('mode', choices=('2d', '3d', 'movie2d'), nargs='?', default='2d',
                    help='Type of display')
     p.add_argument('-p', '--particlefile', type=str, default='MyParticle.nc',
                    help='Name of particle file')
     p.add_argument('-f', '--tracerfile', type=str, default='none',
                    help='Name of tracer file to display underneath particle trajectories')
+    p.add_argument('-r', '--recordedvar', type=str, default='none',
+                   help='Name of a variable recorded along trajectory')
     args = p.parse_args()
 
-    particleplotting(args.particlefile, args.tracerfile, mode=args.mode)
+    particleplotting(args.particlefile, args.tracerfile, args.recordedvar, mode=args.mode)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,0 +1,106 @@
+from test_moving_eddies import moving_eddies_grid
+from argparse import ArgumentParser
+from parcels.field import Field
+import numpy as np
+from parcels.particle import Particle, JITParticle, AdvectionRK4
+
+
+def updateUserVars(particle, grid, time, dt):
+    for var in particle.user_vars.keys():
+        if hasattr(grid, var):
+            setattr(particle, var, getattr(grid, var)[time, particle.lon, particle.lat])
+        else:
+            raise AttributeError('The current grid does contain the "%s" field defined in particle.user_vars.' % var)
+
+
+def CreateHabitatGrid(mu=None, xdim=200, ydim=350):
+    """Generate a grid that contains the physical eddy dynamics
+    from the original moving eddies test example, overlaying a
+    habitat map containing a single maxima and gaussian gradient
+    """
+
+    grid = moving_eddies_grid(xdim, ydim)
+    depth = grid.U.depth
+    time = grid.U.time
+    lon = grid.U.lon
+    lat = grid.U.lat
+
+    H = np.zeros((lon.size, lat.size, time.size), dtype=np.float32)
+
+    if mu is not None:
+        mu = [2, 46.5]
+
+    def MVNorm(x, y, mu=[0, 0], sigma=[[1, 0], [0, 1]]):
+        mu_x = mu[0]
+        mu_y = mu[1]
+        sigma = np.array(sigma)
+        sig_x = sigma[0, 0]
+        sig_y = sigma[1, 1]
+        sig_xy = sigma[1, 0]
+
+        pd = 1/(2 * np.pi * sig_x * sig_y * np.sqrt(1 - sig_xy))
+        pd = pd * np.exp(-1 / (2 * (1 - np.power(sig_xy, 2))) * (
+            ((np.power(x - mu_x, 2)) / np.power(sig_x, 2)) +
+            ((np.power(y - mu_y, 2)) / np.power(sig_y, 2)) -
+            ((2 * sig_xy * (x - mu_x) * (y - mu_y)) / (sig_x * sig_y))))
+
+        return pd
+
+    sig = [[1, 0], [0, 1]]
+    for i, x in enumerate(lon):
+        for j, y in enumerate(lat):
+            H[i, j, :] = MVNorm(x, y, mu, sig)
+
+    H_field = Field('H', H, lon, lat, depth, time, transpose=True)
+
+    # grid.add_field(H_field)
+    grid.fields.update({'H': H_field})
+    setattr(grid, 'H', H_field)
+
+    return grid
+
+
+if __name__ == "__main__":
+    p = ArgumentParser(description="""
+    Example of underlying habitat field""")
+    p.add_argument('mode', choices=('scipy', 'jit'), nargs='?', default='scipy',
+                   help='Execution mode for performing RK4 computation')
+    p.add_argument('-p', '--particles', type=int, default=10,
+                   help='Number of particles to advect')
+    p.add_argument('-v', '--verbose', action='store_true', default=False,
+                   help='Print particle information before and after execution')
+    p.add_argument('--profiling', action='store_true', default=False,
+                   help='Print profiling information after run')
+    p.add_argument('-g', '--grid', type=int, nargs=2, default=None,
+                   help='Generate grid file with given dimensions')
+    p.add_argument('-m', '--method', choices=('RK4', 'EE'), default='RK4',
+                   help='Numerical method used for advection')
+    args = p.parse_args()
+
+    # Generate grid files according to given dimensions
+    if args.grid is None:
+        args.grid = [200, 200]
+
+    grid = CreateHabitatGrid(args.grid[0], args.grid[1])
+    grid.write('sampler')
+
+    ParticleClass = JITParticle if args.mode == 'jit' else Particle
+
+    class Sampler(ParticleClass):
+        user_vars = {'H': np.float32}
+
+        def __init__(self, *args, **kwargs):
+            """Custom initialisation function which calls the base
+            initialisation and adds the instance variable p"""
+            super(Sampler, self).__init__(*args, **kwargs)
+
+    pset = grid.ParticleSet(size=args.particles, pclass=Sampler, start=(0, 45), finish=(4, 47))
+
+    hours = 25*24
+    substeps = 12
+
+    record_user_vars = pset.Kernel(updateUserVars)
+
+    pset.execute(AdvectionRK4 + record_user_vars, timesteps=hours*substeps, dt=800.,
+                 output_file=pset.ParticleFile(name="SamplerParticle"),
+                 output_steps=substeps)


### PR DESCRIPTION
Added in the functionality for custom user particle subclasses of
Particle or JITParticle to define “user_vars” and sampling kernels
which will record an arbitrary field to sample from other than lat and
lon.
Not sure if I have done this best way, i’ve tried to edit the current
structure as little as possible. 

Something not working properly with
JITParticle subclasses- suspect it has something to do with me not
allocating memory for the new user_vars OrderedDict in the Particle
Class. Maybe this could blow up our memory allowance as it’s in the superclass?