### PR TITLE
On the fly movies with fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
     - conda update --yes conda
 
 install:
-    - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy netcdf4 pandas
+    - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy netcdf4 pandas matplotlib
     - pip install --upgrade pip
     - pip install -r requirements.txt
     - git submodule update --init --recursive

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -146,7 +146,13 @@ class Field(object):
     def show(self, **kwargs):
         import matplotlib.pyplot as plt
         t = kwargs.get('t', 0)
-        data = np.squeeze(self.data[t, :])
+        idx = self.time_index(t)
+        t0 = self.time[idx-1]
+        t1 = self.time[idx]
+        f0 = self.data[idx-1, :]
+        f1 = self.data[idx, :]
+        val = f0 + (f1 - f0) * ((t - t0) / (t1 - t0))
+        data = np.squeeze(val)
         vmin = kwargs.get('vmin', data.min())
         vmax = kwargs.get('vmax', data.max())
         cs = plt.contourf(self.lon, self.lat, data,

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -168,10 +168,6 @@ class Field(object):
         cs.cmap.set_under('w')
         cs.set_clim(vmin, vmax)
         plt.colorbar(cs)
-        plt.xlabel('Longitude')
-        plt.ylabel('Latitude')
-        plt.title(self.name + ' at  time ' + str(t) + ' seconds')
-        plt.show()
 
     def write(self, filename, varname=None):
         filepath = str(path.local('%s%s.nc' % (filename, self.name)))

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -5,6 +5,7 @@ from py import path
 import numpy as np
 from xray import DataArray, Dataset
 import operator
+import matplotlib.pyplot as plt
 from ctypes import Structure, c_int, c_float, c_double, POINTER
 
 
@@ -91,9 +92,23 @@ class Field(object):
         return self.eval(*key)
 
     @cachedmethod(operator.attrgetter('interpolator_cache'))
-    def interpolator(self, t_idx):
+    def interpolator2D(self, t_idx):
         return RectBivariateSpline(self.lat, self.lon,
                                    self.data[t_idx, :])
+
+    def interpolator1D(self, idx, time, y, x):
+        # Return linearly interpolated field value:
+        if x is None and y is None:
+            t0 = self.time[idx-1]
+            t1 = self.time[idx]
+            f0 = self.data[idx-1, :]
+            f1 = self.data[idx, :]
+        else:
+            f0 = self.interpolator2D(idx-1).ev(y, x)
+            f1 = self.interpolator2D(idx).ev(y, x)
+            t0 = self.time[idx-1]
+            t1 = self.time[idx]
+        return f0 + (f1 - f0) * ((time - t0) / (t1 - t0))
 
     @cachedmethod(operator.attrgetter('time_index_cache'))
     def time_index(self, time):
@@ -108,14 +123,9 @@ class Field(object):
     def eval(self, time, x, y):
         idx = self.time_index(time)
         if idx > 0:
-            # Return linearly interpolated field value:
-            f0 = self.interpolator(idx-1).ev(y, x)
-            f1 = self.interpolator(idx).ev(y, x)
-            t0 = self.time[idx-1]
-            t1 = self.time[idx]
-            return f0 + (f1 - f0) * ((time - t0) / (t1 - t0))
+            return self.interpolator1D(idx, time, y, x)
         else:
-            return self.interpolator(idx).ev(y, x)
+            return self.interpolator2D(idx).ev(y, x)
 
     def ccode_subscript(self, t, x, y):
         ccode = "temporal_interpolation_linear(%s, %s, %s, %s, %s, %s)" \
@@ -144,15 +154,9 @@ class Field(object):
         return cstruct
 
     def show(self, **kwargs):
-        import matplotlib.pyplot as plt
         t = kwargs.get('t', 0)
         idx = self.time_index(t)
-        t0 = self.time[idx-1]
-        t1 = self.time[idx]
-        f0 = self.data[idx-1, :]
-        f1 = self.data[idx, :]
-        val = f0 + (f1 - f0) * ((t - t0) / (t1 - t0))
-        data = np.squeeze(val)
+        data = np.squeeze(self.interpolator1D(idx, t, None, None))
         vmin = kwargs.get('vmin', data.min())
         vmax = kwargs.get('vmax', data.max())
         cs = plt.contourf(self.lon, self.lat, data,
@@ -163,7 +167,7 @@ class Field(object):
         plt.colorbar(cs)
         plt.xlabel('Longitude')
         plt.ylabel('Latitude')
-        plt.title(self.name)
+        plt.title(self.name + ' at  time ' + str(t) + ' seconds')
         plt.show()
 
     def write(self, filename, varname=None):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -156,7 +156,10 @@ class Field(object):
     def show(self, **kwargs):
         t = kwargs.get('t', 0)
         idx = self.time_index(t)
-        data = np.squeeze(self.interpolator1D(idx, t, None, None))
+        if self.time.size > 1:
+            data = np.squeeze(self.interpolator1D(idx, t, None, None))
+        else:
+            data = np.squeeze(self.data)
         vmin = kwargs.get('vmin', data.min())
         vmax = kwargs.get('vmax', data.max())
         cs = plt.contourf(self.lon, self.lat, data,

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -6,6 +6,7 @@ import netCDF4
 from collections import OrderedDict, Iterable
 import matplotlib.pyplot as plt
 import math
+import datetime
 
 __all__ = ['Particle', 'ParticleSet', 'JITParticle',
            'ParticleFile', 'AdvectionRK4', 'AdvectionEE']
@@ -291,6 +292,7 @@ class ParticleSet(object):
 
     def show(self, **kwargs):
         field = kwargs.get('field', True)
+        t = kwargs.get('t', 0)
         lon = [p.lon for p in self]
         lat = [p.lat for p in self]
         plt.ion()
@@ -300,11 +302,16 @@ class ParticleSet(object):
             axes = plt.gca()
             axes.set_xlim([self.grid.U.lon[0], self.grid.U.lon[-1]])
             axes.set_ylim([self.grid.U.lat[0], self.grid.U.lat[-1]])
-            plt.show()
+            namestr = ''
         else:
             if not isinstance(field, Field):
                 field = getattr(self.grid, field)
             field.show(**kwargs)
+            namestr = ' on ' + field.name
+        plt.xlabel('Longitude')
+        plt.ylabel('Latitude')
+        plt.title('Particles' + namestr + ' after ' + str(datetime.timedelta(seconds=t)) + ' hours')
+        plt.show()
         plt.pause(0.0001)
 
     def Kernel(self, pyfunc):

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -257,6 +257,9 @@ class ParticleSet(object):
         plt.clf()
         plt.plot(np.transpose(lon), np.transpose(lat), 'ko')
         if field is True:
+            axes = plt.gca()
+            axes.set_xlim([self.grid.U.lon[0], self.grid.U.lon[-1]])
+            axes.set_ylim([self.grid.U.lat[0], self.grid.U.lat[-1]])
             plt.show()
         else:
             field = getattr(self.grid, field)

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -1,4 +1,5 @@
 from parcels.kernel import Kernel
+from parcels.field import Field
 from parcels.compiler import GNUCompiler
 import numpy as np
 import netCDF4
@@ -262,7 +263,8 @@ class ParticleSet(object):
             axes.set_ylim([self.grid.U.lat[0], self.grid.U.lat[-1]])
             plt.show()
         else:
-            field = getattr(self.grid, field)
+            if not isinstance(field, Field):
+                field = getattr(self.grid, field)
             field.show(**kwargs)
         plt.pause(0.0001)
 

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -250,11 +250,14 @@ class ParticleSet(object):
         field = kwargs.get('field', None)
         lon = [p.lon for p in self]
         lat = [p.lat for p in self]
+        plt.ion()
+        plt.clf()
         plt.plot(np.transpose(lon), np.transpose(lat), 'ko')
         if field is None:
             plt.show()
         else:
             field.show(**kwargs)
+        plt.pause(0.0001)
 
     def Kernel(self, pyfunc):
         return Kernel(self.grid, self.ptype, pyfunc)

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -222,6 +222,7 @@ class ParticleSet(object):
         :param timesteps: Number of individual timesteps to execute
         :param output_file: ParticleFile object for particle output
         :param output_steps: Size of output intervals in timesteps
+        :param show_movie: True shows particles; name of field plots that field as background
         """
         if self.kernel is None:
             # Generate and store Kernel
@@ -246,18 +247,19 @@ class ParticleSet(object):
             if output_file:
                 output_file.write(self, current)
             if show_movie:
-                self.show(field=self.grid.U, t=current)
+                self.show(field=show_movie, t=current)
 
     def show(self, **kwargs):
-        field = kwargs.get('field', None)
+        field = kwargs.get('field', True)
         lon = [p.lon for p in self]
         lat = [p.lat for p in self]
         plt.ion()
         plt.clf()
         plt.plot(np.transpose(lon), np.transpose(lat), 'ko')
-        if field is None:
+        if field is True:
             plt.show()
         else:
+            field = getattr(self.grid, field)
             field.show(**kwargs)
         plt.pause(0.0001)
 

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -3,6 +3,7 @@ from parcels.compiler import GNUCompiler
 import numpy as np
 import netCDF4
 from collections import OrderedDict
+import matplotlib.pyplot as plt
 import math
 
 __all__ = ['Particle', 'ParticleSet', 'JITParticle',
@@ -210,7 +211,7 @@ class ParticleSet(object):
         self.particles[key] = value
 
     def execute(self, pyfunc=AdvectionRK4, time=None, dt=1., timesteps=1,
-                output_file=None, output_steps=-1):
+                output_file=None, show_movie=False, output_steps=-1):
         """Execute a given kernel function over the particle set for
         multiple timesteps. Optionally also provide sub-timestepping
         for particle output.
@@ -244,9 +245,10 @@ class ParticleSet(object):
             current += output_steps * dt
             if output_file:
                 output_file.write(self, current)
+            if show_movie:
+                self.show(field=self.grid.U, t=current)
 
     def show(self, **kwargs):
-        import matplotlib.pyplot as plt
         field = kwargs.get('field', None)
         lon = [p.lon for p in self]
         lat = [p.lat for p in self]

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -87,7 +87,7 @@ def moving_eddies_example(grid, npart=2, mode='jit', verbose=False,
           % (npart, hours * substeps))
     pset.execute(method, timesteps=hours*substeps, dt=300.,
                  output_file=pset.ParticleFile(name="EddyParticle"),
-                 output_steps=substeps)
+                 output_steps=substeps, show_movie=True)
 
     if verbose:
         print("Final particle positions:\n%s" % pset)

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -87,7 +87,7 @@ def moving_eddies_example(grid, npart=2, mode='jit', verbose=False,
           % (npart, hours * substeps))
     pset.execute(method, timesteps=hours*substeps, dt=300.,
                  output_file=pset.ParticleFile(name="EddyParticle"),
-                 output_steps=substeps, show_movie=True)
+                 output_steps=substeps, show_movie=False)
 
     if verbose:
         print("Final particle positions:\n%s" % pset)


### PR DESCRIPTION
Improvements to the way on-the-fly-movies (i.e. movies while the code is run, particularly useful for testing/debugging) are made. Added a variable `show_movie` to .execute. If `show_movie = True`, then only the particle locations are plotted. If `show_movie = U` or any other grid field, that field will be shown in the background. See also #16.

Note that travis builds fail because of `Invalid DISPLAY variable`. Simplest solution to fix this travis error is to set `show_movie = False` in `moving_eddies_example` but then the code won't be tested, of course. Any suggestions?