### PR TITLE
Automated in-place unit conversion (m to degree)

### DIFF
--- a/include/parcels.h
+++ b/include/parcels.h
@@ -26,15 +26,15 @@ static inline int search_linear_double(double t, int i, int size, double *tvals)
 }
 
 /* Bilinear interpolation routine for 2D grid */
-static inline float spatial_interpolation_bilinear(float x, float y, int i, int j, int ydim,
+static inline float spatial_interpolation_bilinear(float x, float y, int i, int j, int xdim,
                                                    float *lon, float *lat, float **f_data)
 {
   /* Cast data array into data[lat][lon] as per NEMO convention */
-  float (*data)[ydim] = (float (*)[ydim]) f_data;
-  return (data[i][j] * (lon[i+1] - x) * (lat[j+1] - y)
-        + data[i+1][j] * (x - lon[i]) * (lat[j+1] - y)
-        + data[i][j+1] * (lon[i+1] - x) * (y - lat[j])
-        + data[i+1][j+1] * (x - lon[i]) * (y - lat[j]))
+  float (*data)[xdim] = (float (*)[xdim]) f_data;
+  return (data[j][i] * (lon[i+1] - x) * (lat[j+1] - y)
+        + data[j][i+1] * (x - lon[i]) * (lat[j+1] - y)
+        + data[j+1][i] * (lon[i+1] - x) * (y - lat[j])
+        + data[j+1][i+1] * (x - lon[i]) * (y - lat[j]))
         / ((lon[i+1] - lon[i]) * (lat[j+1] - lat[j]));
 }
 
@@ -43,7 +43,7 @@ static inline float temporal_interpolation_linear(float x, float y, int xi, int 
                                                   double time, CField *f)
 {
   /* Cast data array intp data[time][lat][lon] as per NEMO convention */
-  float (*data)[f->xdim][f->ydim] = (float (*)[f->xdim][f->ydim]) f->data;
+  float (*data)[f->ydim][f->xdim] = (float (*)[f->ydim][f->xdim]) f->data;
   float f0, f1;
   double t0, t1;
   int i = xi, j = yi;
@@ -54,10 +54,10 @@ static inline float temporal_interpolation_linear(float x, float y, int xi, int 
   f->tidx = search_linear_double(time, f->tidx, f->tdim, f->time);
   if (f->tidx < f->tdim-1 && time > f->time[f->tidx]) {
     t0 = f->time[f->tidx]; t1 = f->time[f->tidx+1];
-    f0 = spatial_interpolation_bilinear(x, y, i, j, f->ydim, f->lon, f->lat, (float**)(data[f->tidx]));
-    f1 = spatial_interpolation_bilinear(x, y, i, j, f->ydim, f->lon, f->lat, (float**)(data[f->tidx+1]));
+    f0 = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat, (float**)(data[f->tidx]));
+    f1 = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat, (float**)(data[f->tidx+1]));
     return f0 + (f1 - f0) * (float)((time - t0) / (t1 - t0));
   } else {
-    return spatial_interpolation_bilinear(x, y, i, j, f->ydim, f->lon, f->lat, (float**)(data[f->tidx]));
+    return spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat, (float**)(data[f->tidx]));
   }
 }

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -57,10 +57,10 @@ class ParticleAttributeNode(IntrinsicNode):
     def ccode_index_update(self):
         """C-code for the index update requires after updating p.lon/p.lat"""
         if self.attr == 'lon':
-            return "search_linear_float(%s, %s, U->xdim, U->lat)" \
+            return "search_linear_float(%s, %s, U->xdim, U->lon)" \
                 % (self.ccode, self.ccode_index_var)
         if self.attr == 'lat':
-            return "search_linear_float(%s, %s, U->ydim, U->lon)" \
+            return "search_linear_float(%s, %s, U->ydim, U->lat)" \
                 % (self.ccode, self.ccode_index_var)
         return ""
 

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -372,6 +372,14 @@ class KernelGenerator(ast.NodeVisitor):
         """Record intrinsic fields used in kernel"""
         self.field_args[node.obj.name] = node.obj
 
+    def visit_Print(self, node):
+        for n in node.values:
+            self.visit(n)
+        node.ccode = c.Statement('printf(%s)' % ", ".join([n.ccode for n in node.values]))
+
+    def visit_Str(self, node):
+        node.ccode = node.s
+
 
 class LoopGenerator(object):
     """Code generator class that adds type definitions and the outer

--- a/parcels/compiler.py
+++ b/parcels/compiler.py
@@ -1,9 +1,17 @@
 import subprocess
-import os
+from os import path, environ, getuid, makedirs
+from tempfile import gettempdir
 
 
 def get_package_dir():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
+    return path.abspath(path.join(path.dirname(__file__), path.pardir))
+
+
+def get_cache_dir():
+    directory = path.join(gettempdir(), "parcels-%s" % getuid())
+    if not path.exists(directory):
+        makedirs(directory)
+    return directory
 
 
 class Compiler(object):
@@ -18,8 +26,8 @@ class Compiler(object):
     :arg ldargs: A list of arguments to the linker (optional)."""
 
     def __init__(self, cc, ld=None, cppargs=[], ldargs=[]):
