### PR TITLE
JITParticle float32/float64 declaration bug

### DIFF
--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -163,7 +163,7 @@ class JITParticle(Particle):
     """
 
     base_vars = OrderedDict([('lon', np.float32), ('lat', np.float32),
-                             ('time', np.float32), ('dt', np.float32),
+                             ('time', np.float64), ('dt', np.float32),
                              ('xi', np.int32), ('yi', np.int32),
                              ('active', np.int32)])
     user_vars = OrderedDict()


### PR DESCRIPTION
There was a bug in JIT mode where the `time` in the JITParticle was declared as a `float32`, even though time of the `Field` class is `float64`, causing issues in the globcurrent test. 
When I fixed this by changing `time` in JITParticle to `float64` (see 8f2662f), other errors popped up where `py.test` hangs on `test_kernel_language`.

Inspection of the compiled code showed that the compilation adds a line `unsigned char _cgen_pad[4];` to the end of the `typedef struct` of the particles. 

For `test_kernel_language` that can be fixed by also making `dt` a `float64`, but then the same issue appears with `test_advection`. This probably needs someone with deeper understanding of the JIT compilation to have a look at, @mlange05 ?