### PR TITLE
Delay particle start example kernel & script

### DIFF
--- a/examples/example_delay_start.py
+++ b/examples/example_delay_start.py
@@ -1,0 +1,41 @@
+from parcels import Grid, JITParticle, ScipyParticle, Variable
+from parcels import AdvectionRK4
+import numpy as np
+from datetime import timedelta as delta
+
+
+ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
+
+
+def DelayStart(particle, grid, time, dt):
+    """An example kernel showing how particle starts can be delayed, using a starttime variable
+    """
+    if time > particle.starttime:
+        particle.active = 1
+
+
+def pensinsula_example(mode, npart=10):
+
+    grid = Grid.from_nemo('examples/Peninsula_data/peninsula', extra_vars={'P': 'P'})
+
+    class DelayStartParticle(ptype[mode]):
+        starttime = Variable('starttime', dtype=np.float32, default=0.)
+
+    # Initialise particles
+    x = 3. * (1. / 1.852 / 60)  # 3 km offset from boundary
+    y = (grid.U.lat[0] + x, grid.U.lat[-1] - x)  # latitude range, including offsets
+
+    pset = grid.ParticleSet(npart, pclass=DelayStartParticle, start=(x, y[0]), finish=(x, y[1]))
+    p = 0
+    for particle in pset:
+        particle.active = -1  # Using -1 value to signal that particle has not yet started
+        particle.starttime = 3600 * p  # set starttime for each particle
+        p += 1
+
+    pset.execute(AdvectionRK4 + pset.Kernel(DelayStart),
+                 runtime=delta(hours=24), dt=delta(minutes=5),
+                 interval=delta(hours=1), show_movie=True)
+
+
+if __name__ == "__main__":
+    pensinsula_example('jit')

--- a/parcels/kernels/advection.py
+++ b/parcels/kernels/advection.py
@@ -7,71 +7,74 @@ __all__ = ['AdvectionRK4', 'AdvectionEE', 'AdvectionRK45']
 
 
 def AdvectionRK4(particle, grid, time, dt):
-    u1 = grid.U[time, particle.lon, particle.lat]
-    v1 = grid.V[time, particle.lon, particle.lat]
-    lon1, lat1 = (particle.lon + u1*.5*dt, particle.lat + v1*.5*dt)
-    u2, v2 = (grid.U[time + .5 * dt, lon1, lat1], grid.V[time + .5 * dt, lon1, lat1])
-    lon2, lat2 = (particle.lon + u2*.5*dt, particle.lat + v2*.5*dt)
-    u3, v3 = (grid.U[time + .5 * dt, lon2, lat2], grid.V[time + .5 * dt, lon2, lat2])
-    lon3, lat3 = (particle.lon + u3*dt, particle.lat + v3*dt)
-    u4, v4 = (grid.U[time + dt, lon3, lat3], grid.V[time + dt, lon3, lat3])
-    particle.lon += (u1 + 2*u2 + 2*u3 + u4) / 6. * dt
-    particle.lat += (v1 + 2*v2 + 2*v3 + v4) / 6. * dt
+    if particle.active == 1:
+        u1 = grid.U[time, particle.lon, particle.lat]
+        v1 = grid.V[time, particle.lon, particle.lat]
+        lon1, lat1 = (particle.lon + u1*.5*dt, particle.lat + v1*.5*dt)
+        u2, v2 = (grid.U[time + .5 * dt, lon1, lat1], grid.V[time + .5 * dt, lon1, lat1])
+        lon2, lat2 = (particle.lon + u2*.5*dt, particle.lat + v2*.5*dt)
+        u3, v3 = (grid.U[time + .5 * dt, lon2, lat2], grid.V[time + .5 * dt, lon2, lat2])
+        lon3, lat3 = (particle.lon + u3*dt, particle.lat + v3*dt)
+        u4, v4 = (grid.U[time + dt, lon3, lat3], grid.V[time + dt, lon3, lat3])
+        particle.lon += (u1 + 2*u2 + 2*u3 + u4) / 6. * dt
+        particle.lat += (v1 + 2*v2 + 2*v3 + v4) / 6. * dt
 
 
 def AdvectionEE(particle, grid, time, dt):
-    u1 = grid.U[time, particle.lon, particle.lat]
-    v1 = grid.V[time, particle.lon, particle.lat]
-    particle.lon += u1 * dt
-    particle.lat += v1 * dt
+    if particle.active == 1:
+        u1 = grid.U[time, particle.lon, particle.lat]
+        v1 = grid.V[time, particle.lon, particle.lat]
+        particle.lon += u1 * dt
+        particle.lat += v1 * dt
 
 
 def AdvectionRK45(particle, grid, time, dt):
