### PR TITLE
Write flag added to particle variables

### DIFF
--- a/examples/PARCELStutorial.ipynb
+++ b/examples/PARCELStutorial.ipynb
@@ -1474,7 +1474,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we need to create a new `ParticleSet` class that includes a few extra variables (called `user_vars` in PARCELS)"
+    "First, we need to create a new `Particle` class that includes three extra variables. The `distance` variable will be written to output, but the auxiliary variables `prev_lon` and `prev_lat` won't be written to output (can be controlled using the `to_write` keyword"
    ]
   },
   {
@@ -1485,16 +1485,16 @@
    },
    "outputs": [],
    "source": [
-    "class DistParticle(JITParticle):                       # Define a new particle class that contains\n",
-    "    distance = Variable('distance', dtype=np.float32)  # three new variables: the distance as well as \n",
-    "    prev_lon = Variable('prev_lon', dtype=np.float32)  # the previous longitude and\n",
-    "    prev_lat = Variable('prev_lat', dtype=np.float32)  # the previous latitude.\n",
-    "    \n",
+    "class DistParticle(JITParticle):  # Define a new particle class that contains three extra variables\n",
+    "    distance = Variable('distance', initial=0., dtype=np.float32)      # the distance travelled\n",
+    "    prev_lon = Variable('prev_lon', dtype=np.float32, to_write=False)  # the previous longitude\n",
+    "    prev_lat = Variable('prev_lat', dtype=np.float32, to_write=False)  # the previous latitude.\n",
+    "\n",
     "    def __init__(self, *args, **kwargs):\n",
     "        # Inheritance of other fields for new particles\n",
     "        super(DistParticle, self).__init__(*args, **kwargs)\n",
-    "        # Set default values for the three new variables\n",
-    "        self.distance = 0.\n",
+    "        # Set default values for the new prev_lon/prev_lat variables \n",
+    "        # (done like this because lon and lat are not yet known)\n",
     "        self.prev_lon = self.lon\n",
     "        self.prev_lat = self.lat"
    ]

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -12,10 +12,11 @@ class Variable(object):
     :param dtype: Data type (numpy.dtype) of the variable
     :param initial: Initial value of the variable
     """
-    def __init__(self, name, dtype=np.float32, initial=0):
+    def __init__(self, name, dtype=np.float32, initial=0, to_write=True):
         self.name = name
         self.dtype = dtype
         self.initial = initial
+        self.to_write = to_write
 
     def __get__(self, instance, cls):
         if issubclass(cls, JITParticle):

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -111,8 +111,8 @@ class ScipyParticle(_Particle):
     lon = Variable('lon', dtype=np.float32)
     lat = Variable('lat', dtype=np.float32)
     time = Variable('time', dtype=np.float64)
-    dt = Variable('dt', dtype=np.float32)
-    active = Variable('active', dtype=np.int32, initial=1)
+    dt = Variable('dt', dtype=np.float32, to_write=False)
+    active = Variable('active', dtype=np.int32, initial=1, to_write=False)
 
     def __init__(self, lon, lat, grid, dt=3600., time=0., cptr=None):
         super(ScipyParticle, self).__init__()
@@ -138,8 +138,8 @@ class JITParticle(ScipyParticle):
     :param user_vars: Class variable that defines additional particle variables
     """
 
-    xi = Variable('xi', dtype=np.int32)
-    yi = Variable('yi', dtype=np.int32)
+    xi = Variable('xi', dtype=np.int32, to_write=False)
+    yi = Variable('yi', dtype=np.int32, to_write=False)
 
     def __init__(self, *args, **kwargs):
         self._cptr = kwargs.pop('cptr', None)

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -72,11 +72,12 @@ class ParticleFile(object):
         for v in particleset.ptype.variables:
             if v.name in ['time', 'lat', 'lon', 'z']:
                 continue
-            setattr(self, v.name, self.dataset.createVariable(v.name, "f4", ("trajectory", "obs"), fill_value=0.))
-            getattr(self, v.name).long_name = ""
-            getattr(self, v.name).standard_name = v.name
-            getattr(self, v.name).units = "unknown"
-            self.user_vars += [v.name]
+            if v.to_write is True:
+                setattr(self, v.name, self.dataset.createVariable(v.name, "f4", ("trajectory", "obs"), fill_value=0.))
+                getattr(self, v.name).long_name = ""
+                getattr(self, v.name).standard_name = v.name
+                getattr(self, v.name).units = "unknown"
+                self.user_vars += [v.name]
 
         self.idx = 0
 


### PR DESCRIPTION
Added a simple `to_write` flag to the custom variable definition
(default is true). `ParticleFile` objects now only write particle
variables to netcdf if this flag is on.

This saves on file size for internal particle variables that are used
at runtime, but have no need to be written to results.