### PR TITLE
Dynamic particle sets

### DIFF
--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -95,7 +95,8 @@ class Kernel(object):
         else:
             for _ in range(timesteps):
                 for p in pset.particles:
-                    self.pyfunc(p, pset.grid, time, dt)
+                    if p.active == 1:
+                        self.pyfunc(p, pset.grid, time, dt)
                 time += dt
 
     def merge(self, kernel):

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -6,6 +6,19 @@ from ctypes import c_int, c_float, c_double, c_void_p, byref
 from ast import parse, FunctionDef, Module
 import inspect
 from copy import deepcopy
+import re
+
+
+re_indent = re.compile(r"^(\s+)")
+
+
+def fix_indentation(string):
+    """Fix indentation to allow in-lined kernel definitions"""
+    lines = string.split('\n')
+    indent = re_indent.match(lines[0])
+    if indent:
+        lines = [l.replace(indent.groups()[0], '', 1) for l in lines]
+    return "\n".join(lines)
 
 
 class Kernel(object):
@@ -22,7 +35,8 @@ class Kernel(object):
             self.funcname = pyfunc.__name__
             self.funcvars = list(pyfunc.__code__.co_varnames)
             # Parse the Python code into an AST
-            self.py_ast = parse(inspect.getsource(pyfunc.__code__))
+            funccode = inspect.getsource(pyfunc.__code__)
+            self.py_ast = parse(fix_indentation(funccode))
             self.py_ast = self.py_ast.body[0]
             self.pyfunc = pyfunc
         else:

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -58,7 +58,7 @@ class Kernel(object):
             exec(compile(py_mod, "<ast>", "exec"), user_ctx)
             self.pyfunc = user_ctx[self.funcname]
 
-        self.name = "%s%s" % (ptype.name, funcname)
+        self.name = "%s%s" % (ptype.name, self.funcname)
 
         self.src_file = str(path.local("%s.c" % self.name))
         self.lib_file = str(path.local("%s.so" % self.name))

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -217,6 +217,10 @@ class ParticleSet(object):
     def __setitem__(self, key, value):
         self.particles[key] = value
 
+    def __iadd__(self, particles):
+        self.add(particles)
+        return self
+
     def add(self, particles):
         if isinstance(particles, ParticleSet):
             particles = particles.particles

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -77,6 +77,7 @@ class Particle(object):
         self.lat = lat
         self.xi = np.where(self.lon >= grid.U.lon)[0][-1]
         self.yi = np.where(self.lat >= grid.U.lat)[0][-1]
+        self.active = 1
 
         for var in self.user_vars:
             setattr(self, var, 0)
@@ -87,6 +88,9 @@ class Particle(object):
     @classmethod
     def getPType(cls):
         return ParticleType(cls)
+
+    def delete(self):
+        self.active = 0
 
 
 class JITParticle(Particle):
@@ -100,7 +104,8 @@ class JITParticle(Particle):
     """
 
     base_vars = OrderedDict([('lon', np.float32), ('lat', np.float32),
-                             ('xi', np.int32), ('yi', np.int32)])
+                             ('xi', np.int32), ('yi', np.int32),
+                             ('active', np.int32)])
     user_vars = OrderedDict()
 
     def __init__(self, *args, **kwargs):
@@ -276,6 +281,8 @@ class ParticleSet(object):
             current += output_steps * dt
             if output_file:
                 output_file.write(self, current)
+        to_remove = [i for i, p in enumerate(self.particles) if p.active == 0]
+        self.remove(to_remove)
 
     def show(self, **kwargs):
         import matplotlib.pyplot as plt

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -231,6 +231,16 @@ class ParticleSet(object):
             particles_data = [p._cptr for p in particles]
             self._particle_data = np.append(self._particle_data, particles_data)
 
+    def remove(self, indices):
+        if isinstance(indices, Iterable):
+            particles = [self.particles[i] for i in indices]
+        else:
+            particles = self.particles[indices]
+        if self.ptype.uses_jit:
+            self._particle_data = np.delete(self._particle_data, indices)
+        self.particles = np.delete(self.particles, indices)
+        return particles
+
     def execute(self, pyfunc=AdvectionRK4, time=None, dt=1., timesteps=1,
                 output_file=None, output_steps=-1):
         """Execute a given kernel function over the particle set for

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -84,6 +84,10 @@ class Particle(object):
     def __repr__(self):
         return "P(%f, %f)[%d, %d]" % (self.lon, self.lat, self.xi, self.yi)
 