-    tol = [1e-9]
-    c = [1./4., 3./8., 12./13., 1., 1./2.]
-    A = [[1./4., 0., 0., 0., 0.],
-         [3./32., 9./32., 0., 0., 0.],
-         [1932./2197., -7200./2197., 7296./2197., 0., 0.],
-         [439./216., -8., 3680./513., -845./4104., 0.],
-         [-8./27., 2., -3544./2565., 1859./4104., -11./40.]]
-    b4 = [25./216., 0., 1408./2565., 2197./4104., -1./5.]
-    b5 = [16./135., 0., 6656./12825., 28561./56430., -9./50., 2./55.]
+    if particle.active == 1:
+        tol = [1e-9]
+        c = [1./4., 3./8., 12./13., 1., 1./2.]
+        A = [[1./4., 0., 0., 0., 0.],
+             [3./32., 9./32., 0., 0., 0.],
+             [1932./2197., -7200./2197., 7296./2197., 0., 0.],
+             [439./216., -8., 3680./513., -845./4104., 0.],
+             [-8./27., 2., -3544./2565., 1859./4104., -11./40.]]
+        b4 = [25./216., 0., 1408./2565., 2197./4104., -1./5.]
+        b5 = [16./135., 0., 6656./12825., 28561./56430., -9./50., 2./55.]
 
-    u1 = grid.U[time, particle.lon, particle.lat]
-    v1 = grid.V[time, particle.lon, particle.lat]
-    lon1, lat1 = (particle.lon + u1 * A[0][0] * dt,
-                  particle.lat + v1 * A[0][0] * dt)
-    u2, v2 = (grid.U[time + c[0] * dt, lon1, lat1],
-              grid.V[time + c[0] * dt, lon1, lat1])
-    lon2, lat2 = (particle.lon + (u1 * A[1][0] + u2 * A[1][1]) * dt,
-                  particle.lat + (v1 * A[1][0] + v2 * A[1][1]) * dt)
-    u3, v3 = (grid.U[time + c[1] * dt, lon2, lat2],
-              grid.V[time + c[1] * dt, lon2, lat2])
-    lon3, lat3 = (particle.lon + (u1 * A[2][0] + u2 * A[2][1] + u3 * A[2][2]) * dt,
-                  particle.lat + (v1 * A[2][0] + v2 * A[2][1] + v3 * A[2][2]) * dt)
-    u4, v4 = (grid.U[time + c[2] * dt, lon3, lat3],
-              grid.V[time + c[2] * dt, lon3, lat3])
-    lon4, lat4 = (particle.lon + (u1 * A[3][0] + u2 * A[3][1] + u3 * A[3][2] + u4 * A[3][3]) * dt,
-                  particle.lat + (v1 * A[3][0] + v2 * A[3][1] + v3 * A[3][2] + v4 * A[3][3]) * dt)
-    u5, v5 = (grid.U[time + c[3] * dt, lon4, lat4],
-              grid.V[time + c[3] * dt, lon4, lat4])
-    lon5, lat5 = (particle.lon + (u1 * A[4][0] + u2 * A[4][1] + u3 * A[4][2] + u4 * A[4][3] + u5 * A[4][4]) * dt,
-                  particle.lat + (v1 * A[4][0] + v2 * A[4][1] + v3 * A[4][2] + v4 * A[4][3] + v5 * A[4][4]) * dt)
-    u6, v6 = (grid.U[time + c[4] * dt, lon5, lat5],
-              grid.V[time + c[4] * dt, lon5, lat5])
+        u1 = grid.U[time, particle.lon, particle.lat]
+        v1 = grid.V[time, particle.lon, particle.lat]
+        lon1, lat1 = (particle.lon + u1 * A[0][0] * dt,
+                      particle.lat + v1 * A[0][0] * dt)
+        u2, v2 = (grid.U[time + c[0] * dt, lon1, lat1],
+                  grid.V[time + c[0] * dt, lon1, lat1])
+        lon2, lat2 = (particle.lon + (u1 * A[1][0] + u2 * A[1][1]) * dt,
+                      particle.lat + (v1 * A[1][0] + v2 * A[1][1]) * dt)
+        u3, v3 = (grid.U[time + c[1] * dt, lon2, lat2],
+                  grid.V[time + c[1] * dt, lon2, lat2])
+        lon3, lat3 = (particle.lon + (u1 * A[2][0] + u2 * A[2][1] + u3 * A[2][2]) * dt,
+                      particle.lat + (v1 * A[2][0] + v2 * A[2][1] + v3 * A[2][2]) * dt)
+        u4, v4 = (grid.U[time + c[2] * dt, lon3, lat3],
+                  grid.V[time + c[2] * dt, lon3, lat3])
+        lon4, lat4 = (particle.lon + (u1 * A[3][0] + u2 * A[3][1] + u3 * A[3][2] + u4 * A[3][3]) * dt,
+                      particle.lat + (v1 * A[3][0] + v2 * A[3][1] + v3 * A[3][2] + v4 * A[3][3]) * dt)
+        u5, v5 = (grid.U[time + c[3] * dt, lon4, lat4],
+                  grid.V[time + c[3] * dt, lon4, lat4])
+        lon5, lat5 = (particle.lon + (u1 * A[4][0] + u2 * A[4][1] + u3 * A[4][2] + u4 * A[4][3] + u5 * A[4][4]) * dt,
+                      particle.lat + (v1 * A[4][0] + v2 * A[4][1] + v3 * A[4][2] + v4 * A[4][3] + v5 * A[4][4]) * dt)
+        u6, v6 = (grid.U[time + c[4] * dt, lon5, lat5],
+                  grid.V[time + c[4] * dt, lon5, lat5])
 
