### PR TITLE
Explicit and relative particle variable initialisation

### DIFF
--- a/examples/example_peninsula.py
+++ b/examples/example_peninsula.py
@@ -87,8 +87,8 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
     class MyParticle(ptype[mode]):
         # JIT compilation requires a-priori knowledge of the particle
         # data structure, so we define additional variables here.
-        p = Variable('p', dtype=np.float32, default=0.)
-        p_start = Variable('p_start', dtype=np.float32, default=0.)
+        p = Variable('p', dtype=np.float32, initial=0.)
+        p_start = Variable('p_start', dtype=np.float32, initial=0.)
 
         def __repr__(self):
             """Custom print function which overrides the built-in"""

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -20,9 +20,9 @@ def grid(xdim=100, ydim=100):
 def test_variable_init(grid, mode, npart=10):
     """Test that checks correct initialisation of custom variables"""
     class TestParticle(ptype[mode]):
-        p_float = Variable('p_float', dtype=np.float32, default=10.)
-        p_double = Variable('p_double', dtype=np.float64, default=11.)
-        p_int = Variable('p_int', dtype=np.int32, default=12.)
+        p_float = Variable('p_float', dtype=np.float32, initial=10.)
+        p_double = Variable('p_double', dtype=np.float64, initial=11.)
+        p_int = Variable('p_int', dtype=np.int32, initial=12.)
     pset = grid.ParticleSet(npart, pclass=TestParticle,
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.linspace(1, 0, npart, dtype=np.float32))
@@ -38,11 +38,11 @@ def test_variable_init(grid, mode, npart=10):
 def test_variable_init_relative(grid, mode, npart=10):
     """Test that checks relative initialisation of custom variables"""
     class TestParticle(ptype[mode]):
-        p_base = Variable('p_base', dtype=np.float32, default=10.)
+        p_base = Variable('p_base', dtype=np.float32, initial=10.)
         p_relative = Variable('p_relative', dtype=np.float32,
-                              default=attrgetter('p_base'))
+                              initial=attrgetter('p_base'))
         p_offset = Variable('p_offset', dtype=np.float32,
-                            default=attrgetter('p_base'))
+                            initial=attrgetter('p_base'))
 
         def __init__(self, *args, **kwargs):
             super(TestParticle, self).__init__(*args, **kwargs)

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -41,8 +41,18 @@ def test_variable_init_relative(grid, mode, npart=10):
         p_base = Variable('p_base', dtype=np.float32, default=10.)
         p_relative = Variable('p_relative', dtype=np.float32,
                               default=attrgetter('p_base'))
+        p_offset = Variable('p_offset', dtype=np.float32,
+                            default=attrgetter('p_base'))
+
+        def __init__(self, *args, **kwargs):
+            super(TestParticle, self).__init__(*args, **kwargs)
+            self.p_offset += 2.
     pset = grid.ParticleSet(npart, pclass=TestParticle,
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.linspace(1, 0, npart, dtype=np.float32))
-    assert np.allclose([p.p_base for p in pset], 10., rtol=1e-12)
+    # Adjust base variable to test for aliasing effects
+    for p in pset:
+        p.p_base += 3.
+    assert np.allclose([p.p_base for p in pset], 13., rtol=1e-12)
     assert np.allclose([p.p_relative for p in pset], 10., rtol=1e-12)
+    assert np.allclose([p.p_offset for p in pset], 12., rtol=1e-12)

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -1,0 +1,32 @@
+from parcels import Grid, ScipyParticle, JITParticle, Variable
+import numpy as np
+import pytest
+
+
+ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
+
+
+@pytest.fixture
+def grid(xdim=100, ydim=100):
+    U = np.zeros((xdim, ydim), dtype=np.float32)
+    V = np.zeros((xdim, ydim), dtype=np.float32)
+    lon = np.linspace(0, 1, xdim, dtype=np.float32)
+    lat = np.linspace(0, 1, ydim, dtype=np.float32)
+    return Grid.from_data(U, lon, lat, V, lon, lat, mesh='flat')
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_variable_init(grid, mode, npart=10):
+    class TestParticle(ptype[mode]):
+        p_float = Variable('p_float', dtype=np.float32, default=10.)
+        p_double = Variable('p_double', dtype=np.float64, default=11.)
+        p_int = Variable('p_int', dtype=np.int32, default=12)
+    pset = grid.ParticleSet(npart, pclass=TestParticle,
+                            lon=np.linspace(0, 1, npart, dtype=np.float32),
+                            lat=np.linspace(1, 0, npart, dtype=np.float32))
+    assert np.array([isinstance(p.p_float, np.float32) for p in pset]).all()
+    assert np.allclose([p.p_float for p in pset], 10., rtol=1e-12)
+    assert np.array([isinstance(p.p_double, np.float64) for p in pset]).all()
+    assert np.allclose([p.p_double for p in pset], 11., rtol=1e-12)
+    assert np.array([isinstance(p.p_int, np.int32) for p in pset]).all()
+    assert np.allclose([p.p_int for p in pset], 12., rtol=1e-12)


### PR DESCRIPTION
This merge changes the way particle variables are initialised in order to cleanly address issue #101. In particular we now:
* Delegate particle variable initialisation to a private `_Particle` base class.
* Change the `Variable` attribute `default` to initial and always initialise explicitly at particle creation.
* This now allows us to honour `initial=attrgetter('another_variable')` notation, where the actual initial value depends on another particle variable.