### PR TITLE
Improved testing and time handling

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -166,6 +166,7 @@ class Field(object):
 
     def show(self, **kwargs):
         t = kwargs.get('t', 0)
+        animation = kwargs.get('animation', False)
         idx = self.time_index(t)
         if self.time.size > 1:
             data = np.squeeze(self.interpolator1D(idx, t, None, None))
@@ -179,6 +180,8 @@ class Field(object):
         cs.cmap.set_under('w')
         cs.set_clim(vmin, vmax)
         plt.colorbar(cs)
+        if not animation:
+            plt.show()
 
     def write(self, filename, varname=None):
         filepath = str(path.local('%s%s.nc' % (filename, self.name)))

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -296,7 +296,7 @@ class ParticleSet(object):
         timesteps = int((endtime - starttime) / dt)
 
         # Check if output is required and compute outer leaps
-        if output_file is None or output_interval <= 0:
+        if output_interval <= 0:
             output_steps = timesteps
         else:
             output_steps = abs(int(output_interval / dt))

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -6,7 +6,7 @@ import netCDF4
 from collections import OrderedDict, Iterable
 import matplotlib.pyplot as plt
 import math
-import datetime
+from datetime import timedelta as delta
 
 __all__ = ['Particle', 'ParticleSet', 'JITParticle',
            'ParticleFile', 'AdvectionRK4', 'AdvectionEE']
@@ -276,6 +276,15 @@ class ParticleSet(object):
                 self.kernel.compile(compiler=GNUCompiler())
                 self.kernel.load_lib()
 
+        if isinstance(starttime, delta):
+            starttime = starttime.total_seconds()
+        if isinstance(endtime, delta):
+            endtime = endtime.total_seconds()
+        if isinstance(dt, delta):
+            dt = dt.total_seconds()
+        if isinstance(output_interval, delta):
+            output_interval = output_interval.total_seconds()
+
         # Check if starttime, endtime and dt are consistent and compute timesteps
         if starttime is None:
             if dt > 0:
@@ -333,9 +342,9 @@ class ParticleSet(object):
             field.show(animation=True, **kwargs)
             namestr = ' on ' + field.name
         if field.time_origin == 0:
-            timestr = ' after ' + str(datetime.timedelta(seconds=t)) + ' hours'
+            timestr = ' after ' + str(delta(seconds=t)) + ' hours'
         else:
-            timestr = ' on ' + str(field.time_origin + datetime.timedelta(seconds=t))
+            timestr = ' on ' + str(field.time_origin + delta(seconds=t))
         plt.xlabel('Longitude')
         plt.ylabel('Latitude')
         plt.title('Particles' + namestr + timestr)

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -330,7 +330,7 @@ class ParticleSet(object):
         else:
             if not isinstance(field, Field):
                 field = getattr(self.grid, field)
-            field.show(**kwargs)
+            field.show(animation=True, **kwargs)
             namestr = ' on ' + field.name
         if field.time_origin == 0:
             timestr = ' after ' + str(datetime.timedelta(seconds=t)) + ' hours'

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,0 +1,21 @@
+from parcels import Grid
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize('xdim', [100, 200])
+@pytest.mark.parametrize('ydim', [100, 200])
+def test_grid_from_data(xdim, ydim):
+    lon = np.linspace(0., 1., xdim, dtype=np.float32)
+    lat = np.linspace(0., 1., ydim, dtype=np.float32)
+    depth = np.zeros(1, dtype=np.float32)
+    time = np.zeros(1, dtype=np.float64)
+    u, v = np.meshgrid(lon, lat)
+
+    grid = Grid.from_data(u, lon, lat, v, lon, lat, depth, time)
+    u_t = np.transpose(u).reshape((lat.size, lon.size))
+    v_t = np.transpose(v).reshape((lat.size, lon.size))
+    assert len(grid.U.data.shape) == 3  # Will be 4 once we use depth
+    assert len(grid.V.data.shape) == 3
+    assert np.allclose(grid.U.data[0, :], u_t, rtol=1e-12)
+    assert np.allclose(grid.V.data[0, :], v_t, rtol=1e-12)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -3,16 +3,40 @@ import numpy as np
 import pytest
 
 