-    lon_4th = particle.lon + (u1 * b4[0] + u2 * b4[1] + u3 * b4[2] + u4 * b4[3] + u5 * b4[4]) * dt
-    lat_4th = particle.lat + (v1 * b4[0] + v2 * b4[1] + v3 * b4[2] + v4 * b4[3] + v5 * b4[4]) * dt
-    lon_5th = particle.lon + (u1 * b5[0] + u2 * b5[1] + u3 * b5[2] + u4 * b5[3] + u5 * b5[4] + u6 * b5[5]) * dt
-    lat_5th = particle.lat + (v1 * b5[0] + v2 * b5[1] + v3 * b5[2] + v4 * b5[3] + v5 * b5[4] + v6 * b5[5]) * dt
+        lon_4th = particle.lon + (u1 * b4[0] + u2 * b4[1] + u3 * b4[2] + u4 * b4[3] + u5 * b4[4]) * dt
+        lat_4th = particle.lat + (v1 * b4[0] + v2 * b4[1] + v3 * b4[2] + v4 * b4[3] + v5 * b4[4]) * dt
+        lon_5th = particle.lon + (u1 * b5[0] + u2 * b5[1] + u3 * b5[2] + u4 * b5[3] + u5 * b5[4] + u6 * b5[5]) * dt
+        lat_5th = particle.lat + (v1 * b5[0] + v2 * b5[1] + v3 * b5[2] + v4 * b5[3] + v5 * b5[4] + v6 * b5[5]) * dt
 
-    kappa = math.sqrt(math.pow(lon_5th - lon_4th, 2) + math.pow(lat_5th - lat_4th, 2))
-    if kappa <= dt * tol[0]:
-        particle.lon = lon_4th
-        particle.lat = lat_4th
-        if kappa <= dt * tol[0] / 10:
-            particle.dt *= 2
-        return KernelOp.SUCCESS
-    else:
-        particle.dt /= 2
-        return KernelOp.FAILURE
+        kappa = math.sqrt(math.pow(lon_5th - lon_4th, 2) + math.pow(lat_5th - lat_4th, 2))
+        if kappa <= dt * tol[0]:
+            particle.lon = lon_4th
+            particle.lat = lat_4th
+            if kappa <= dt * tol[0] / 10:
+                particle.dt *= 2
+            return KernelOp.SUCCESS
+        else:
+            particle.dt /= 2
+            return KernelOp.FAILURE

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -232,10 +232,10 @@ class ParticleSet(object):
                 output_file.write(self, leaptime)
             if show_movie:
                 self.show(field=show_movie, t=leaptime)
-        # Remove deactivated particles
-        to_remove = [i for i, p in enumerate(self.particles) if p.active == 0]
-        if len(to_remove) > 0:
-            self.remove(to_remove)
+            # Remove deactivated particles
+            to_remove = [i for i, p in enumerate(self.particles) if p.active == 0]
+            if len(to_remove) > 0:
+                self.remove(to_remove)
 
     def show(self, **kwargs):
         if plt is None:

--- a/scripts/pull_data.py
+++ b/scripts/pull_data.py
@@ -38,6 +38,10 @@ if __name__ == "__main__":
                 filenames=["OFAM_simple_U.nc", "OFAM_simple_V.nc"],
                 path="examples/OFAM_example_data").download()
 
+    ExampleData(url="http://oceanparcels.org/examples-data/Peninsula_data",
+                filenames=["peninsulaU.nc", "peninsulaV.nc", "peninsulaP.nc"],
+                path="examples/Peninsula_data").download()
+
     dates = [datetime(2002, 1, 1) + timedelta(days=x) for x in range(0, 365)]
     globfiles = [x.strftime("%Y%m%d") + "000000-GLOBCURRENT-L4-CUReul_hs-ALT_SUM-v02.0-fv01.0.nc" for x in dates]
 


### PR DESCRIPTION
Created an example script to show how to implement delayed start of particles (i.e. have particles only be advected some time after the start of the `.execute`). This follows discussions with @Jacketless 

Delayed start is now implemented by setting `particle.active` to a value other than `0` (particle will be deleted) or `1` (particle will be advected)

- Changed the three advection kernels to only work on particles where `active == 1`
- Fixed a bug in `ParticleSet` where deletion of particles with `active == 0` was only done at the end of `.execute`, rather than every `timeleap`
- Added the Peninsula data to oceanparcels.org/examples-data/ and `pull_data`, for a cleaner `example_delay_start` script