### PR TITLE
Regular grid sampling

### DIFF
--- a/parcels/__init__.py
+++ b/parcels/__init__.py
@@ -1,5 +1,5 @@
-from parcels.grid import *
-from parcels.particle import *
-from parcels.field import *
-from parcels.kernel import *
+from parcels.grid import *  # NOQA get flake8 to ignore unused import.
+from parcels.particle import *  # NOQA
+from parcels.field import *  # NOQA
+from parcels.kernel import *  # NOQA
 import parcels.rng as random  # NOQA

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -96,10 +96,10 @@ def positions_from_density_field(pnum, field, mode='monte_carlo'):
     lonwidth = (field.lon[1] - field.lon[0]) / 2
     latwidth = (field.lat[1] - field.lat[0]) / 2
 
-    def add_jitter(value, width, min, max):
-        value += np.random.uniform(-lonwidth, lonwidth)
+    def add_jitter(pos, width, min, max):
+        value = pos + np.random.uniform(-width, width)
         while not (min <= value <= max):
-            value += np.random.uniform(-width, width)
+            value = pos + np.random.uniform(-width, width)
         return value
 
     if mode == 'monte_carlo':

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -228,3 +228,30 @@ def test_zonalflow_sperical(mode, xdim=100, ydim=200):
     assert(pset[1].lon - (lonstart[1] + endtime.total_seconds() * maxvel / 1852 / 60
                           / cos(latstart[1] * pi / 180)) < 1e-4)
     assert(abs(pset[1].p - p_fld) < 1e-4)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_random_field(mode, xdim=20, ydim=20, npart=100):
+    """Sampling test that test for overshoots by sampling a field of
+    random numbers between 0 and 1.
+    """
+    np.random.seed(123456)
+    lon = np.linspace(0., 1., xdim, dtype=np.float32)
+    lat = np.linspace(0., 1., ydim, dtype=np.float32)
+    U = np.zeros((xdim, ydim), dtype=np.float32)
+    V = np.zeros((xdim, ydim), dtype=np.float32)
+    K = np.random.uniform(0, 1., size=(xdim, ydim))
+    S = np.ones((xdim, ydim), dtype=np.float32)
+    grid = Grid.from_data(U, lon, lat, V, lon, lat, mesh='flat',
+                          field_data={'K': K, 'start': S})
+
+    class SampleParticle(ptype[mode]):
+        user_vars = {'k': np.float32}
+    pset = grid.ParticleSet(size=npart, pclass=SampleParticle,
+                            start_field=grid.start)
+
+    def SampleK(particle, grid, time, dt):
+        particle.k = grid.K[time, particle.lon, particle.lat]
+    pset.execute(SampleK, endtime=1., dt=1.0)
+    sampled = np.array([p.k for p in pset])
+    assert((sampled >= 0.).all())

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -75,8 +75,8 @@ def test_grid_sample(grid, xdim=120, ydim=80):
     lat = np.linspace(-80, 80, ydim, dtype=np.float32)
     v_s = np.array([grid.V[0, x, 70.] for x in lon])
     u_s = np.array([grid.U[0, -45., y] for y in lat])
-    assert np.allclose(v_s, lon, rtol=1e-12)
-    assert np.allclose(u_s, lat, rtol=1e-12)
+    assert np.allclose(v_s, lon, rtol=1e-7)
+    assert np.allclose(u_s, lat, rtol=1e-7)
 
 
 def test_grid_sample_eval(grid, xdim=60, ydim=60):
@@ -85,8 +85,8 @@ def test_grid_sample_eval(grid, xdim=60, ydim=60):
     lat = np.linspace(-80, 80, ydim, dtype=np.float32)
     v_s = np.array([grid.V.eval(0, x, 70.) for x in lon])
     u_s = np.array([grid.U.eval(0, -45., y) for y in lat])
-    assert np.allclose(v_s, lon, rtol=1e-12)
-    assert np.allclose(u_s, lat, rtol=1e-12)
+    assert np.allclose(v_s, lon, rtol=1e-7)
+    assert np.allclose(u_s, lat, rtol=1e-7)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/tests/test_moving_eddies.py
+++ b/tests/test_moving_eddies.py
@@ -80,8 +80,8 @@ def moving_eddies_example(grid, npart=2, mode='jit', verbose=False,
     if verbose:
         print("Initial particle positions:\n%s" % pset)
 
-    # Execte for 25 days, with 5min timesteps and hourly output
-    endtime = delta(days=25)
+    # Execte for 21 days, with 5min timesteps and hourly output
+    endtime = delta(days=21)
     print("MovingEddies: Advecting %d particles for %s" % (npart, str(endtime)))
     pset.execute(method, endtime=endtime, dt=delta(minutes=5),
                  output_file=pset.ParticleFile(name="EddyParticle"),

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -1,4 +1,4 @@
-from parcels import Grid, Particle, JITParticle
+from parcels import Grid, Field, Particle, JITParticle
 import numpy as np
 import pytest
 
@@ -33,6 +33,19 @@ def test_pset_create_line(grid, mode, npart=100):
     pset = grid.ParticleSet(npart, start=(0, 1), finish=(1, 0), pclass=ptype[mode])
     assert np.allclose([p.lon for p in pset], lon, rtol=1e-12)
     assert np.allclose([p.lat for p in pset], lat, rtol=1e-12)
+
+
+@pytest.mark.parametrize('mode', ['scipy'])
+def test_pset_create_field(grid, mode, npart=100):
+    np.random.seed(123456)
+    shape = (grid.U.lon.size, grid.U.lat.size)
+    K = Field('K', lon=grid.U.lon, lat=grid.U.lat,
+              data=np.ones(shape, dtype=np.float32))
+    pset = grid.ParticleSet(npart, pclass=ptype[mode], start_field=K)
+    assert (np.array([p.lon for p in pset]) <= 1.).all()
+    assert (np.array([p.lon for p in pset]) >= 0.).all()
+    assert (np.array([p.lat for p in pset]) <= 1.).all()
+    assert (np.array([p.lat for p in pset]) >= 0.).all()
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])


### PR DESCRIPTION
This merge changes the SciPy interpolator in our Python/SciPy implementation from `RectBivariateSpline` to `RegularGridInterpolator`. This fixes sampling overshoots that can arise from a random-value field with sharp gradients, as reported by @Jacketless in issue #74. Note that the new interpolator is closer to what we do in JIT, but it has two distinct side effects:
* Lower accuracy of the `field.eval()` function, which requires lowering tolerances in sampling tests
* Particles moving out of the domain bounds now cause interpolator errors. In Python mode this was previously handled by extrapolation through the spline interpolator and we are still extrapolating in JIT mode.

Please note also that another bug in the stochastic particle set initialiser was found during this bug fix, which was fixed through a small re-write of the initialiser function. An appropriate test has of course also been added. @Jacketless, please review this carefully.