-        self._cc = os.environ.get('CC', cc)
-        self._ld = os.environ.get('LDSHARED', ld)
+        self._cc = environ.get('CC', cc)
+        self._ld = environ.get('LDSHARED', ld)
         self._cppargs = cppargs
         self._ldargs = ldargs
 

--- a/parcels/compiler.py
+++ b/parcels/compiler.py
@@ -47,7 +47,6 @@ Compilation command: %s
 Source file: %s
 Log file: %s""" % (" ".join(cc), src, logfile.name)
                 raise RuntimeError(err)
-        print("Compiled: %s" % str(obj))
 
 
 class GNUCompiler(Compiler):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -53,8 +53,14 @@ class UnitConverter(object):
     def to_target(self, value, x, y):
         return value
 
+    def ccode_to_target(self, x, y):
+        return "1.0"
+
     def to_source(self, value, x, y):
         return value
+
+    def ccode_to_source(self, x, y):
+        return "1.0"
 
 
 class Geographic(UnitConverter):
@@ -64,6 +70,9 @@ class Geographic(UnitConverter):
 
     def to_target(self, value, x, y):
         return value / 1000. / 1.852 / 60.
+
+    def ccode_to_target(self, x, y):
+        return "(1.0 / (1000.0 * 1.852 * 60.0))"
 
 
 class GeographicPolar(UnitConverter):
@@ -75,6 +84,9 @@ class GeographicPolar(UnitConverter):
 
     def to_target(self, value, x, y):
         return value / 1000. / 1.852 / 60. / cos(y * pi / 180)
+
+    def ccode_to_target(self, x, y):
+        return "(1.0 / (1000. * 1.852 * 60. * cos(%s * M_PI / 180)))" % y
 
 
 class Field(object):
@@ -238,8 +250,9 @@ class Field(object):
         return self.units.to_target(value, x, y)
 
     def ccode_subscript(self, t, x, y):
-        ccode = "temporal_interpolation_linear(%s, %s, %s, %s, %s, %s)" \
-                % (y, x, "particle->yi", "particle->xi", t, self.name)
+        ccode = "%s * temporal_interpolation_linear(%s, %s, %s, %s, %s, %s)" \
+                % (self.units.ccode_to_target(x, y),
+                   y, x, "particle->yi", "particle->xi", t, self.name)
         return ccode
 
     @property

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -8,9 +8,10 @@ import operator
 import matplotlib.pyplot as plt
 from ctypes import Structure, c_int, c_float, c_double, POINTER
 from netCDF4 import num2date
+from math import cos, pi
 
 
-__all__ = ['CentralDifferences', 'Field']
+__all__ = ['CentralDifferences', 'Field', 'Geographic', 'GeographicPolar']
 
 
 def CentralDifferences(field_data, lat, lon):
@@ -42,6 +43,40 @@ def CentralDifferences(field_data, lat, lon):
     return [dVdx, dVdy]
 
 
+class UnitConverter(object):
+    """ Interface class for spatial unit conversion during field sampling
+        that performs no conversion.
+    """
+    source_unit = None
+    target_unit = None
+
+    def to_target(self, value, x, y):
+        return value
+
+    def to_source(self, value, x, y):
+        return value
+
+
+class Geographic(UnitConverter):
+    """ Unit converter from geometric to geographic coordinates (m to degree) """
+    source_unit = 'm'
+    target_unit = 'degree'
+
+    def to_target(self, value, x, y):
+        return value / 1000. / 1.852 / 60.
+
+
+class GeographicPolar(UnitConverter):
+    """ Unit converter from geometric to geographic coordinates (m to degree)
+        with a correction to account for narrower grid cells closer to the poles.
+    """
+    source_unit = 'm'
+    target_unit = 'degree'
+
+    def to_target(self, value, x, y):
+        return value / 1000. / 1.852 / 60. / cos(y * pi / 180)
+
+
 class Field(object):
     """Class that encapsulates access to field data.
 
