### PR TITLE
Fix execution after particleset addition

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -132,6 +132,9 @@ class ParticleSet(object):
         if self.ptype.uses_jit:
             particles_data = [p._cptr for p in particles]
             self._particle_data = np.append(self._particle_data, particles_data)
+            # Update C-pointer on particles
+            for p, pdata in zip(self.particles, self._particle_data):
+                p._cptr = pdata
 
     def remove(self, indices):
         if isinstance(indices, Iterable):

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -103,6 +103,19 @@ def test_pset_add_shorthand(grid, mode, npart=100):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pset_add_execute(grid, mode, npart=10):
+    def AddLat(particle, grid, time, dt):
+        particle.lat += 0.1
+
+    pset = grid.ParticleSet(0, lon=[], lat=[], pclass=ptype[mode])
+    for i in range(npart):
+        pset += ptype[mode](lon=0.1, lat=0.1, grid=grid)
+    for _ in range(3):
+        pset.execute(pset.Kernel(AddLat), starttime=0., endtime=1., dt=1.0)
+    assert np.allclose(np.array([p.lat for p in pset]), 0.4, rtol=1e-12)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pset_merge_inplace(grid, mode, npart=100):
     pset1 = grid.ParticleSet(npart, pclass=ptype[mode],
                              lon=np.linspace(0, 1, npart, dtype=np.float32),


### PR DESCRIPTION
This merge fixes a bug in the `ParticleSet.add()` method that causes the C-pointers under the particles to go out of sync with the Python representation of the particle. It also adds a test for this and should fix issue #115.