+def generate_grid(xdim, ydim, zdim=1, tdim=1):
+    lon = np.linspace(0., 1., xdim, dtype=np.float32)
+    lat = np.linspace(0., 1., ydim, dtype=np.float32)
+    depth = np.zeros(zdim, dtype=np.float32)
+    time = np.zeros(tdim, dtype=np.float64)
+    U, V = np.meshgrid(lon, lat)
+    return (np.array(U, dtype=np.float32),
+            np.array(V, dtype=np.float32),
+            lon, lat, depth, time)
+
+
 @pytest.mark.parametrize('xdim', [100, 200])
 @pytest.mark.parametrize('ydim', [100, 200])
 def test_grid_from_data(xdim, ydim):
-    lon = np.linspace(0., 1., xdim, dtype=np.float32)
-    lat = np.linspace(0., 1., ydim, dtype=np.float32)
-    depth = np.zeros(1, dtype=np.float32)
-    time = np.zeros(1, dtype=np.float64)
-    u, v = np.meshgrid(lon, lat)
-
+    """ Simple test for grid initialisation from data. """
+    u, v, lon, lat, depth, time = generate_grid(xdim, ydim)
     grid = Grid.from_data(u, lon, lat, v, lon, lat, depth, time)
+    u_t = np.transpose(u).reshape((lat.size, lon.size))
+    v_t = np.transpose(v).reshape((lat.size, lon.size))
+    assert len(grid.U.data.shape) == 3  # Will be 4 once we use depth
+    assert len(grid.V.data.shape) == 3
+    assert np.allclose(grid.U.data[0, :], u_t, rtol=1e-12)
+    assert np.allclose(grid.V.data[0, :], v_t, rtol=1e-12)
+
+
+@pytest.mark.parametrize('xdim', [100, 200])
+@pytest.mark.parametrize('ydim', [100, 200])
+def test_grid_from_nemo(xdim, ydim, tmpdir, filename='test_nemo'):
+    """ Simple test for grid initialisation from NEMO file format. """
+    filepath = tmpdir.join(filename)
+    u, v, lon, lat, depth, time = generate_grid(xdim, ydim)
+    grid_out = Grid.from_data(u, lon, lat, v, lon, lat, depth, time)
+    grid_out.write(filepath)
+    grid = Grid.from_nemo(filepath)
     u_t = np.transpose(u).reshape((lat.size, lon.size))
     v_t = np.transpose(v).reshape((lat.size, lon.size))
     assert len(grid.U.data.shape) == 3  # Will be 4 once we use depth

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -1,6 +1,9 @@
-from parcels import Grid
+from parcels import Grid, Particle, JITParticle
 import numpy as np
 import pytest
+
+
+ptype = {'scipy': Particle, 'jit': JITParticle}
 
 
 @pytest.fixture
@@ -36,3 +39,32 @@ def test_grid_sample_eval(grid, xdim=60, ydim=60):
     u_s = np.array([grid.U.eval(0, -45., y) for y in lat])
     assert np.allclose(v_s, lon, rtol=1e-12)
     assert np.allclose(u_s, lat, rtol=1e-12)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_grid_sample_particle(grid, mode, npart=120):
