### PR TITLE
Fix relative variable initialisation from lon/lat

### DIFF
--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -19,6 +19,8 @@ class Variable(object):
         self.to_write = to_write
 
     def __get__(self, instance, cls):
+        if instance is None:
+            return self
         if issubclass(cls, JITParticle):
             return instance._cptr.__getitem__(self.name)
         else:
@@ -115,11 +117,12 @@ class ScipyParticle(_Particle):
     active = Variable('active', dtype=np.int32, initial=1, to_write=False)
 
     def __init__(self, lon, lat, grid, dt=3600., time=0., cptr=None):
+        # Enforce default values through Variable descriptor
+        type(self).lon.initial = lon
+        type(self).lat.initial = lat
+        type(self).time.initial = time
+        type(self).dt.initial = dt
         super(ScipyParticle, self).__init__()
-        self.lon = lon
-        self.lat = lat
-        self.time = time
-        self.dt = dt
 
     def __repr__(self):
         return "P(%f, %f, %f)" % (self.lon, self.lat, self.time)

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -43,16 +43,22 @@ def test_variable_init_relative(grid, mode, npart=10):
                               initial=attrgetter('p_base'))
         p_offset = Variable('p_offset', dtype=np.float32,
                             initial=attrgetter('p_base'))
+        p_lon = Variable('p_lon', dtype=np.float32,
+                         initial=attrgetter('lon'))
+        p_lat = Variable('p_lat', dtype=np.float32,
+                         initial=attrgetter('lat'))
 
         def __init__(self, *args, **kwargs):
             super(TestParticle, self).__init__(*args, **kwargs)
             self.p_offset += 2.
-    pset = grid.ParticleSet(npart, pclass=TestParticle,
-                            lon=np.linspace(0, 1, npart, dtype=np.float32),
-                            lat=np.linspace(1, 0, npart, dtype=np.float32))
+    lon = np.linspace(0, 1, npart, dtype=np.float32)
+    lat = np.linspace(1, 0, npart, dtype=np.float32)
+    pset = grid.ParticleSet(npart, pclass=TestParticle, lon=lon, lat=lat)
     # Adjust base variable to test for aliasing effects
     for p in pset:
         p.p_base += 3.
     assert np.allclose([p.p_base for p in pset], 13., rtol=1e-12)
     assert np.allclose([p.p_relative for p in pset], 10., rtol=1e-12)
     assert np.allclose([p.p_offset for p in pset], 12., rtol=1e-12)
+    assert np.allclose([p.p_lon for p in pset], lon, rtol=1e-12)
+    assert np.allclose([p.p_lat for p in pset], lat, rtol=1e-12)


### PR DESCRIPTION
Relative variable initialisation via the `Variable` descriptors is currently happening _before_ the `ScipyParticle` constructor sets `lon`/`lat`. This merge changes that by using the `initial` mechanism on the descriptors to inject the given initial lon/lat values into the variable initialisation routine. The PR also adds a test for this to the original relative init test and should finally fix issue #101.