### PR TITLE
Cleaning, testing and fixing time interpolation

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -124,6 +124,9 @@ class Field(object):
         if not self.lat.dtype == np.float32:
             print("WARNING: Casting lat data to np.float32")
             self.lat = self.lat.astype(np.float32)
+        if not self.time.dtype == np.float64:
+            print("WARNING: Casting time data to np.float64")
+            self.time = self.time.astype(np.float64)
         if transpose:
             # Make a copy of the transposed array to enforce
             # C-contiguous memory layout for JIT mode.


### PR DESCRIPTION
This merge cleans up the current SciPy interpolation cascade and adds tests and bug fixes for the time interpolation in JIT:
* We now only do temporal interpoaltion by hand, and defer all spatial interpolation to a wrapper routine that invokes the SciPy wrappers, allowing us to intercept NaN values or errors.
* The SciPy interpolators now return NaN and we detect this to insert 0 as before. We can hook into this to build a generic "recovery kernel" dispatch system later.
* A new test explicitly tests temporal interpolation inside, on the edges and outside the given time interval.
* Check and force `field.time` to always be `np.float64`.
* Re-writes the JIT time loop to fix subsequent temporal sampling bugs in JIT mode. This now hardcodes a "tolerance" value of `1.e-6` for the time loop condition.