@@ -53,7 +88,7 @@ class Field(object):
     """
 
     def __init__(self, name, data, lon, lat, depth=None, time=None,
-                 transpose=False, vmin=None, vmax=None, time_origin=0):
+                 transpose=False, vmin=None, vmax=None, time_origin=0, units=None):
         self.name = name
         self.data = data
         self.lon = lon
@@ -61,6 +96,7 @@ class Field(object):
         self.depth = np.zeros(1, dtype=np.float32) if depth is None else depth
         self.time = np.zeros(1, dtype=np.float64) if time is None else time
         self.time_origin = time_origin
+        self.units = units if units is not None else UnitConverter()
 
         # Ensure that field data is the right data type
         if not self.data.dtype == np.float32:
@@ -196,9 +232,10 @@ class Field(object):
     def eval(self, time, x, y):
         idx = self.time_index(time)
         if idx > 0:
-            return self.interpolator1D(idx, time, y, x)
+            value = self.interpolator1D(idx, time, y, x)
         else:
-            return self.interpolator2D(idx).ev(y, x)
+            value = self.interpolator2D(idx).ev(y, x)
+        return self.units.to_target(value, x, y)
 
     def ccode_subscript(self, t, x, y):
         ccode = "temporal_interpolation_linear(%s, %s, %s, %s, %s, %s)" \

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -252,7 +252,7 @@ class Field(object):
     def ccode_subscript(self, t, x, y):
         ccode = "%s * temporal_interpolation_linear(%s, %s, %s, %s, %s, %s)" \
                 % (self.units.ccode_to_target(x, y),
-                   y, x, "particle->yi", "particle->xi", t, self.name)
+                   x, y, "particle->xi", "particle->yi", t, self.name)
         return ccode
 
     @property
@@ -269,9 +269,9 @@ class Field(object):
                         ('data', POINTER(POINTER(c_float)))]
 
         # Create and populate the c-struct object
-        cstruct = CField(self.lat.size, self.lon.size, self.time.size, 0,
-                         self.lat.ctypes.data_as(POINTER(c_float)),
+        cstruct = CField(self.lon.size, self.lat.size, self.time.size, 0,
                          self.lon.ctypes.data_as(POINTER(c_float)),
+                         self.lat.ctypes.data_as(POINTER(c_float)),
                          self.time.ctypes.data_as(POINTER(c_double)),
                          self.data.ctypes.data_as(POINTER(POINTER(c_float))))
         return cstruct

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -1,6 +1,7 @@
 from netCDF4 import Dataset
 from parcels.field import Field, UnitConverter, Geographic, GeographicPolar
 from parcels.particle import ParticleSet
+import numpy as np
 from py import path
 from glob import glob
 from collections import defaultdict
@@ -31,7 +32,7 @@ class Grid(object):
 
     @classmethod
     def from_data(cls, data_u, lon_u, lat_u, data_v, lon_v, lat_v,
-                  depth, time, field_data={}, transpose=True,
+                  depth=None, time=None, field_data={}, transpose=True,
                   u_units=None, v_units=None, **kwargs):
         """Initialise Grid object from raw data
 
