### PR TITLE
64bit lon/lat and better time support

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -114,6 +114,12 @@ class Field(object):
         if not self.data.dtype == np.float32:
             print("WARNING: Casting field data to np.float32")
             self.data = self.data.astype(np.float32)
+        if not self.lon.dtype == np.float32:
+            print("WARNING: Casting lon data to np.float32")
+            self.lon = self.lon.astype(np.float32)
+        if not self.lat.dtype == np.float32:
+            print("WARNING: Casting lat data to np.float32")
+            self.lat = self.lat.astype(np.float32)            
         if transpose:
             # Make a copy of the transposed array to enforce
             # C-contiguous memory layout for JIT mode.

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -367,7 +367,7 @@ class FileBuffer(object):
             dt = num2date(self.dataset[self.dimensions['time']][:],
                           self.time_units, self.calendar)
             dt -= num2date(0, self.time_units, self.calendar)
-            return map(timedelta.total_seconds, dt)
+            return list(map(timedelta.total_seconds, dt))
         else:
             return self.dataset[self.dimensions['time']][:]
 

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -353,15 +353,17 @@ class ParticleSet(object):
             axes.set_xlim([self.grid.U.lon[0], self.grid.U.lon[-1]])
             axes.set_ylim([self.grid.U.lat[0], self.grid.U.lat[-1]])
             namestr = ''
+            time_origin = self.grid.U.time_origin
         else:
             if not isinstance(field, Field):
                 field = getattr(self.grid, field)
             field.show(animation=True, **kwargs)
             namestr = ' on ' + field.name
-        if field.time_origin == 0:
+            time_origin = field.time_origin
+        if time_origin is 0:
             timestr = ' after ' + str(delta(seconds=t)) + ' hours'
         else:
-            timestr = ' on ' + str(field.time_origin + delta(seconds=t))
+            timestr = ' on ' + str(time_origin + delta(seconds=t))
         plt.xlabel('Longitude')
         plt.ylabel('Latitude')
         plt.title('Particles' + namestr + timestr)

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -6,6 +6,7 @@ import netCDF4
 from collections import OrderedDict, Iterable
 import matplotlib.pyplot as plt
 from datetime import timedelta as delta
+from datetime import datetime
 import sys
 
 __all__ = ['Particle', 'ParticleSet', 'JITParticle',
@@ -288,6 +289,10 @@ class ParticleSet(object):
             dt = dt.total_seconds()
         if isinstance(output_interval, delta):
             output_interval = output_interval.total_seconds()
+        if isinstance(starttime, datetime):
+            starttime = (starttime - self.time_origin).total_seconds()
+        if isinstance(endtime, datetime):
+            endtime = (endtime - self.time_origin).total_seconds()
 
         # Check if starttime, endtime, runtime and dt are consistent and compute timesteps
         if runtime is not None and endtime is not None:

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -7,7 +7,6 @@ from collections import OrderedDict, Iterable
 import matplotlib.pyplot as plt
 from datetime import timedelta as delta
 from datetime import datetime
-import sys
 
 __all__ = ['Particle', 'ParticleSet', 'JITParticle',
            'ParticleFile', 'AdvectionRK4', 'AdvectionEE']
@@ -296,7 +295,7 @@ class ParticleSet(object):
 
         # Check if starttime, endtime, runtime and dt are consistent and compute timesteps
         if runtime is not None and endtime is not None:
-            sys.exit("ERROR: Only one of (endtime, runtime) can be specified")
+            raise RuntimeError('Only one of (endtime, runtime) can be specified')
         if starttime is None:
             if dt > 0:
                 starttime = self.grid.time[0]


### PR DESCRIPTION
This PR:
- fixes bug #70 by casting lon/lat to 32 bits
- adds a new .execute keyword `runtime` that sets `endtime = starttime + runtime`
- fixes some small bugs in calendar support

While Travis is green for python2.7, there is something wrong with python3. However, I don't have that installed, so can't easily test what goes wrong. @mlange05, any idea?