### PR TITLE
Include netcdf timeorigin

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -23,7 +23,7 @@ class Field(object):
     """
 
     def __init__(self, name, data, lon, lat, depth=None, time=None,
-                 transpose=False, vmin=None, vmax=None):
+                 transpose=False, vmin=None, vmax=None, time_origin=0):
         self.name = name
         self.data = data
         self.lon = lon
@@ -56,6 +56,7 @@ class Field(object):
 
         self.interpolator_cache = LRUCache(maxsize=2)
         self.time_index_cache = LRUCache(maxsize=2)
+        self.time_origin = time_origin
 
     @classmethod
     def from_netcdf(cls, name, dimensions, datasets, **kwargs):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -84,8 +84,8 @@ class Field(object):
 
         # assign time_origin if the time dimension has units and calendar
         try:
-            time_units = dset[dimensions['time']].units
-            calendar = dset[dimensions['time']].calendar
+            time_units = datasets[0][dimensions['time']].units
+            calendar = datasets[0][dimensions['time']].calendar
             time_origin = num2date(0, time_units, calendar)
         except:
             time_origin = 0

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -23,7 +23,7 @@ class Field(object):
     """
 
     def __init__(self, name, data, lon, lat, depth=None, time=None,
-                 transpose=False, vmin=None, vmax=None, time_origin=0):
+                 transpose=False, vmin=None, vmax=None):
         self.name = name
         self.data = data
         self.lon = lon
@@ -56,7 +56,6 @@ class Field(object):
 
         self.interpolator_cache = LRUCache(maxsize=2)
         self.time_index_cache = LRUCache(maxsize=2)
-        self.time_origin = time_origin
 
     @classmethod
     def from_netcdf(cls, name, dimensions, datasets, **kwargs):

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -78,7 +78,6 @@ class Grid(object):
             fields[var] = Field.from_netcdf(var, dimensions, dsets, **kwargs)
         u = fields.pop('U')
         v = fields.pop('V')
-
         return cls(u, v, u.depth, u.time, fields=fields)
 
     @classmethod

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -1,4 +1,4 @@
-from netCDF4 import Dataset, num2date
+from netCDF4 import Dataset
 from parcels.field import Field
 from parcels.particle import ParticleSet
 from py import path