+    """ Sample the grid using an array of particles.
+
+    Note that the low tolerances (1.e-6) are due to the first-order
+    interpolation in JIT mode and give an indication of the
+    corresponding sampling error.
+    """
+    class SampleParticle(ptype[mode]):
+        user_vars = {'u': np.float32, 'v': np.float32}
+
+    def Sample(particle, grid, time, dt):
+        particle.u = grid.U[0., particle.lon, particle.lat]
+        particle.v = grid.V[0., particle.lon, particle.lat]
+
+    lon = np.linspace(-170, 170, npart, dtype=np.float32)
+    lat = np.linspace(-80, 80, npart, dtype=np.float32)
+
+    pset = grid.ParticleSet(npart, pclass=SampleParticle, lon=lon,
+                            lat=np.zeros(npart, dtype=np.float32) + 70.)
+    pset.execute(pset.Kernel(Sample), endtime=1., dt=1.)
+    assert np.allclose(np.array([p.v for p in pset]), lon, rtol=1e-6)
+
+    pset = grid.ParticleSet(npart, pclass=SampleParticle, lat=lat,
+                            lon=np.zeros(npart, dtype=np.float32) - 45.)
+    pset.execute(pset.Kernel(Sample), endtime=1., dt=1.)
+    assert np.allclose(np.array([p.u for p in pset]), lat, rtol=1e-6)

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -1,0 +1,38 @@
+from parcels import Grid
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def grid(xdim=200, ydim=100):
+    """ Standard grid spanning the earth's coordinates with U and V
+        equivalent to longitude and latitude.
+    """
+    lon = np.linspace(-180, 180, xdim, dtype=np.float32)
+    lat = np.linspace(-90, 90, ydim, dtype=np.float32)
+    depth = np.zeros(1, dtype=np.float32)
+    time = np.zeros(1, dtype=np.float64)
+    U, V = np.meshgrid(lat, lon)
+    return Grid.from_data(np.array(U, dtype=np.float32), lon, lat,
+                          np.array(V, dtype=np.float32), lon, lat,
+                          depth, time)
+
+
+def test_grid_sample(grid, xdim=120, ydim=80):
+    """ Sample the grid using indexing notation. """
+    lon = np.linspace(-170, 170, xdim, dtype=np.float32)
+    lat = np.linspace(-80, 80, ydim, dtype=np.float32)
+    v_s = np.array([grid.V[0, x, 70.] for x in lon])
+    u_s = np.array([grid.U[0, -45., y] for y in lat])
+    assert np.allclose(v_s, lon, rtol=1e-12)
+    assert np.allclose(u_s, lat, rtol=1e-12)
+
+
+def test_grid_sample_eval(grid, xdim=60, ydim=60):
+    """ Sample the grid using the explicit eval function. """
+    lon = np.linspace(-170, 170, xdim, dtype=np.float32)
+    lat = np.linspace(-80, 80, ydim, dtype=np.float32)
+    v_s = np.array([grid.V.eval(0, x, 70.) for x in lon])
+    u_s = np.array([grid.U.eval(0, -45., y) for y in lat])
+    assert np.allclose(v_s, lon, rtol=1e-12)
+    assert np.allclose(u_s, lat, rtol=1e-12)

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -107,7 +107,7 @@ def test_moving_eddies_fwdbwd(mode, npart=2):
 
     # Execte for 14 days, with 30sec timesteps and hourly output
     endtime = delta(days=14)
-    dt = delta(seconds=30)
+    dt = delta(minutes=5)
     print("MovingEddies: Advecting %d particles for %s" % (npart, str(endtime)))
     pset.execute(method, starttime=0, endtime=endtime, dt=dt,
                  output_file=pset.ParticleFile(name="EddyParticlefwd"),

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 import numpy as np
 import math
 import pytest
-from datetime import timedelta as td
+from datetime import timedelta as delta
 
 
 method = {'RK4': AdvectionRK4, 'EE': AdvectionEE}
@@ -82,14 +82,11 @@ def moving_eddies_example(grid, npart=2, mode='jit', verbose=False,
         print("Initial particle positions:\n%s" % pset)
 
     # Execte for 25 days, with 5min timesteps and hourly output
-    endtime = td(days=25).total_seconds()
-    dt = td(minutes=5).total_seconds()
-    output_interval = td(hours=1).total_seconds()
-    print("MovingEddies: Advecting %d particles for %d seconds"
-          % (npart, endtime))
-    pset.execute(method, endtime=endtime, dt=dt,
+    endtime = delta(days=25)
+    print("MovingEddies: Advecting %d particles for %s" % (npart, str(endtime)))
+    pset.execute(method, endtime=endtime, dt=delta(minutes=5),
                  output_file=pset.ParticleFile(name="EddyParticle"),
-                 output_interval=output_interval, show_movie=False)
+                 output_interval=delta(hours=1), show_movie=False)
 
     if verbose:
         print("Final particle positions:\n%s" % pset)
@@ -109,19 +106,17 @@ def test_moving_eddies_fwdbwd(mode, npart=2):
                             start=(3.3, 46.), finish=(3.3, 47.8))
 
     # Execte for 14 days, with 30sec timesteps and hourly output
-    endtime = td(days=14).total_seconds()
-    output_interval = td(hours=1).total_seconds()
-    dt = td(seconds=30).total_seconds()
-    print("MovingEddies: Advecting %d particles for %d seconds"
-          % (npart, endtime))
+    endtime = delta(days=14)
+    dt = delta(seconds=30)
+    print("MovingEddies: Advecting %d particles for %s" % (npart, str(endtime)))
     pset.execute(method, starttime=0, endtime=endtime, dt=dt,
                  output_file=pset.ParticleFile(name="EddyParticlefwd"),
-                 output_interval=output_interval)
+                 output_interval=delta(hours=1))
 
     print("Now running in backward time mode")
     pset.execute(method, starttime=endtime, endtime=0, dt=-dt,
                  output_file=pset.ParticleFile(name="EddyParticlebwd"),
-                 output_interval=output_interval)
+                 output_interval=delta(hours=1))
 
     assert(pset[0].lon > 3.2 and 45.9 < pset[0].lat < 46.1)
     assert(pset[1].lon > 3.2 and 47.7 < pset[1].lat < 47.9)