+    @classmethod
+    def getPType(cls):
+        return ParticleType(cls)
+
 
 class JITParticle(Particle):
     """Particle class for JIT-based Particle objects
@@ -101,6 +105,10 @@ class JITParticle(Particle):
 
     def __init__(self, *args, **kwargs):
         self._cptr = kwargs.pop('cptr', None)
+        if self._cptr is None:
+            # Allocate data for a single particle
+            ptype = super(JITParticle, self).getPType()
+            self._cptr = np.empty(1, dtype=ptype.dtype)[0]
         super(JITParticle, self).__init__(*args, **kwargs)
 
     def __getattr__(self, attr):
@@ -137,7 +145,7 @@ class ParticleType(object):
         self.user_vars = pclass.user_vars
 
     def __repr__(self):
-        return self.name
+        return "PType<self.name>"
 
     @property
     def dtype(self):

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -2,7 +2,7 @@ from parcels.kernel import Kernel
 from parcels.compiler import GNUCompiler
 import numpy as np
 import netCDF4
-from collections import OrderedDict
+from collections import OrderedDict, Iterable
 import math
 
 __all__ = ['Particle', 'ParticleSet', 'JITParticle',
@@ -216,6 +216,16 @@ class ParticleSet(object):
 
     def __setitem__(self, key, value):
         self.particles[key] = value
+
+    def add(self, particles):
+        if isinstance(particles, ParticleSet):
+            particles = particles.particles
+        if not isinstance(particles, Iterable):
+            particles = [particles]
+        self.particles = np.append(self.particles, particles)
+        if self.ptype.uses_jit:
+            particles_data = [p._cptr for p in particles]
+            self._particle_data = np.append(self._particle_data, particles_data)
 
     def execute(self, pyfunc=AdvectionRK4, time=None, dt=1., timesteps=1,
                 output_file=None, output_steps=-1):

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -77,7 +77,6 @@ def test_pset_add_explicit(grid, mode, npart=100):
     assert np.allclose([p.lat for p in pset], lat, rtol=1e-12)
 
 
-@pytest.mark.xfail(reason="Particle addition to set has not been implemented yet")
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pset_add_shorthand(grid, mode, npart=100):
     lon = np.linspace(0, 1, npart, dtype=np.float32)
@@ -104,7 +103,7 @@ def test_pset_merge_inplace(grid, mode, npart=100):
     assert(pset1.size == 200)
 
 
-@pytest.mark.xfail(reason="ParticleSet merge has not been implemented yet")
+@pytest.mark.xfail(reason="ParticleSet duplication has not been implemented yet")
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pset_merge_duplicate(grid, mode, npart=100):
     pset1 = grid.ParticleSet(npart, pclass=ptype[mode],

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -64,7 +64,6 @@ def test_pset_custom_ptype(grid, mode, npart=100):
     assert np.allclose([p.n - 2 for p in pset], np.zeros(npart), rtol=1e-12)
 
 
-@pytest.mark.xfail(reason="Particle addition to set has not been implemented yet")
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pset_add_explicit(grid, mode, npart=100):
     lon = np.linspace(0, 1, npart, dtype=np.float32)
@@ -91,7 +90,6 @@ def test_pset_add_shorthand(grid, mode, npart=100):
     assert np.allclose([p.lat for p in pset], lat, rtol=1e-12)
 
 
-@pytest.mark.xfail(reason="ParticleSet merge has not been implemented yet")
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pset_merge_inplace(grid, mode, npart=100):
     pset1 = grid.ParticleSet(npart, pclass=ptype[mode],

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -1,0 +1,147 @@
+from parcels import Grid, Particle, JITParticle
+import numpy as np
+import pytest
+
+
+ptype = {'scipy': Particle, 'jit': JITParticle}
+
+
+@pytest.fixture
+def grid(xdim=100, ydim=100):
+    U = np.zeros((xdim, ydim), dtype=np.float32)
+    V = np.zeros((xdim, ydim), dtype=np.float32)
+    lon = np.linspace(0, 1, xdim, dtype=np.float32)
+    lat = np.linspace(0, 1, ydim, dtype=np.float32)
+    depth = np.zeros(1, dtype=np.float32)
+    time = np.zeros(1, dtype=np.float64)
+    return Grid.from_data(U, lon, lat, V, lon, lat, depth, time)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pset_create_lon_lat(grid, mode, npart=100):
+    lon = np.linspace(0, 1, npart, dtype=np.float32)
+    lat = np.linspace(1, 0, npart, dtype=np.float32)
+    pset = grid.ParticleSet(npart, lon=lon, lat=lat, pclass=ptype[mode])
+    assert np.allclose([p.lon for p in pset], lon, rtol=1e-12)
+    assert np.allclose([p.lat for p in pset], lat, rtol=1e-12)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pset_create_line(grid, mode, npart=100):
+    lon = np.linspace(0, 1, npart, dtype=np.float32)
+    lat = np.linspace(1, 0, npart, dtype=np.float32)
+    pset = grid.ParticleSet(npart, start=(0, 1), finish=(1, 0), pclass=ptype[mode])
+    assert np.allclose([p.lon for p in pset], lon, rtol=1e-12)
+    assert np.allclose([p.lat for p in pset], lat, rtol=1e-12)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pset_access(grid, mode, npart=100):
+    lon = np.linspace(0, 1, npart, dtype=np.float32)
+    lat = np.linspace(1, 0, npart, dtype=np.float32)
+    pset = grid.ParticleSet(npart, lon=lon, lat=lat, pclass=ptype[mode])
+    assert(pset.size == 100)
+    assert np.allclose([pset[i].lon for i in range(pset.size)], lon, rtol=1e-12)
+    assert np.allclose([pset[i].lat for i in range(pset.size)], lat, rtol=1e-12)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pset_custom_ptype(grid, mode, npart=100):
+    class TestParticle(ptype[mode]):
+        user_vars = {'p': np.float32, 'n': np.int32}
+
+        def __init__(self, *args, **kwargs):
+            super(TestParticle, self).__init__(*args, **kwargs)
+            self.p = 0.33
+            self.n = 2
+
+    pset = grid.ParticleSet(npart, pclass=TestParticle,
+                            lon=np.linspace(0, 1, npart, dtype=np.float32),
+                            lat=np.linspace(1, 0, npart, dtype=np.float32))
+    assert(pset.size == 100)
+    # FIXME: The float test fails with a conversion error of 1.e-8
+    # assert np.allclose([p.p - 0.33 for p in pset], np.zeros(npart), rtol=1e-12)
+    assert np.allclose([p.n - 2 for p in pset], np.zeros(npart), rtol=1e-12)
+
+
+@pytest.mark.xfail(reason="Particle addition to set has not been implemented yet")
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pset_add_explicit(grid, mode, npart=100):
+    lon = np.linspace(0, 1, npart, dtype=np.float32)
+    lat = np.linspace(1, 0, npart, dtype=np.float32)
+    pset = grid.ParticleSet(0, lon=[], lat=[], pclass=ptype[mode])
+    for i in range(npart):
+        particle = ptype[mode](lon=lon[i], lat=lat[i], grid=grid)
+        pset.add(particle)
+    assert(pset.size == 100)
+    assert np.allclose([p.lon for p in pset], lon, rtol=1e-12)
+    assert np.allclose([p.lat for p in pset], lat, rtol=1e-12)
+
+
+@pytest.mark.xfail(reason="Particle addition to set has not been implemented yet")
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pset_add_shorthand(grid, mode, npart=100):
+    lon = np.linspace(0, 1, npart, dtype=np.float32)
+    lat = np.linspace(1, 0, npart, dtype=np.float32)
+    pset = grid.ParticleSet(0, lon=[], lat=[], pclass=ptype[mode])
+    for i in range(npart):
+        pset += ptype[mode](lon=lon[i], lat=lat[i], grid=grid)
+    assert(pset.size == 100)
+    assert np.allclose([p.lon for p in pset], lon, rtol=1e-12)
+    assert np.allclose([p.lat for p in pset], lat, rtol=1e-12)
+
+
+@pytest.mark.xfail(reason="ParticleSet merge has not been implemented yet")
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pset_merge_inplace(grid, mode, npart=100):
+    pset1 = grid.ParticleSet(npart, pclass=ptype[mode],
+                             lon=np.linspace(0, 1, npart, dtype=np.float32),
+                             lat=np.linspace(1, 0, npart, dtype=np.float32))
+    pset2 = grid.ParticleSet(npart, pclass=ptype[mode],
+                             lon=np.linspace(0, 1, npart, dtype=np.float32),
+                             lat=np.linspace(0, 1, npart, dtype=np.float32))
+    assert(pset1.size == 100)
+    assert(pset2.size == 100)
+    pset1.add(pset2)
+    assert(pset1.size == 200)
+
+
+@pytest.mark.xfail(reason="ParticleSet merge has not been implemented yet")
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pset_merge_duplicate(grid, mode, npart=100):
+    pset1 = grid.ParticleSet(npart, pclass=ptype[mode],
+                             lon=np.linspace(0, 1, npart, dtype=np.float32),
+                             lat=np.linspace(1, 0, npart, dtype=np.float32))
+    pset2 = grid.ParticleSet(npart, pclass=ptype[mode],
+                             lon=np.linspace(0, 1, npart, dtype=np.float32),
+                             lat=np.linspace(0, 1, npart, dtype=np.float32))
+    pset3 = pset1 + pset2
+    assert(pset1.size == 100)
+    assert(pset2.size == 100)
+    assert(pset3.size == 200)
+
+
+@pytest.mark.xfail(reason="Particle removal has not been implemented yet")
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pset_remove_index(grid, mode, npart=100):
+    lon = np.linspace(0, 1, npart, dtype=np.float32)
+    lat = np.linspace(1, 0, npart, dtype=np.float32)
+    pset = grid.ParticleSet(npart, lon=lon, lat=lat, pclass=ptype[mode])
+    for ilon, ilat in zip(lon[::-1], lat[::-1]):
+        p = pset.remove(-1)
+        assert(p.lon == ilon)
+        assert(p.lat == ilat)
+    assert(pset.size == 0)
+
+
+@pytest.mark.xfail(reason="Particle removal has not been implemented yet")
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pset_remove_particle(grid, mode, npart=100):
+    lon = np.linspace(0, 1, npart, dtype=np.float32)
+    lat = np.linspace(1, 0, npart, dtype=np.float32)
+    pset = grid.ParticleSet(npart, lon=lon, lat=lat, pclass=ptype[mode])
+    for ilon, ilat in zip(lon[::-1], lat[::-1]):
+        p = pset.remove(pset[-1])
+        assert(p.lon == ilon)
+        assert(p.lat == ilat)
+    assert(pset.size == 0)

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -143,7 +143,7 @@ def test_pset_remove_particle(grid, mode, npart=100):
     assert(pset.size == 0)
 
 
-@pytest.mark.parametrize('mode', ['scipy'])
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pset_remove_kernel(grid, mode, npart=100):
     def DeleteKernel(particle, grid, time, dt):
         if particle.lon >= .4:

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -118,7 +118,6 @@ def test_pset_merge_duplicate(grid, mode, npart=100):
     assert(pset3.size == 200)
 
 
-@pytest.mark.xfail(reason="Particle removal has not been implemented yet")
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pset_remove_index(grid, mode, npart=100):
     lon = np.linspace(0, 1, npart, dtype=np.float32)

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -141,3 +141,16 @@ def test_pset_remove_particle(grid, mode, npart=100):
         assert(p.lon == ilon)
         assert(p.lat == ilat)
     assert(pset.size == 0)
+
+
+@pytest.mark.parametrize('mode', ['scipy'])
+def test_pset_remove_kernel(grid, mode, npart=100):
+    def DeleteKernel(particle, grid, time, dt):
+        if particle.lon >= .4:
+            particle.delete()
+
+    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+                            lon=np.linspace(0, 1, npart, dtype=np.float32),
+                            lat=np.linspace(1, 0, npart, dtype=np.float32))
+    pset.execute(pset.Kernel(DeleteKernel), timesteps=1, dt=1.0)
+    assert(pset.size == 40)


### PR DESCRIPTION
This merge brings additional set manipulation capabilities for the `ParticleSet` class,  including the addition and removal of one or more particles from any given set. The merge comes with a battery of unit tests for all manipulation routines, as well as two important bug-fixes, in particular:
* Single particle instantiation
* Addition of single particles and merging of `ParticleSets`
* Removal of particles from a set via indexes
* Self-removal of particles from within kernels via `particle.delete()`
* Bug-fix for auto-unindentation for in-lined kernel definitions
* Bug-fix in kernel naming to avoid clashes in the test suite

Note that certain set operations are not yet supported, such as duplicate-and-merge (`pset3 = pset1 + pset2`) and removal of real particle objects rather than indices; these are currently xfailing tests. Comments on the desired details of the API itself are very welcome. 

Also note that the addition and removal operations we are using are currently slow, especially for large sets, since we rely on numpy arrays under the hood. Optimisation of these data structures is left for another day though since it's non-trivial.