@@ -44,6 +45,8 @@ class Grid(object):
         :param depth: Depth coordinates of the grid
         :param time: Time coordinates of the grid
         """
+        depth = np.zeros(1, dtype=np.float32) if depth is None else depth
+        time = np.zeros(1, dtype=np.float64) if time is None else time
         # Create velocity fields
         ufield = Field('U', data_u, lon_u, lat_u, depth=depth,
                        time=time, transpose=transpose,

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -1,5 +1,6 @@
 from parcels.codegenerator import KernelGenerator, LoopGenerator
-from py import path
+from parcels.compiler import get_cache_dir
+from os import path
 import math  # NOQA get flake8 to ignore unused import.
 import numpy.ctypeslib as npct
 from ctypes import c_int, c_float, c_double, c_void_p, byref
@@ -60,9 +61,10 @@ class Kernel(object):
 
         self.name = "%s%s" % (ptype.name, self.funcname)
 
-        self.src_file = str(path.local("%s.c" % self.name))
-        self.lib_file = str(path.local("%s.so" % self.name))
-        self.log_file = str(path.local("%s.log" % self.name))
+        cachedir = get_cache_dir()
+        self.src_file = str(path.join(cachedir, "%s.c" % self.name))
+        self.lib_file = str(path.join(cachedir, "%s.so" % self.name))
+        self.log_file = str(path.join(cachedir, "%s.log" % self.name))
         self._lib = None
 
         # Generate the kernel function and add the outer loop

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -84,7 +84,7 @@ class Kernel(object):
     def _cache_key(self):
         field_keys = "-".join(["%s:%s" % (name, field.units.__class__.__name__)
                                for name, field in self.field_args.items()])
-        key = self.name + field_keys
+        key = self.name + self.ptype._cache_key + field_keys
         return md5(key.encode('utf-8')).hexdigest()
 
     def compile(self, compiler):

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -152,6 +152,10 @@ class ParticleType(object):
         return "PType<%s>::%s" % (self.name, str(self.var_types))
 
     @property
+    def _cache_key(self):
+        return"-".join(["%s:%s" % v for v in self.var_types.items()])
+
+    @property
     def dtype(self):
         """Numpy.dtype object that defines the C struct"""
         return np.dtype(list(self.var_types.items()))

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -5,7 +5,6 @@ import numpy as np
 import netCDF4
 from collections import OrderedDict, Iterable
 import matplotlib.pyplot as plt
-import math
 from datetime import timedelta as delta
 
 __all__ = ['Particle', 'ParticleSet', 'JITParticle',
@@ -13,27 +12,23 @@ __all__ = ['Particle', 'ParticleSet', 'JITParticle',
 
 
 def AdvectionRK4(particle, grid, time, dt):
-    f_lat = dt / 1000. / 1.852 / 60.
-    f_lon = f_lat / math.cos(particle.lat*math.pi/180)
     u1 = grid.U[time, particle.lon, particle.lat]
     v1 = grid.V[time, particle.lon, particle.lat]
-    lon1, lat1 = (particle.lon + u1*.5*f_lon, particle.lat + v1*.5*f_lat)
+    lon1, lat1 = (particle.lon + u1*.5*dt, particle.lat + v1*.5*dt)
     u2, v2 = (grid.U[time + .5 * dt, lon1, lat1], grid.V[time + .5 * dt, lon1, lat1])
-    lon2, lat2 = (particle.lon + u2*.5*f_lon, particle.lat + v2*.5*f_lat)
+    lon2, lat2 = (particle.lon + u2*.5*dt, particle.lat + v2*.5*dt)
     u3, v3 = (grid.U[time + .5 * dt, lon2, lat2], grid.V[time + .5 * dt, lon2, lat2])
-    lon3, lat3 = (particle.lon + u3*f_lon, particle.lat + v3*f_lat)
+    lon3, lat3 = (particle.lon + u3*dt, particle.lat + v3*dt)
     u4, v4 = (grid.U[time + dt, lon3, lat3], grid.V[time + dt, lon3, lat3])
-    particle.lon += (u1 + 2*u2 + 2*u3 + u4) / 6. * f_lon
-    particle.lat += (v1 + 2*v2 + 2*v3 + v4) / 6. * f_lat
+    particle.lon += (u1 + 2*u2 + 2*u3 + u4) / 6. * dt
+    particle.lat += (v1 + 2*v2 + 2*v3 + v4) / 6. * dt
 
 
 def AdvectionEE(particle, grid, time, dt):
-    f_lat = dt / 1000. / 1.852 / 60.
-    f_lon = f_lat / math.cos(particle.lat*math.pi/180)
     u1 = grid.U[time, particle.lon, particle.lat]
     v1 = grid.V[time, particle.lon, particle.lat]
-    particle.lon += u1 * f_lon
-    particle.lat += v1 * f_lat
+    particle.lon += u1 * dt
+    particle.lat += v1 * dt
 
 
 def positions_from_density_field(pnum, startfield, mode='monte_carlo'):

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -143,7 +143,7 @@ class ParticleType(object):
         self.uses_jit = issubclass(pclass, JITParticle)
         self.var_types = None
         if self.uses_jit:
-            self.var_types = pclass.base_vars
+            self.var_types = pclass.base_vars.copy()
             self.var_types.update(pclass.user_vars)
 
         self.user_vars = pclass.user_vars

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -141,6 +141,7 @@ class ParticleType(object):
 
         self.name = pclass.__name__
         self.uses_jit = issubclass(pclass, JITParticle)
+        self.var_types = None
         if self.uses_jit:
             self.var_types = pclass.base_vars
             self.var_types.update(pclass.user_vars)
@@ -148,7 +149,7 @@ class ParticleType(object):
         self.user_vars = pclass.user_vars
 
     def __repr__(self):
-        return "PType<self.name>"
+        return "PType<%s>::%s" % (self.name, str(self.var_types))
 
     @property
     def dtype(self):

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -305,7 +305,7 @@ class ParticleSet(object):
         timesteps = int((endtime - starttime) / dt)
 
         # Check if output is required and compute outer leaps
-        if output_interval <= 0:
+        if output_interval <= 0 or output_interval > abs(endtime-starttime):
             output_steps = timesteps
         else:
             output_steps = abs(int(output_interval / dt))

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -1,4 +1,4 @@
-from parcels import Grid, Particle, JITParticle, AdvectionRK4, Geographic, GeographicPolar
+from parcels import Grid, Particle, JITParticle, AdvectionRK4
 import numpy as np
 import pytest
 from datetime import timedelta as delta
@@ -24,8 +24,7 @@ def test_advection_zonal(lon, lat, mode, npart=10):
     """
     U = np.ones((lon.size, lat.size), dtype=np.float32)
     V = np.zeros((lon.size, lat.size), dtype=np.float32)