--- a/tests/test_particle_release.py
+++ b/tests/test_particle_release.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 from parcels.field import Field
 import numpy as np
 from parcels.particle import Particle, JITParticle, AdvectionRK4
+from datetime import timedelta as delta
 
 
 def CreateInitialPositionField(grid):
@@ -50,10 +51,7 @@ if __name__ == "__main__":
     pset = grid.ParticleSet(size=args.particles, pclass=ParticleClass,
                             start_field=grid.Start)
 
-    endtime = 25*24*3600
-    dt = 800
-    output_interval = 12 * dt
-
-    pset.execute(AdvectionRK4, endtime=endtime, dt=dt,
+    dt = delta(seconds=800)
+    pset.execute(AdvectionRK4, endtime=delta(days=25), dt=dt,
                  output_file=pset.ParticleFile(name="ReleaseTestParticle"),
-                 output_interval=output_interval)
+                 output_interval=12 * dt)

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -117,7 +117,7 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
     print("Peninsula: Advecting %d particles for %s" % (npart, str(time)))
     k_adv = pset.Kernel(method)
     k_p = pset.Kernel(UpdateP)
-    pset.execute(k_adv + k_p, endtime=time, dt=delta(seconds=36),
+    pset.execute(k_adv + k_p, endtime=time, dt=delta(minutes=5),
                  output_file=pset.ParticleFile(name="MyParticle") if output else None,
                  output_interval=delta(hours=1) if output else -1)
 
@@ -127,7 +127,7 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
     return pset
 
 
-@pytest.mark.parametrize('mode', ['jit'])
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_peninsula_grid(mode):
     """Execute peninsula test from grid generated in memory"""
     grid = peninsula_grid(100, 50)

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 import numpy as np
 import math  # NOQA
 import pytest
-from datetime import timedelta as td
+from datetime import timedelta as delta
 
 
 method = {'RK4': AdvectionRK4, 'EE': AdvectionEE}
@@ -113,16 +113,13 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
         print("Initial particle positions:\n%s" % pset)
 
     # Advect the particles for 24h
-    time = td(hours=24).total_seconds()
-    dt = td(seconds=36).total_seconds()
-    output_interval = td(hours=1).total_seconds() if output else -1
-    out = pset.ParticleFile(name="MyParticle") if output else None
-    print("Peninsula: Advecting %d particles for %d seconds"
-          % (npart, time))
+    time = delta(hours=24)
+    print("Peninsula: Advecting %d particles for %s" % (npart, str(time)))
     k_adv = pset.Kernel(method)
     k_p = pset.Kernel(UpdateP)
-    pset.execute(k_adv + k_p, endtime=time, dt=dt,
-                 output_file=out, output_interval=output_interval)
+    pset.execute(k_adv + k_p, endtime=time, dt=delta(seconds=36),
+                 output_file=pset.ParticleFile(name="MyParticle") if output else None,
+                 output_interval=delta(hours=1) if output else -1)
 
     if verbose:
         print("Final particle positions:\n%s" % pset)


### PR DESCRIPTION
This merge brings a few small bug fixes, improvements to the test base and automated handling of `datetime.timedelta` objects in the execution loop. In detail:
* Handle and interpret `datetime.timedelta` objects in the execution loop
* Use timedelta objects in example tests
* Add baseline tests for grid creation and field sampling functionalities
* Fix standalone `field` visualisation
* Allow setting `output_interval` without specifying an output file 