### PR TITLE
Fixed a small type-o in moving eddies test

### DIFF
--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -58,7 +58,7 @@ def moving_eddies_grid(xdim=200, ydim=350):
         V[-1, :, t] = V[-2, :, t]  # Fill in the last column
 
         U[:, :-1, t] = np.diff(P[:, :, t], axis=1) / dy / corio_0 * g
-        V[:, -1, t] = U[:, -2, t]  # Fill in the last row
+        U[:, -1, t] = U[:, -2, t]  # Fill in the last row
 
     return Grid.from_data(U, lon, lat, V, lon, lat,
                           depth, time, field_data={'P': P})


### PR DESCRIPTION
I suddenly spotted a very small typo in moving eddies example (a V where there should be a U). Quickly fixed it here. 

Am doing it through a PR rather than directly on master as I understand this is the way to fix even simple bugs like this?