### PR TITLE
Fix JIT execution after particle removeal

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -143,6 +143,9 @@ class ParticleSet(object):
             particles = self.particles[indices]
         if self.ptype.uses_jit:
             self._particle_data = np.delete(self._particle_data, indices)
+            # Update C-pointer on particles
+            for p, pdata in zip(self.particles, self._particle_data):
+                p._cptr = pdata
         self.particles = np.delete(self.particles, indices)
         return particles
 

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -196,7 +196,6 @@ def test_pset_multi_execute(grid, mode, npart=10, n=5):
     assert np.allclose([p.lat - n*0.1 for p in pset], np.zeros(npart), rtol=1e-12)
 
 
-@pytest.mark.xfail(reason="Multi-execute breaks with particle removal")
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pset_multi_execute_delete(grid, mode, npart=10, n=5):
     def AddLat(particle, grid, time, dt):


### PR DESCRIPTION
The same idea as in PR #118, but this time fixing particle removal by updating the C-pointers under JIT particles.