@@ -17,12 +17,11 @@ class Grid(object):
     :param time: Time coordinates of the grid
     :param fields: Dictionary of additional fields
     """
-    def __init__(self, U, V, depth, time, time_origin=0, fields={}):
+    def __init__(self, U, V, depth, time, fields={}):
         self.U = U
         self.V = V
         self.depth = depth
         self.time = time
-        self.time_origin = time_origin
         self.fields = fields
 
         # Add additional fields as attributes
@@ -80,15 +79,7 @@ class Grid(object):
         u = fields.pop('U')
         v = fields.pop('V')
 
-        # assign time_origin if the time dimension has units and calendar
-        try:
-            time_units = dsets[0][dimensions['time']].units
-            calendar = dsets[0][dimensions['time']].calendar
-            time_origin = num2date(0, time_units, calendar)
-        except:
-            time_origin = 0
-
-        return cls(u, v, u.depth, u.time, fields=fields, time_origin=time_origin)
+        return cls(u, v, u.depth, u.time, fields=fields)
 
     @classmethod
     def from_nemo(cls, basename, uvar='vozocrtx', vvar='vomecrty',

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -181,7 +181,7 @@ class ParticleSet(object):
         self.particles = np.empty(size, dtype=pclass)
         self.ptype = ParticleType(pclass)
         self.kernel = None
-        self.time_origin = grid.time_origin
+        self.time_origin = grid.U.time_origin
 
         if self.ptype.uses_jit:
             # Allocate underlying data for C-allocated particles
@@ -310,10 +310,10 @@ class ParticleSet(object):
                 field = getattr(self.grid, field)
             field.show(**kwargs)
             namestr = ' on ' + field.name
-        if self.grid.time_origin == 0:
+        if field.time_origin == 0:
             timestr = ' after ' + str(datetime.timedelta(seconds=t)) + ' hours'
         else:
-            timestr = ' on ' + str(self.grid.time_origin + datetime.timedelta(seconds=t))
+            timestr = ' on ' + str(field.time_origin + datetime.timedelta(seconds=t))
         plt.xlabel('Longitude')
         plt.ylabel('Latitude')
         plt.title('Particles' + namestr + timestr)

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -308,10 +308,10 @@ class ParticleSet(object):
                 field = getattr(self.grid, field)
             field.show(**kwargs)
             namestr = ' on ' + field.name
-        if self.grid.U.time_origin == 0:
+        if self.grid.time_origin == 0:
             timestr = ' after ' + str(datetime.timedelta(seconds=t)) + ' hours'
         else:
-            timestr = ' on ' + str(self.grid.U.time_origin + datetime.timedelta(seconds=t))
+            timestr = ' on ' + str(self.grid.time_origin + datetime.timedelta(seconds=t))
         plt.xlabel('Longitude')
         plt.ylabel('Latitude')
         plt.title('Particles' + namestr + timestr)

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -360,7 +360,7 @@ class ParticleFile(object):
         self.trajectory[:] = np.arange(particleset.size, dtype=np.int32)
 
         # Create time, lat, lon and z variables according to CF conventions:
-        self.time = self.dataset.createVariable("time", "f8", ("trajectory", "obs"), fill_value=0.)
+        self.time = self.dataset.createVariable("time", "f8", ("trajectory", "obs"), fill_value=-9999.)
         self.time.long_name = ""
         self.time.standard_name = "time"
         if time_origin == 0:
@@ -370,19 +370,19 @@ class ParticleFile(object):
             self.time.calendar = "julian"
         self.time.axis = "T"
 
-        self.lat = self.dataset.createVariable("lat", "f4", ("trajectory", "obs"), fill_value=0.)
+        self.lat = self.dataset.createVariable("lat", "f4", ("trajectory", "obs"), fill_value=-9999.)
         self.lat.long_name = ""
         self.lat.standard_name = "latitude"
         self.lat.units = "degrees_north"
         self.lat.axis = "Y"
 
-        self.lon = self.dataset.createVariable("lon", "f4", ("trajectory", "obs"), fill_value=0.)
+        self.lon = self.dataset.createVariable("lon", "f4", ("trajectory", "obs"), fill_value=-9999.)
         self.lon.long_name = ""
         self.lon.standard_name = "longitude"
         self.lon.units = "degrees_east"
         self.lon.axis = "X"
 
-        self.z = self.dataset.createVariable("z", "f4", ("trajectory", "obs"), fill_value=0.)
+        self.z = self.dataset.createVariable("z", "f4", ("trajectory", "obs"), fill_value=-9999.)
         self.z.long_name = ""
         self.z.standard_name = "depth"
         self.z.units = "m"

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -172,6 +172,7 @@ class ParticleSet(object):
     :param pclass: Optional class object that defines custom particle
     :param lon: List of initial longitude values for particles
     :param lat: List of initial latitude values for particles
+    :param time_origin: Time origin of the particles (taken from grid)
     """
 
     def __init__(self, size, grid, pclass=JITParticle,
@@ -180,6 +181,7 @@ class ParticleSet(object):
         self.particles = np.empty(size, dtype=pclass)
         self.ptype = ParticleType(pclass)
         self.kernel = None
+        self.time_origin = grid.time_origin
 
         if self.ptype.uses_jit:
             # Allocate underlying data for C-allocated particles
@@ -327,7 +329,7 @@ class ParticleSet(object):
 
 class ParticleFile(object):
 
-    def __init__(self, name, particleset, initial_dump=True, time_origin=0):
+    def __init__(self, name, particleset, initial_dump=True):
         """Initialise netCDF4.Dataset for trajectory output.
 
         The output follows the format outlined in the Discrete
@@ -363,10 +365,10 @@ class ParticleFile(object):
         self.time = self.dataset.createVariable("time", "f8", ("trajectory", "obs"), fill_value=-9999.)
         self.time.long_name = ""
         self.time.standard_name = "time"
-        if time_origin == 0:
+        if particleset.time_origin == 0:
             self.time.units = "seconds"
         else:
-            self.time.units = "seconds since " + str(time_origin)
+            self.time.units = "seconds since " + str(particleset.time_origin)
             self.time.calendar = "julian"
         self.time.axis = "T"
 

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -308,9 +308,13 @@ class ParticleSet(object):
                 field = getattr(self.grid, field)
             field.show(**kwargs)
             namestr = ' on ' + field.name
+        if self.grid.U.time_origin == 0:
+            timestr = ' after ' + str(datetime.timedelta(seconds=t)) + ' hours'
+        else:
+            timestr = ' on ' + str(self.grid.U.time_origin + datetime.timedelta(seconds=t))
         plt.xlabel('Longitude')
         plt.ylabel('Latitude')
-        plt.title('Particles' + namestr + ' after ' + str(datetime.timedelta(seconds=t)) + ' hours')
+        plt.title('Particles' + namestr + timestr)
         plt.show()
         plt.pause(0.0001)
 

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -327,7 +327,7 @@ class ParticleSet(object):
 
 class ParticleFile(object):
 
-    def __init__(self, name, particleset, initial_dump=True):
+    def __init__(self, name, particleset, initial_dump=True, time_origin=0):
         """Initialise netCDF4.Dataset for trajectory output.
 
         The output follows the format outlined in the Discrete
@@ -363,8 +363,11 @@ class ParticleFile(object):
         self.time = self.dataset.createVariable("time", "f8", ("trajectory", "obs"), fill_value=0.)
         self.time.long_name = ""
         self.time.standard_name = "time"
-        self.time.units = "seconds since 1970-01-01 00:00:00 0:00"
-        self.time.calendar = "julian"
+        if time_origin == 0:
+            self.time.units = "seconds"
+        else:
+            self.time.units = "seconds since " + str(time_origin)
+            self.time.calendar = "julian"
         self.time.axis = "T"
 
         self.lat = self.dataset.createVariable("lat", "f4", ("trajectory", "obs"), fill_value=0.)

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -362,7 +362,7 @@ class ParticleFile(object):
         self.trajectory[:] = np.arange(particleset.size, dtype=np.int32)
 
         # Create time, lat, lon and z variables according to CF conventions:
-        self.time = self.dataset.createVariable("time", "f8", ("trajectory", "obs"), fill_value=-9999.)
+        self.time = self.dataset.createVariable("time", "f8", ("trajectory", "obs"), fill_value=np.nan)
         self.time.long_name = ""
         self.time.standard_name = "time"
         if particleset.time_origin == 0:
@@ -372,19 +372,19 @@ class ParticleFile(object):
             self.time.calendar = "julian"
         self.time.axis = "T"
 
-        self.lat = self.dataset.createVariable("lat", "f4", ("trajectory", "obs"), fill_value=-9999.)
+        self.lat = self.dataset.createVariable("lat", "f4", ("trajectory", "obs"), fill_value=np.nan)
         self.lat.long_name = ""
         self.lat.standard_name = "latitude"
         self.lat.units = "degrees_north"
         self.lat.axis = "Y"
 
-        self.lon = self.dataset.createVariable("lon", "f4", ("trajectory", "obs"), fill_value=-9999.)
+        self.lon = self.dataset.createVariable("lon", "f4", ("trajectory", "obs"), fill_value=np.nan)
         self.lon.long_name = ""
         self.lon.standard_name = "longitude"
         self.lon.units = "degrees_east"
         self.lon.axis = "X"
 
-        self.z = self.dataset.createVariable("z", "f4", ("trajectory", "obs"), fill_value=-9999.)
+        self.z = self.dataset.createVariable("z", "f4", ("trajectory", "obs"), fill_value=np.nan)
         self.z.long_name = ""
         self.z.standard_name = "depth"
         self.z.units = "m"


### PR DESCRIPTION
Added option to pass `time_origin` to `Grid.from_netcdf`, which is useful for grids that use calendar time.

By passing a time_origin (often given in netcdf files like those from NEMO, http://gws-access.ceda.ac.uk/public/nemo/runs/ORCA0083-N06/means) to `.execute`, the time on the movies is pretty-printed, and the output netcdf files will show the correct time