-    grid = Grid.from_data(U, lon, lat, V, lon, lat,
-                          u_units=GeographicPolar(), v_units=Geographic())
+    grid = Grid.from_data(U, lon, lat, V, lon, lat, mesh='spherical')
 
     pset = grid.ParticleSet(npart, pclass=ptype[mode],
                             lon=np.zeros(npart, dtype=np.float32) + 20.,
@@ -41,8 +40,7 @@ def test_advection_meridional(lon, lat, mode, npart=10):
     """
     U = np.zeros((lon.size, lat.size), dtype=np.float32)
     V = np.ones((lon.size, lat.size), dtype=np.float32)
-    grid = Grid.from_data(U, lon, lat, V, lon, lat,
-                          u_units=GeographicPolar(), v_units=Geographic())
+    grid = Grid.from_data(U, lon, lat, V, lon, lat, mesh='spherical')
 
     pset = grid.ParticleSet(npart, pclass=ptype[mode],
                             lon=np.linspace(-60, 60, npart, dtype=np.float32),

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -1,0 +1,52 @@
+from parcels import Grid, Particle, JITParticle, AdvectionRK4, Geographic, GeographicPolar
+import numpy as np
+import pytest
+from datetime import timedelta as delta
+
+
+ptype = {'scipy': Particle, 'jit': JITParticle}
+
+
+@pytest.fixture
+def lon(xdim=200):
+    return np.linspace(-170, 170, xdim, dtype=np.float32)
+
+
+@pytest.fixture
+def lat(ydim=100):
+    return np.linspace(-80, 80, ydim, dtype=np.float32)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_advection_zonal(lon, lat, mode, npart=10):
+    """ Particles at high latitude move geographically faster due to
+        the pole correction in `GeographicPolar`.
+    """
+    U = np.ones((lon.size, lat.size), dtype=np.float32)
+    V = np.zeros((lon.size, lat.size), dtype=np.float32)
+    grid = Grid.from_data(U, lon, lat, V, lon, lat,
+                          u_units=GeographicPolar(), v_units=Geographic())
+
+    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+                            lon=np.zeros(npart, dtype=np.float32) + 20.,
+                            lat=np.linspace(0, 80, npart, dtype=np.float32))
+    pset.execute(AdvectionRK4, endtime=delta(hours=2), dt=delta(seconds=30))
+    assert (np.diff(np.array([p.lon for p in pset])) > 1.e-4).all()
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_advection_meridional(lon, lat, mode, npart=10):
+    """ Particles at high latitude move geographically faster due to
+        the pole correction in `GeographicPolar`.
+    """
+    U = np.zeros((lon.size, lat.size), dtype=np.float32)
+    V = np.ones((lon.size, lat.size), dtype=np.float32)
+    grid = Grid.from_data(U, lon, lat, V, lon, lat,
+                          u_units=GeographicPolar(), v_units=Geographic())
+
+    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+                            lon=np.linspace(-60, 60, npart, dtype=np.float32),
+                            lat=np.linspace(0, 30, npart, dtype=np.float32))
+    delta_lat = np.diff(np.array([p.lat for p in pset]))
+    pset.execute(AdvectionRK4, endtime=delta(hours=2), dt=delta(seconds=30))
+    assert np.allclose(np.diff(np.array([p.lat for p in pset])), delta_lat, rtol=1.e-4)

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -172,10 +172,10 @@ def test_meridionalflow_sperical(mode, xdim=100, ydim=200):
     pset = grid.ParticleSet(2, pclass=pclass(mode), lon=lonstart, lat=latstart)
     pset.execute(pset.Kernel(AdvectionRK4), endtime=endtime, dt=delta(hours=1))
 
-    assert(pset[0].lat - (latstart[0] + endtime.total_seconds() * maxvel / 1852 / 60) < 1e-7)
-    assert(pset[0].lon - lonstart[0] < 1e-7)
-    assert(pset[1].lat - (latstart[1] + endtime.total_seconds() * maxvel / 1852 / 60) < 1e-7)
-    assert(pset[1].lon - lonstart[1] < 1e-7)
+    assert(pset[0].lat - (latstart[0] + endtime.total_seconds() * maxvel / 1852 / 60) < 1e-4)
+    assert(pset[0].lon - lonstart[0] < 1e-4)
+    assert(pset[1].lat - (latstart[1] + endtime.total_seconds() * maxvel / 1852 / 60) < 1e-4)
+    assert(pset[1].lon - lonstart[1] < 1e-4)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
@@ -202,9 +202,9 @@ def test_zonalflow_sperical(mode, xdim=100, ydim=200):
     pset = grid.ParticleSet(2, pclass=pclass(mode), lon=lonstart, lat=latstart)
     pset.execute(pset.Kernel(AdvectionRK4), endtime=endtime, dt=delta(hours=1))
 
-    assert(pset[0].lat - latstart[0] < 1e-7)
+    assert(pset[0].lat - latstart[0] < 1e-4)
     assert(pset[0].lon - (lonstart[0] + endtime.total_seconds() * maxvel / 1852 / 60
-                          / cos(latstart[0] * pi / 180)) < 1e-7)
-    assert(pset[1].lat - latstart[1] < 1e-7)
+                          / cos(latstart[0] * pi / 180)) < 1e-4)
+    assert(pset[1].lat - latstart[1] < 1e-4)
     assert(pset[1].lon - (lonstart[1] + endtime.total_seconds() * maxvel / 1852 / 60
-                          / cos(latstart[1] * pi / 180)) < 1e-7)
+                          / cos(latstart[1] * pi / 180)) < 1e-4)

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -163,8 +163,7 @@ def test_meridionalflow_sperical(mode, xdim=100, ydim=200):
     V = maxvel * np.ones([xdim, ydim])
 
     grid = Grid.from_data(np.array(U, dtype=np.float32), lon, lat,
-                          np.array(V, dtype=np.float32), lon, lat,
-                          mesh='spherical')
+                          np.array(V, dtype=np.float32), lon, lat)
 
     lonstart = [0, 45]
     latstart = [0, 45]
@@ -193,8 +192,7 @@ def test_zonalflow_sperical(mode, xdim=100, ydim=200):
     U = maxvel * np.ones([xdim, ydim])
 
     grid = Grid.from_data(np.array(U, dtype=np.float32), lon, lat,
-                          np.array(V, dtype=np.float32), lon, lat,
-                          mesh='spherical')
+                          np.array(V, dtype=np.float32), lon, lat)
 
     lonstart = [0, 45]
     latstart = [0, 45]

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -1,4 +1,4 @@
-from parcels import Grid, Particle, JITParticle, Geographic, GeographicPolar
+from parcels import Grid, Particle, JITParticle, Geographic
 import numpy as np
 import pytest
 from math import cos, pi
@@ -16,7 +16,8 @@ def grid(xdim=200, ydim=100):
     lat = np.linspace(-90, 90, ydim, dtype=np.float32)
     U, V = np.meshgrid(lat, lon)
     return Grid.from_data(np.array(U, dtype=np.float32), lon, lat,
-                          np.array(V, dtype=np.float32), lon, lat)
+                          np.array(V, dtype=np.float32), lon, lat,
+                          mesh='flat')
 
 
 @pytest.fixture
@@ -48,9 +49,8 @@ def grid_geometric_polar(xdim=200, ydim=100):
     U *= 1000. * 1.852 * 60.
     V *= 1000. * 1.852 * 60.
     grid = Grid.from_data(np.array(U, dtype=np.float32), lon, lat,
-                          np.array(V, dtype=np.float32), lon, lat)
-    grid.U.units = GeographicPolar()
-    grid.V.units = Geographic()
+                          np.array(V, dtype=np.float32), lon, lat,
+                          mesh='spherical')
     return grid
 
 

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -1,6 +1,7 @@
-from parcels import Grid, Particle, JITParticle
+from parcels import Grid, Particle, JITParticle, Geographic, GeographicPolar
 import numpy as np
 import pytest
+from math import cos, pi
 
 
 ptype = {'scipy': Particle, 'jit': JITParticle}
@@ -9,16 +10,62 @@ ptype = {'scipy': Particle, 'jit': JITParticle}
 @pytest.fixture
 def grid(xdim=200, ydim=100):
     """ Standard grid spanning the earth's coordinates with U and V
-        equivalent to longitude and latitude.
+        equivalent to longitude and latitude in deg.
     """
     lon = np.linspace(-180, 180, xdim, dtype=np.float32)
     lat = np.linspace(-90, 90, ydim, dtype=np.float32)
-    depth = np.zeros(1, dtype=np.float32)
-    time = np.zeros(1, dtype=np.float64)
     U, V = np.meshgrid(lat, lon)
     return Grid.from_data(np.array(U, dtype=np.float32), lon, lat,
-                          np.array(V, dtype=np.float32), lon, lat,
-                          depth, time)
+                          np.array(V, dtype=np.float32), lon, lat)
+
+
+@pytest.fixture
+def grid_geometric(xdim=200, ydim=100):
+    """ Standard earth grid with U and V equivalent to lon/lat in m. """
+    lon = np.linspace(-180, 180, xdim, dtype=np.float32)
+    lat = np.linspace(-90, 90, ydim, dtype=np.float32)
+    U, V = np.meshgrid(lat, lon)
+    U *= 1000. * 1.852 * 60.
+    V *= 1000. * 1.852 * 60.
+    grid = Grid.from_data(np.array(U, dtype=np.float32), lon, lat,
+                          np.array(V, dtype=np.float32), lon, lat)
+    grid.U.units = Geographic()
+    grid.V.units = Geographic()
+    return grid
+
+
+@pytest.fixture
+def grid_geometric_polar(xdim=200, ydim=100):
+    """ Standard earth grid with U and V equivalent to lon/lat in m
+        and the inversion of the pole correction applied to U.
+    """
+    lon = np.linspace(-180, 180, xdim, dtype=np.float32)
+    lat = np.linspace(-90, 90, ydim, dtype=np.float32)
+    U, V = np.meshgrid(lat, lon)
+    # Apply inverse of pole correction to U
+    for i, y in enumerate(lat):
+        U[:, i] *= cos(y * pi / 180)
+    U *= 1000. * 1.852 * 60.
+    V *= 1000. * 1.852 * 60.
+    grid = Grid.from_data(np.array(U, dtype=np.float32), lon, lat,
+                          np.array(V, dtype=np.float32), lon, lat)
+    grid.U.units = GeographicPolar()
+    grid.V.units = Geographic()
+    return grid
+
+
+def pclass(mode):
+    class SampleParticle(ptype[mode]):
+        user_vars = {'u': np.float32, 'v': np.float32}
+    return SampleParticle
+
+
+@pytest.fixture
+def samplefunc():
+    def Sample(particle, grid, time, dt):
+        particle.u = grid.U[0., particle.lon, particle.lat]
+        particle.v = grid.V[0., particle.lon, particle.lat]
+    return Sample
 
 
 def test_grid_sample(grid, xdim=120, ydim=80):
@@ -42,29 +89,60 @@ def test_grid_sample_eval(grid, xdim=60, ydim=60):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
-def test_grid_sample_particle(grid, mode, npart=120):
+def test_grid_sample_particle(grid, mode, samplefunc, npart=120):
     """ Sample the grid using an array of particles.
 
     Note that the low tolerances (1.e-6) are due to the first-order
     interpolation in JIT mode and give an indication of the
     corresponding sampling error.
     """
-    class SampleParticle(ptype[mode]):
-        user_vars = {'u': np.float32, 'v': np.float32}
-
-    def Sample(particle, grid, time, dt):
-        particle.u = grid.U[0., particle.lon, particle.lat]
-        particle.v = grid.V[0., particle.lon, particle.lat]
-
     lon = np.linspace(-170, 170, npart, dtype=np.float32)
     lat = np.linspace(-80, 80, npart, dtype=np.float32)
 
-    pset = grid.ParticleSet(npart, pclass=SampleParticle, lon=lon,
+    pset = grid.ParticleSet(npart, pclass=pclass(mode), lon=lon,
                             lat=np.zeros(npart, dtype=np.float32) + 70.)
-    pset.execute(pset.Kernel(Sample), endtime=1., dt=1.)
+    pset.execute(pset.Kernel(samplefunc), endtime=1., dt=1.)
     assert np.allclose(np.array([p.v for p in pset]), lon, rtol=1e-6)
 
-    pset = grid.ParticleSet(npart, pclass=SampleParticle, lat=lat,
+    pset = grid.ParticleSet(npart, pclass=pclass(mode), lat=lat,
                             lon=np.zeros(npart, dtype=np.float32) - 45.)
-    pset.execute(pset.Kernel(Sample), endtime=1., dt=1.)
+    pset.execute(pset.Kernel(samplefunc), endtime=1., dt=1.)
     assert np.allclose(np.array([p.u for p in pset]), lat, rtol=1e-6)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_grid_sample_geographic(grid_geometric, mode, samplefunc, npart=120):
+    """ Sample a grid with conversion to geographic units (degrees). """
+    grid = grid_geometric
+    lon = np.linspace(-170, 170, npart, dtype=np.float32)
+    lat = np.linspace(-80, 80, npart, dtype=np.float32)
+
+    pset = grid.ParticleSet(npart, pclass=pclass(mode), lon=lon,
+                            lat=np.zeros(npart, dtype=np.float32) + 70.)
+    pset.execute(pset.Kernel(samplefunc), endtime=1., dt=1.)
+    assert np.allclose(np.array([p.v for p in pset]), lon, rtol=1e-6)
+
+    pset = grid.ParticleSet(npart, pclass=pclass(mode), lat=lat,
+                            lon=np.zeros(npart, dtype=np.float32) - 45.)
+    pset.execute(pset.Kernel(samplefunc), endtime=1., dt=1.)
+    assert np.allclose(np.array([p.u for p in pset]), lat, rtol=1e-6)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_grid_sample_geographic_polar(grid_geometric_polar, mode, samplefunc, npart=120):
+    """ Sample a grid with conversion to geographic units and a pole correction. """
+    grid = grid_geometric_polar
+    lon = np.linspace(-170, 170, npart, dtype=np.float32)
+    lat = np.linspace(-80, 80, npart, dtype=np.float32)
+
+    pset = grid.ParticleSet(npart, pclass=pclass(mode), lon=lon,
+                            lat=np.zeros(npart, dtype=np.float32) + 70.)
+    pset.execute(pset.Kernel(samplefunc), endtime=1., dt=1.)
+    assert np.allclose(np.array([p.v for p in pset]), lon, rtol=1e-6)
+
+    pset = grid.ParticleSet(npart, pclass=pclass(mode), lat=lat,
+                            lon=np.zeros(npart, dtype=np.float32) - 45.)
+    pset.execute(pset.Kernel(samplefunc), endtime=1., dt=1.)
+    # Note: 1.e-2 is a very low rtol, so there seems to be a rather
+    # large sampling error for the JIT correction.
+    assert np.allclose(np.array([p.u for p in pset]), lat, rtol=1e-2)

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -1,4 +1,4 @@
-from parcels import Grid, Particle, JITParticle, AdvectionRK4, AdvectionEE
+from parcels import Grid, Particle, JITParticle, AdvectionRK4, AdvectionEE, Geographic, GeographicPolar
 from argparse import ArgumentParser
 import numpy as np
 import math
@@ -61,8 +61,8 @@ def moving_eddies_grid(xdim=200, ydim=350):
         U[:, :-1, t] = np.diff(P[:, :, t], axis=1) / dy / corio_0 * g
         U[:, -1, t] = U[:, -2, t]  # Fill in the last row
 
-    return Grid.from_data(U, lon, lat, V, lon, lat,
-                          depth, time, field_data={'P': P})
+    return Grid.from_data(U, lon, lat, V, lon, lat, depth, time, field_data={'P': P},
+                          u_units=GeographicPolar(), v_units=Geographic())
 
 
 def moving_eddies_example(grid, npart=2, mode='jit', verbose=False,

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -1,4 +1,4 @@
-from parcels import Grid, Particle, JITParticle, AdvectionRK4, AdvectionEE, Geographic, GeographicPolar
+from parcels import Grid, Particle, JITParticle, AdvectionRK4, AdvectionEE
 from argparse import ArgumentParser
 import numpy as np
 import math
@@ -61,8 +61,7 @@ def moving_eddies_grid(xdim=200, ydim=350):
         U[:, :-1, t] = np.diff(P[:, :, t], axis=1) / dy / corio_0 * g
         U[:, -1, t] = U[:, -2, t]  # Fill in the last row
 
-    return Grid.from_data(U, lon, lat, V, lon, lat, depth, time, field_data={'P': P},
-                          u_units=GeographicPolar(), v_units=Geographic())
+    return Grid.from_data(U, lon, lat, V, lon, lat, depth, time, field_data={'P': P})
 
 
 def moving_eddies_example(grid, npart=2, mode='jit', verbose=False,

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -1,4 +1,4 @@
-from parcels import Grid, Particle, JITParticle, AdvectionRK4, AdvectionEE
+from parcels import Grid, Particle, JITParticle, AdvectionRK4, AdvectionEE, Geographic, GeographicPolar
 from argparse import ArgumentParser
 import numpy as np
 import math  # NOQA
@@ -65,8 +65,8 @@ def peninsula_grid(xdim, ydim):
     lon = La / 1.852 / 60.
     lat = Wa / 1.852 / 60.
 
-    return Grid.from_data(U, lon, lat, V, lon, lat,
-                          depth, time, field_data={'P': P})
+    return Grid.from_data(U, lon, lat, V, lon, lat, depth, time, field_data={'P': P},
+                          u_units=GeographicPolar(), v_units=Geographic())
 
 
 def UpdateP(particle, grid, time, dt):

--- a/tests/test_peninsula.py
+++ b/tests/test_peninsula.py
@@ -1,4 +1,4 @@
-from parcels import Grid, Particle, JITParticle, AdvectionRK4, AdvectionEE, Geographic, GeographicPolar
+from parcels import Grid, Particle, JITParticle, AdvectionRK4, AdvectionEE
 from argparse import ArgumentParser
 import numpy as np
 import math  # NOQA
@@ -65,8 +65,7 @@ def peninsula_grid(xdim, ydim):
     lon = La / 1.852 / 60.
     lat = Wa / 1.852 / 60.
 
-    return Grid.from_data(U, lon, lat, V, lon, lat, depth, time, field_data={'P': P},
-                          u_units=GeographicPolar(), v_units=Geographic())
+    return Grid.from_data(U, lon, lat, V, lon, lat, depth, time, field_data={'P': P})
 
 
 def UpdateP(particle, grid, time, dt):


### PR DESCRIPTION
This merge adds automatic unit conversion via `UnitConverter` objects and implements converters for meter-to-degree conversion (`Geographic`) and geographic with pole correction (`GeographicPolar`). The new API allows the units of a `Field` to be set as `field.units = Geographic()` or via the constructor. NEMO grids (`Grid.from_nemo()`) default to `U->GeographicPolar` and `V->Geographic` units, while all other grid constructors assume meters.

Note, we also introduce hashed cache keys to the JIT pipeline, so that we can add the converter types to the cache key for the generated files. This fixes errors due to several different kernels trying read/write/execute from the same set of files.