### PR TITLE
Recovery kernel loop

### DIFF
--- a/include/parcels.h
+++ b/include/parcels.h
@@ -3,7 +3,7 @@
 
 typedef enum
   {
-    SUCCESS=0, REPEAT=1, DELETE=2, FAIL=3, FAIL_OUT_OF_BOUNDS=4
+    SUCCESS=0, REPEAT=1, DELETE=2, ERROR=3, ERROR_OUT_OF_BOUNDS=4
   } ErrorCode;
 
 typedef struct

--- a/include/parcels.h
+++ b/include/parcels.h
@@ -3,7 +3,7 @@
 
 typedef enum
   {
-    SUCCESS, REPEAT, FAIL, FAIL_OUT_OF_BOUNDS
+    SUCCESS=0, REPEAT=1, DELETE=2, FAIL=3, FAIL_OUT_OF_BOUNDS=4
   } KernelOp;
 
 typedef struct

--- a/include/parcels.h
+++ b/include/parcels.h
@@ -4,7 +4,7 @@
 typedef enum
   {
     SUCCESS=0, REPEAT=1, DELETE=2, FAIL=3, FAIL_OUT_OF_BOUNDS=4
-  } KernelOp;
+  } ErrorCode;
 
 typedef struct
 {

--- a/include/parcels.h
+++ b/include/parcels.h
@@ -3,7 +3,7 @@
 
 typedef enum
   {
-    SUCCESS, FAILURE
+    SUCCESS, REPEAT, FAIL, FAIL_OUT_OF_BOUNDS
   } KernelOp;
 
 typedef struct

--- a/include/parcels.h
+++ b/include/parcels.h
@@ -47,8 +47,8 @@ static inline ErrorCode spatial_interpolation_bilinear(float x, float y, int i, 
 }
 
 /* Linear interpolation along the time axis */
-static inline float temporal_interpolation_linear(float x, float y, int xi, int yi,
-                                                  double time, CField *f)
+static inline ErrorCode temporal_interpolation_linear(float x, float y, int xi, int yi,
+                                                      double time, CField *f, float *value)
 {
   ErrorCode err;
   /* Cast data array intp data[time][lat][lon] as per NEMO convention */
@@ -67,11 +67,12 @@ static inline float temporal_interpolation_linear(float x, float y, int xi, int 
                                         (float**)(data[f->tidx]), &f0);
     err = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat,
                                         (float**)(data[f->tidx+1]), &f1);
-    return f0 + (f1 - f0) * (float)((time - t0) / (t1 - t0));
+    *value = f0 + (f1 - f0) * (float)((time - t0) / (t1 - t0));
+    return SUCCESS;
   } else {
     err = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat,
-                                         (float**)(data[f->tidx]), &f0);
-    return f0;
+                                         (float**)(data[f->tidx]), value);
+    return SUCCESS;
   }
 }
 

--- a/include/parcels.h
+++ b/include/parcels.h
@@ -6,6 +6,8 @@ typedef enum
     SUCCESS=0, REPEAT=1, DELETE=2, ERROR=3, ERROR_OUT_OF_BOUNDS=4
   } ErrorCode;
 
+#define CHECKERROR(res) do {if (res != SUCCESS) return res;} while (0)
+
 typedef struct
 {
   int xdim, ydim, tdim, tidx;
@@ -18,6 +20,7 @@ typedef struct
 /* Local linear search to update grid index */
 static inline ErrorCode search_linear_float(float x, int size, float *xvals, int *index)
 {
+  if (x < xvals[0] || xvals[size-1] < x) {return ERROR_OUT_OF_BOUNDS;}
   while (*index < size-1 && x > xvals[*index+1]) ++(*index);
   while (*index > 0 && x < xvals[*index]) --(*index);
   return SUCCESS;
@@ -57,8 +60,8 @@ static inline ErrorCode temporal_interpolation_linear(float x, float y, int xi, 
   double t0, t1;
   int i = xi, j = yi;
   /* Identify grid cell to sample through local linear search */
-  err = search_linear_float(x, f->xdim, f->lon, &i);
-  err = search_linear_float(y, f->ydim, f->lat, &j);
+  err = search_linear_float(x, f->xdim, f->lon, &i); CHECKERROR(err);
+  err = search_linear_float(y, f->ydim, f->lat, &j); CHECKERROR(err);
   /* Find time index for temporal interpolation */
   err = search_linear_double(time, f->tdim, f->time, &(f->tidx));
   if (f->tidx < f->tdim-1 && time > f->time[f->tidx]) {

--- a/include/parcels.h
+++ b/include/parcels.h
@@ -16,55 +16,62 @@ typedef struct
 
 
 /* Local linear search to update grid index */
-static inline int search_linear_float(float x, int i, int size, float *xvals)
+static inline ErrorCode search_linear_float(float x, int size, float *xvals, int *index)
 {
-    while (i < size-1 && x > xvals[i+1]) ++i;
-    while (i > 0 && x < xvals[i]) --i;
-    return i;
+  while (*index < size-1 && x > xvals[*index+1]) ++(*index);
+  while (*index > 0 && x < xvals[*index]) --(*index);
+  return SUCCESS;
 }
 
 /* Local linear search to update time index */
-static inline int search_linear_double(double t, int i, int size, double *tvals)
+static inline ErrorCode search_linear_double(double t, int size, double *tvals, int *index)
 {
-    while (i < size-1 && t > tvals[i+1]) ++i;
-    while (i > 0 && t < tvals[i]) --i;
-    return i;
+  while (*index < size-1 && t > tvals[*index+1]) ++(*index);
+  while (*index > 0 && t < tvals[*index]) --(*index);
+  return SUCCESS;
 }
 
 /* Bilinear interpolation routine for 2D grid */
-static inline float spatial_interpolation_bilinear(float x, float y, int i, int j, int xdim,
-                                                   float *lon, float *lat, float **f_data)
+static inline ErrorCode spatial_interpolation_bilinear(float x, float y, int i, int j, int xdim,
+                                                       float *lon, float *lat, float **f_data,
+                                                       float *value)
 {
   /* Cast data array into data[lat][lon] as per NEMO convention */
   float (*data)[xdim] = (float (*)[xdim]) f_data;
-  return (data[j][i] * (lon[i+1] - x) * (lat[j+1] - y)
-        + data[j][i+1] * (x - lon[i]) * (lat[j+1] - y)
-        + data[j+1][i] * (lon[i+1] - x) * (y - lat[j])
-        + data[j+1][i+1] * (x - lon[i]) * (y - lat[j]))
-        / ((lon[i+1] - lon[i]) * (lat[j+1] - lat[j]));
+  *value = (data[j][i] * (lon[i+1] - x) * (lat[j+1] - y)
+            + data[j][i+1] * (x - lon[i]) * (lat[j+1] - y)
+            + data[j+1][i] * (lon[i+1] - x) * (y - lat[j])
+            + data[j+1][i+1] * (x - lon[i]) * (y - lat[j]))
+            / ((lon[i+1] - lon[i]) * (lat[j+1] - lat[j]));
+  return SUCCESS;
 }
 
 /* Linear interpolation along the time axis */
 static inline float temporal_interpolation_linear(float x, float y, int xi, int yi,
                                                   double time, CField *f)
 {
+  ErrorCode err;
   /* Cast data array intp data[time][lat][lon] as per NEMO convention */
   float (*data)[f->ydim][f->xdim] = (float (*)[f->ydim][f->xdim]) f->data;
   float f0, f1;
   double t0, t1;
   int i = xi, j = yi;
   /* Identify grid cell to sample through local linear search */
-  i = search_linear_float(x, i, f->xdim, f->lon);
-  j = search_linear_float(y, j, f->ydim, f->lat);
+  err = search_linear_float(x, f->xdim, f->lon, &i);
+  err = search_linear_float(y, f->ydim, f->lat, &j);
   /* Find time index for temporal interpolation */
-  f->tidx = search_linear_double(time, f->tidx, f->tdim, f->time);
+  err = search_linear_double(time, f->tdim, f->time, &(f->tidx));
   if (f->tidx < f->tdim-1 && time > f->time[f->tidx]) {
     t0 = f->time[f->tidx]; t1 = f->time[f->tidx+1];
-    f0 = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat, (float**)(data[f->tidx]));
-    f1 = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat, (float**)(data[f->tidx+1]));
+    err = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat,
+                                        (float**)(data[f->tidx]), &f0);
+    err = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat,
+                                        (float**)(data[f->tidx+1]), &f1);
     return f0 + (f1 - f0) * (float)((time - t0) / (t1 - t0));
   } else {
-    return spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat, (float**)(data[f->tidx]));
+    err = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat,
+                                         (float**)(data[f->tidx]), &f0);
+    return f0;
   }
 }
 

--- a/parcels/__init__.py
+++ b/parcels/__init__.py
@@ -4,5 +4,5 @@ from parcels.particleset import *  # noqa
 from parcels.field import *  # noqa
 from parcels.kernel import *  # noqa
 import parcels.rng as random  # noqa
-from parcels.kernels.advection import *  # noqa
 from parcels.particlefile import *  # noqa
+from parcels.kernels import *  # noqa

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -99,7 +99,7 @@ class ParticleNode(IntrinsicNode):
         if attr in [v.name for v in self.obj.variables]:
             return ParticleAttributeNode(self, attr)
         elif attr in ['delete']:
-            return ParticleAttributeNode(self, 'active')
+            return ParticleAttributeNode(self, 'state')
         else:
             raise AttributeError("""Particle type %s does not define attribute "%s".
 Please add '%s' to %s.users_vars or define an appropriate sub-class."""
@@ -161,8 +161,8 @@ class IntrinsicTransformer(ast.NodeTransformer):
         node.func = self.visit(node.func)
         node.args = [self.visit(a) for a in node.args]
         if isinstance(node.func, ParticleAttributeNode) \
-           and node.func.attr == 'active':
-            node = IntrinsicNode(node, "%s = 0" % node.func.ccode)
+           and node.func.attr == 'state':
+            node = IntrinsicNode(node, "%s = DELETE" % node.func.ccode)
         return node
 
 

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -51,7 +51,8 @@ class RandomNode(IntrinsicNode):
 
 
 class KernelOpNode(IntrinsicNode):
-    symbol_map = {'SUCCESS': 'SUCCESS', 'FAILURE': 'FAILURE'}
+    symbol_map = {'Success': 'SUCCESS', 'Repeat': 'REPEAT',
+                  'Fail': 'FAIL', 'FailOutOfBounds': 'FAIL_OUT_OF_BOUNDS'}
 
     def __getattr__(self, attr):
         if attr in self.symbol_map:

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -52,7 +52,7 @@ class RandomNode(IntrinsicNode):
 
 class ErrorCodeNode(IntrinsicNode):
     symbol_map = {'Success': 'SUCCESS', 'Repeat': 'REPEAT', 'Delete': 'DELETE',
-                  'Fail': 'FAIL', 'FailOutOfBounds': 'FAIL_OUT_OF_BOUNDS'}
+                  'Error': 'ERROR', 'ErrorOutOfBounds': 'ERROR_OUT_OF_BOUNDS'}
 
     def __getattr__(self, attr):
         if attr in self.symbol_map:

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -464,6 +464,7 @@ class LoopGenerator(object):
         sign = c.Assign("sign", "dt > 0. ? 1. : -1.")
         dt_pos = c.Assign("__dt", "fmin(fabs(particles[p].dt), fabs(endtime - particles[p].time))")
         body = [c.Assign("res", "%s(&(particles[p]), %s)" % (funcname, fargs_str))]
+        body += [c.Assign("particles[p].state", "res")]  # Store return code on particle
         body += [c.If("res == SUCCESS", c.Block([c.Statement("particles[p].time += sign * __dt"),
                                                  dt_pos, c.Statement("continue")]))]
         body += [c.If("res == REPEAT", c.Block([dt_pos, c.Statement("continue")]),

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -439,7 +439,7 @@ class LoopGenerator(object):
         self.grid = grid
         self.ptype = ptype
 
-    def generate(self, funcname, field_args, kernel_ast, adaptive=False):
+    def generate(self, funcname, field_args, kernel_ast):
         ccode = []
 
         # Add include for Parcels and math header

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -78,7 +78,7 @@ class ParticleAttributeNode(IntrinsicNode):
     @property
     def pyast_index_update(self):
         pyast = ast.Assign()
-        pyast.targets = [IntrinsicNode(None, ccode=self.ccode_index_var)]
+        pyast.targets = [IntrinsicNode(None, ccode='err')]
         pyast.value = IntrinsicNode(None, ccode=self.ccode_index_update)
         return pyast
 
@@ -86,10 +86,10 @@ class ParticleAttributeNode(IntrinsicNode):
     def ccode_index_update(self):
         """C-code for the index update requires after updating p.lon/p.lat"""
         if self.attr == 'lon':
-            return "search_linear_float(%s, %s, U->xdim, U->lon)" \
+            return "search_linear_float(%s, U->xdim, U->lon, &%s)" \
                 % (self.ccode, self.ccode_index_var)
         if self.attr == 'lat':
-            return "search_linear_float(%s, %s, U->ydim, U->lat)" \
+            return "search_linear_float(%s, U->ydim, U->lat, &%s)" \
                 % (self.ccode, self.ccode_index_var)
         return ""
 
@@ -216,6 +216,7 @@ class KernelGenerator(ast.NodeVisitor):
         for kvar in self.kernel_vars + self.array_vars:
             if kvar in funcvars:
                 funcvars.remove(kvar)
+        self.ccode.body.insert(0, c.Value('ErrorCode', 'err'))
         if len(funcvars) > 0:
             self.ccode.body.insert(0, c.Value("float", ", ".join(funcvars)))
 

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -212,7 +212,7 @@ class IntrinsicTransformer(ast.NodeTransformer):
         node.args = [self.visit(a) for a in node.args]
         if isinstance(node.func, ParticleAttributeNode) \
            and node.func.attr == 'state':
-            node = IntrinsicNode(node, "%s = DELETE" % node.func.ccode)
+            node = IntrinsicNode(node, "return DELETE")
         return node
 
 

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -93,10 +93,10 @@ class ParticleAttributeNode(IntrinsicNode):
     def ccode_index_update(self):
         """C-code for the index update requires after updating p.lon/p.lat"""
         if self.attr == 'lon':
-            return "search_linear_float(%s, U->xdim, U->lon, &%s)" \
+            return "search_linear_float(%s, U->xdim, U->lon, &(%s)); CHECKERROR(err)" \
                 % (self.ccode, self.ccode_index_var)
         if self.attr == 'lat':
-            return "search_linear_float(%s, U->ydim, U->lat, &%s)" \
+            return "search_linear_float(%s, U->ydim, U->lat, &(%s)); CHECKERROR(err)" \
                 % (self.ccode, self.ccode_index_var)
         return ""
 
@@ -477,7 +477,8 @@ class KernelGenerator(ast.NodeVisitor):
         ccode_eval = node.field.obj.ccode_eval(node.var, *node.args.ccode)
         ccode_conv = node.field.obj.ccode_convert(*node.args.ccode)
         node.ccode = c.Block([c.Assign("err", ccode_eval),
-                              c.Statement("%s *= %s" % (node.var, ccode_conv))])
+                              c.Statement("%s *= %s" % (node.var, ccode_conv)),
+                              c.Statement("CHECKERROR(err)")])
 
     def visit_Return(self, node):
         self.visit(node.value)

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -306,11 +306,12 @@ class Field(object):
 
         return self.units.to_target(value, x, y)
 
-    def ccode_subscript(self, t, x, y):
-        ccode = "%s * temporal_interpolation_linear(%s, %s, %s, %s, %s, %s)" \
-                % (self.units.ccode_to_target(x, y),
-                   x, y, "particle->xi", "particle->yi", t, self.name)
-        return ccode
+    def ccode_eval(self, var, t, x, y):
+        return "temporal_interpolation_linear(%s, %s, %s, %s, %s, %s, &%s)" \
+            % (x, y, "particle->xi", "particle->yi", t, self.name, var)
+
+    def ccode_convert(self, _, x, y):
+        return self.units.ccode_to_target(x, y)
 
     @property
     def ctypes_struct(self):

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -20,8 +20,10 @@ re_indent = re.compile(r"^(\s+)")
 
 
 class KernelOp(Enum):
-    SUCCESS = 0
-    FAILURE = 1
+    Success = 0
+    Repeat = 1
+    Fail = 2
+    FailOutOfBounds = 3
 
 
 def fix_indentation(string):
@@ -127,14 +129,14 @@ class Kernel(object):
                     while min(p.dt, endtime - p.time) > 0:
                         dt = min(p.dt, endtime - p.time)
                         res = self.pyfunc(p, pset.grid, p.time, dt)
-                        if res is None or res == KernelOp.SUCCESS:
+                        if res is None or res == KernelOp.Success:
                             p.time += dt
             else:
                 for p in pset.particles:
                     while max(p.dt, endtime - p.time) < 0:
                         dt = max(p.dt, endtime - p.time)
                         res = self.pyfunc(p, pset.grid, p.time, dt)
-                        if res is None or res == KernelOp.SUCCESS:
+                        if res is None or res == KernelOp.Success:
                             p.time += dt
 
     def merge(self, kernel):

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -88,9 +88,8 @@ class Kernel(object):
                                               self.funcvars)
             self.field_args = kernelgen.field_args
             loopgen = LoopGenerator(grid, ptype)
-            adaptive = 'AdvectionRK45' in self.funcname
             self.ccode = loopgen.generate(self.funcname, self.field_args,
-                                          kernel_ccode, adaptive=adaptive)
+                                          kernel_ccode)
 
             basename = path.join(get_cache_dir(), self._cache_key)
             self.src_file = "%s.c" % basename

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -8,7 +8,7 @@ import inspect
 from copy import deepcopy
 import re
 from hashlib import md5
-from enum import Enum
+from enum import IntEnum
 import math  # noqa
 import random  # noqa
 
@@ -19,11 +19,12 @@ __all__ = ['Kernel', 'KernelOp']
 re_indent = re.compile(r"^(\s+)")
 
 
-class KernelOp(Enum):
+class KernelOp(IntEnum):
     Success = 0
     Repeat = 1
-    Fail = 2
-    FailOutOfBounds = 3
+    Delete = 2
+    Fail = 3
+    FailOutOfBounds = 4
 
 
 def fix_indentation(string):

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -136,6 +136,10 @@ class Kernel(object):
                     # Handle particle time and time loop
                     if res is None or res == KernelOp.Success:
                         p.time += sign * dt_pos
+                    elif res == KernelOp.Repeat:
+                        pass  # Try again without time update
+                    else:
+                        break  # Failure - stop time loop
                     # Compute min/max dt for next timestep
                     dt_pos = min(abs(p.dt), abs(endtime - p.time))
 

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -127,13 +127,16 @@ class Kernel(object):
 
                     # Handle particle time and time loop
                     if res is None or res == ErrorCode.Success:
+                        # Update time and repeat
                         p.time += sign * dt_pos
+                        dt_pos = min(abs(p.dt), abs(endtime - p.time))
+                        continue
                     elif res == ErrorCode.Repeat:
-                        pass  # Try again without time update
+                        # Try again without time update
+                        dt_pos = min(abs(p.dt), abs(endtime - p.time))
+                        continue
                     else:
                         break  # Failure - stop time loop
-                    # Compute min/max dt for next timestep
-                    dt_pos = min(abs(p.dt), abs(endtime - p.time))
 
         # Remove all failing particles from the current set
         fail_indices = [i for i, p in enumerate(pset.particles)

--- a/parcels/kernels/__init__.py
+++ b/parcels/kernels/__init__.py
@@ -1,1 +1,2 @@
 from .advection import *  # noqa
+from .error import *  # noqa

--- a/parcels/kernels/advection.py
+++ b/parcels/kernels/advection.py
@@ -1,5 +1,5 @@
 """Collection of pre-built advection kernels"""
-from parcels.kernel import KernelOp
+from parcels.kernels.error import ErrorCode
 import math
 
 
@@ -73,4 +73,4 @@ def AdvectionRK45(particle, grid, time, dt):
             particle.dt *= 2
     else:
         particle.dt /= 2
-        return KernelOp.Repeat
+        return ErrorCode.Repeat

--- a/parcels/kernels/advection.py
+++ b/parcels/kernels/advection.py
@@ -73,4 +73,4 @@ def AdvectionRK45(particle, grid, time, dt):
             particle.dt *= 2
     else:
         particle.dt /= 2
-        return KernelOp.FAILURE
+        return KernelOp.Repeat

--- a/parcels/kernels/error.py
+++ b/parcels/kernels/error.py
@@ -1,0 +1,27 @@
+"""Collection of pre-built recovery kernels"""
+from enum import IntEnum
+
+
+__all__ = ['ErrorCode', 'recovery_map']
+
+
+class ErrorCode(IntEnum):
+    Success = 0
+    Repeat = 1
+    Delete = 2
+    Fail = 3
+    FailOutOfBounds = 4
+
+
+def recovery_fail(particle):
+    """Default failure kernel that throws exception"""
+    raise RuntimeError(
+        "\nKernel error during execution: %s\n"
+        "Particle %s\nTime time: %f,\ttimestep size: %f"
+        % (particle.state, particle, particle.time, particle.dt)
+    )
+
+
+# Default mapping of failure types (KernelOp)
+# to recovery kernels.
+recovery_map = {ErrorCode.Fail: recovery_fail}

--- a/parcels/kernels/error.py
+++ b/parcels/kernels/error.py
@@ -2,7 +2,7 @@
 from enum import IntEnum
 
 
-__all__ = ['ErrorCode', 'recovery_map']
+__all__ = ['ErrorCode', 'KernelError', 'OutOfBoundsError', 'recovery_map']
 
 
 class ErrorCode(IntEnum):
@@ -13,15 +13,41 @@ class ErrorCode(IntEnum):
     ErrorOutOfBounds = 4
 
 
-def recovery_error(particle):
-    """Default failure kernel that throws exception"""
-    raise RuntimeError(
-        "\nKernel error during execution: %s\n"
-        "Particle %s\nTime time: %f,\ttimestep size: %f"
-        % (particle.state, particle, particle.time, particle.dt)
-    )
+class KernelError(RuntimeError):
+    """General particle kernel error with optional custom message"""
+
+    def __init__(self, particle, msg=None):
+        message = ("%s\nParticle %s\nTime time: %f,\ttimestep size: %f\n") % (
+            particle.state, particle, particle.time, particle.dt
+        )
+        if msg:
+            message += msg
+        super(KernelError, self).__init__(message)
+
+
+def recovery_kernel_error(particle):
+    """Default error kernel that throws exception"""
+    msg = "Error: %s" % particle.exception if particle.exception else None
+    raise KernelError(particle, msg=msg)
+
+
+class OutOfBoundsError(KernelError):
+    """Particle kernel error for out-of-bounds field sampling"""
+
+    def __init__(self, particle, lon, lat, field=None):
+        message = "%s sampled at (%f, %f)" % (
+            field.name if field else "Grid", lon, lat
+        )
+        super(OutOfBoundsError, self).__init__(particle, msg=message)
+
+
+def recovery_kernel_out_of_bounds(particle):
+    """Default sampling error kernel that throws OutOfBoundsError"""
+    error = particle.exception
+    raise OutOfBoundsError(particle, error.x, error.y, error.field)
 
 
 # Default mapping of failure types (KernelOp)
 # to recovery kernels.
-recovery_map = {ErrorCode.Error: recovery_error}
+recovery_map = {ErrorCode.Error: recovery_kernel_error,
+                ErrorCode.ErrorOutOfBounds: recovery_kernel_out_of_bounds}

--- a/parcels/kernels/error.py
+++ b/parcels/kernels/error.py
@@ -9,11 +9,11 @@ class ErrorCode(IntEnum):
     Success = 0
     Repeat = 1
     Delete = 2
-    Fail = 3
-    FailOutOfBounds = 4
+    Error = 3
+    ErrorOutOfBounds = 4
 
 
-def recovery_fail(particle):
+def recovery_error(particle):
     """Default failure kernel that throws exception"""
     raise RuntimeError(
         "\nKernel error during execution: %s\n"
@@ -24,4 +24,4 @@ def recovery_fail(particle):
 
 # Default mapping of failure types (KernelOp)
 # to recovery kernels.
-recovery_map = {ErrorCode.Fail: recovery_fail}
+recovery_map = {ErrorCode.Error: recovery_error}

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -1,3 +1,4 @@
+from parcels.kernel import KernelOp as op
 from operator import attrgetter
 import numpy as np
 
@@ -114,7 +115,7 @@ class ScipyParticle(_Particle):
     lat = Variable('lat', dtype=np.float32)
     time = Variable('time', dtype=np.float64)
     dt = Variable('dt', dtype=np.float32, to_write=False)
-    active = Variable('active', dtype=np.int32, initial=1, to_write=False)
+    state = Variable('state', dtype=np.int32, initial=op.Success, to_write=False)
 
     def __init__(self, lon, lat, grid, dt=3600., time=0., cptr=None):
         # Enforce default values through Variable descriptor
@@ -128,7 +129,7 @@ class ScipyParticle(_Particle):
         return "P(%f, %f, %f)" % (self.lon, self.lat, self.time)
 
     def delete(self):
-        self.active = 0
+        self.state = op.Delete
 
 
 class JITParticle(ScipyParticle):

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -1,4 +1,4 @@
-from parcels.kernel import KernelOp as op
+from parcels.kernels.error import ErrorCode
 from operator import attrgetter
 import numpy as np
 
@@ -115,7 +115,7 @@ class ScipyParticle(_Particle):
     lat = Variable('lat', dtype=np.float32)
     time = Variable('time', dtype=np.float64)
     dt = Variable('dt', dtype=np.float32, to_write=False)
-    state = Variable('state', dtype=np.int32, initial=op.Success, to_write=False)
+    state = Variable('state', dtype=np.int32, initial=ErrorCode.Success, to_write=False)
 
     def __init__(self, lon, lat, grid, dt=3600., time=0., cptr=None):
         # Enforce default values through Variable descriptor
@@ -129,7 +129,7 @@ class ScipyParticle(_Particle):
         return "P(%f, %f, %f)" % (self.lon, self.lat, self.time)
 
     def delete(self):
-        self.state = op.Delete
+        self.state = ErrorCode.Delete
 
 
 class JITParticle(ScipyParticle):

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -97,6 +97,9 @@ class _Particle(object):
             # Enforce type of initial value
             setattr(self, v.name, v.dtype(initial))
 
+        # Placeholder for explicit error handling
+        self.exception = None
+
     @classmethod
     def getPType(cls):
         return ParticleType(cls)

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -1,4 +1,4 @@
-from parcels.kernel import Kernel
+from parcels.kernel import Kernel, KernelOp as op
 from parcels.field import Field
 from parcels.particle import JITParticle
 from parcels.compiler import GNUCompiler
@@ -254,7 +254,7 @@ class ParticleSet(object):
             if show_movie:
                 self.show(field=show_movie, t=leaptime)
         # Remove deactivated particles
-        to_remove = [i for i, p in enumerate(self.particles) if p.active == 0]
+        to_remove = [i for i, p in enumerate(self.particles) if p.state == op.Delete]
         if len(to_remove) > 0:
             self.remove(to_remove)
 

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -253,10 +253,6 @@ class ParticleSet(object):
                 output_file.write(self, leaptime)
             if show_movie:
                 self.show(field=show_movie, t=leaptime)
-        # Remove deactivated particles
-        to_remove = [i for i, p in enumerate(self.particles) if p.state == op.Delete]
-        if len(to_remove) > 0:
-            self.remove(to_remove)
 
     def show(self, **kwargs):
         savefile = kwargs.get('savefile', None)

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -1,4 +1,4 @@
-from parcels.kernel import Kernel, KernelOp as op
+from parcels.kernel import Kernel
 from parcels.field import Field
 from parcels.particle import JITParticle
 from parcels.compiler import GNUCompiler

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -215,7 +215,7 @@ class ParticleSet(object):
         if starttime is None:
             starttime = self.grid.time[0] if dt > 0 else self.grid.time[-1]
         if runtime is not None:
-            endtime = starttime + runtime if dt > 0 else starttime - runtime
+            endtime = starttime + runtime
         else:
             if endtime is None:
                 endtime = self.grid.time[-1] if dt > 0 else self.grid.time[0]

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -165,7 +165,7 @@ class ParticleSet(object):
         return particles
 
     def execute(self, pyfunc=AdvectionRK4, starttime=None, endtime=None, dt=1.,
-                runtime=None, interval=None, output_file=None, tol=None,
+                runtime=None, interval=None, recovery=None, output_file=None,
                 show_movie=False):
         """Execute a given kernel function over the particle set for
         multiple timesteps. Optionally also provide sub-timestepping
@@ -180,6 +180,8 @@ class ParticleSet(object):
         :param interval: Interval for inner sub-timestepping (leap), which dictates
                          the update frequency of file output and animation.
         :param output_file: ParticleFile object for particle output
+        :param recovery: Dictionary with additional recovery kernels to allow
+                         custom recovery behaviour in case of kernel errors.
         :param show_movie: True shows particles; name of field plots that field as background
         """
         if self.kernel is None:
@@ -248,7 +250,8 @@ class ParticleSet(object):
         leaptime = starttime
         for _ in range(timeleaps):
             leaptime += interval
-            self.kernel.execute(self, endtime=leaptime, dt=dt)
+            self.kernel.execute(self, endtime=leaptime, dt=dt,
+                                recovery=recovery)
             if output_file:
                 output_file.write(self, leaptime)
             if show_movie:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
 ignore = E501,F403,E226,W503
 
-[pytest]
+[tool:pytest]
 python_files = test_*.py example_*.py *.ipynb

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -79,7 +79,9 @@ def grid_stationary(xdim=100, ydim=100, maxtime=delta(hours=6)):
     time = np.arange(0., maxtime.total_seconds(), 60., dtype=np.float64)
     U = np.ones((xdim, ydim, 1), dtype=np.float32) * u_0 * np.cos(f * time)
     V = np.ones((xdim, ydim, 1), dtype=np.float32) * -u_0 * np.sin(f * time)
-    return Grid.from_data(U, lon, lat, V, lon, lat, time=time, mesh='flat')
+    return Grid.from_data(np.asarray(U, np.float32), lon, lat,
+                          np.asarray(V, np.float32), lon, lat,
+                          time=time, mesh='flat')
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
@@ -118,7 +120,9 @@ def grid_moving(xdim=100, ydim=100, maxtime=delta(hours=6)):
     time = np.arange(0., maxtime.total_seconds(), 60., dtype=np.float64)
     U = np.ones((xdim, ydim, 1), dtype=np.float32) * u_g + (u_0 - u_g) * np.cos(f * time)
     V = np.ones((xdim, ydim, 1), dtype=np.float32) * -(u_0 - u_g) * np.sin(f * time)
-    return Grid.from_data(U, lon, lat, V, lon, lat, time=time, mesh='flat')
+    return Grid.from_data(np.asarray(U, np.float32), lon, lat,
+                          np.asarray(V, np.float32), lon, lat,
+                          time=time, mesh='flat')
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
@@ -163,7 +167,9 @@ def grid_decaying(xdim=100, ydim=100, maxtime=delta(hours=6)):
         np.exp(-gamma_g * time) + (u_0 - u_g) * np.exp(-gamma * time) * np.cos(f * time)
     V = np.ones((xdim, ydim, 1), dtype=np.float32) * -(u_0 - u_g) *\
         np.exp(-gamma * time) * np.sin(f * time)
-    return Grid.from_data(U, lon, lat, V, lon, lat, time=time, mesh='flat')
+    return Grid.from_data(np.asarray(U, np.float32), lon, lat,
+                          np.asarray(V, np.float32), lon, lat,
+                          time=time, mesh='flat')
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -60,8 +60,9 @@ def test_grid_gradient():
         x = 4
         y = 6
         time = np.linspace(0, 2, 3)
-        field = Field("Test", data=createSimpleGrid(x, y, time), time=time, lon=np.linspace(0, x-1, x),
-                      lat=np.linspace(-y/2, y/2-1, y))
+        field = Field("Test", data=createSimpleGrid(x, y, time), time=time,
+                      lon=np.linspace(0, x-1, x, dtype=np.float32),
+                      lat=np.linspace(-y/2, y/2-1, y, dtype=np.float32))
 
         # Calculate field gradients for testing against numpy gradients.
         grad_fields = field.gradient()

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -235,7 +235,8 @@ def test_random_field(mode, k_sample_p, xdim=20, ydim=20, npart=100):
     P = np.random.uniform(0, 1., size=(xdim, ydim))
     S = np.ones((xdim, ydim), dtype=np.float32)
     grid = Grid.from_data(U, lon, lat, V, lon, lat, mesh='flat',
-                          field_data={'P': P, 'start': S})
+                          field_data={'P': np.asarray(P, dtype=np.float32),
+                                      'start': S})
     pset = grid.ParticleSet(size=npart, pclass=pclass(mode),
                             start_field=grid.start)
     pset.execute(k_sample_p, endtime=1., dt=1.0)
@@ -251,8 +252,8 @@ def test_sampling_out_of_bounds_time(mode, k_sample_p, xdim=10, ydim=10, tdim=10
     U = np.zeros((xdim, ydim, tdim), dtype=np.float32)
     V = np.zeros((xdim, ydim, tdim), dtype=np.float32)
     P = np.ones((xdim, ydim, 1), dtype=np.float32) * time
-    grid = Grid.from_data(U, lon, lat, V, lon, lat, time=time,
-                          mesh='flat', field_data={'P': P})
+    grid = Grid.from_data(U, lon, lat, V, lon, lat, time=time, mesh='flat',
+                          field_data={'P': np.asarray(P, dtype=np.float32)})
     pset = grid.ParticleSet(size=1, pclass=pclass(mode),
                             start=(0.5, 0.5), finish=(0.5, 0.5))
     pset.execute(k_sample_p, starttime=-1.0, endtime=-0.9, dt=0.1)

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -58,7 +58,7 @@ def test_execution_runtime(grid, mode, start, end, substeps, dt, npart=10):
     assert np.allclose(np.array([p.time for p in pset]), end)
 
 
-@pytest.mark.parametrize('mode', ['scipy'])
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_execution_fail_timed(grid, mode, npart=10):
     def TimedFail(particle, grid, time, dt):
         if particle.time >= 10.:

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -7,7 +7,7 @@ ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 
 
 def DoNothing(particle, grid, time, dt):
-    return KernelOp.SUCCESS
+    return KernelOp.Success
 
 
 @pytest.fixture
@@ -59,12 +59,12 @@ def test_execution_runtime(grid, mode, start, end, substeps, dt, npart=10):
 
 
 @pytest.mark.parametrize('mode', ['scipy'])
-def test_execution_fail(grid, mode, npart=10):
+def test_execution_fail_timed(grid, mode, npart=10):
     def TimedFail(particle, grid, time, dt):
         if particle.time >= 10.:
-            return KernelOp.FAILURE
+            return KernelOp.Fail
         else:
-            return KernelOp.SUCCESS
+            return KernelOp.Success
 
     pset = grid.ParticleSet(npart, pclass=ptype[mode],
                             lon=np.linspace(0, 1, npart, dtype=np.float32),

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -1,4 +1,4 @@
-from parcels import Grid, ScipyParticle, JITParticle, KernelOp
+from parcels import Grid, ScipyParticle, JITParticle, ErrorCode
 import numpy as np
 import pytest
 
@@ -7,7 +7,7 @@ ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 
 
 def DoNothing(particle, grid, time, dt):
-    return KernelOp.Success
+    return ErrorCode.Success
 
 
 @pytest.fixture
@@ -62,9 +62,9 @@ def test_execution_runtime(grid, mode, start, end, substeps, dt, npart=10):
 def test_execution_fail_timed(grid, mode, npart=10):
     def TimedFail(particle, grid, time, dt):
         if particle.time >= 10.:
-            return KernelOp.Fail
+            return ErrorCode.Fail
         else:
-            return KernelOp.Success
+            return ErrorCode.Success
 
     pset = grid.ParticleSet(npart, pclass=ptype[mode],
                             lon=np.linspace(0, 1, npart, dtype=np.float32),

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -1,0 +1,58 @@
+from parcels import Grid, ScipyParticle, JITParticle, KernelOp
+import numpy as np
+import pytest
+
+
+ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
+
+
+def DoNothing(particle, grid, time, dt):
+    return KernelOp.SUCCESS
+
+
+@pytest.fixture
+def grid(xdim=20, ydim=20):
+    """ Standard unit mesh grid """
+    lon = np.linspace(0., 1., xdim, dtype=np.float32)
+    lat = np.linspace(0., 1., ydim, dtype=np.float32)
+    U, V = np.meshgrid(lat, lon)
+    return Grid.from_data(np.array(U, dtype=np.float32), lon, lat,
+                          np.array(V, dtype=np.float32), lon, lat,
+                          mesh='flat')
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+@pytest.mark.parametrize('start, end, substeps, dt', [
+    (0., 10., 1, 1.),
+    (0., 10., 4, 1.),
+    (0., 10., 1, 3.),
+    (2., 16., 5, 3.),
+    (20., 10., 4, -1.),
+    (20., -10., 7, -2.),
+])
+def test_execution_endtime(grid, mode, start, end, substeps, dt, npart=10):
+    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+                            lon=np.linspace(0, 1, npart, dtype=np.float32),
+                            lat=np.linspace(1, 0, npart, dtype=np.float32))
+    pset.execute(DoNothing, starttime=start, endtime=end, dt=dt)
+    assert np.allclose(np.array([p.time for p in pset]), end)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+@pytest.mark.parametrize('start, end, substeps, dt', [
+    (0., 10., 1, 1.),
+    (0., 10., 4, 1.),
+    (0., 10., 1, 3.),
+    (2., 16., 5, 3.),
+    (20., 10., 4, -1.),
+    (20., -10., 7, -2.),
+])
+def test_execution_runtime(grid, mode, start, end, substeps, dt, npart=10):
+    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+                            lon=np.linspace(0, 1, npart, dtype=np.float32),
+                            lat=np.linspace(1, 0, npart, dtype=np.float32))
+    t_step = (end - start) / substeps
+    for _ in range(substeps):
+        pset.execute(DoNothing, starttime=start, runtime=t_step, dt=dt)
+        start += t_step
+    assert np.allclose(np.array([p.time for p in pset]), end)

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -62,7 +62,7 @@ def test_execution_runtime(grid, mode, start, end, substeps, dt, npart=10):
 def test_execution_fail_timed(grid, mode, npart=10):
     def TimedFail(particle, grid, time, dt):
         if particle.time >= 10.:
-            return ErrorCode.Fail
+            return ErrorCode.Error
         else:
             return ErrorCode.Success
 


### PR DESCRIPTION
This new feature enables user-level customisation of the error handling procedures in the main kernel loop through JIT and SciPy mode. The core idea is that kernels can now throw different types of errors, eg. `ErrorCode.OutOfBounds` and that the user can specify custom kernels to override the default behaviour to create model-specific recovery behaviour. The recovery kernels themselves are always run in Python and can be injected via the `recovery={Error.MyErrorCode: MyRecoveryKernel}` argument.

Caveats:
* Minor: `OutOfBounds` errors do not propagate the exact sampling location that created the error as SciPy mode does, but the location of the particle at the time. Adding that would require dynamically allocating memory for meta-information, which is left for another PR.
* Major: **Kernel errors do not trigger rollback!** That entails that a kernel that updates particle information before throwing an error results in inconsistent particle data, since time is not incremented the kernel will be applied again once error recovery succeeded. This can be prevented by performing all field sampling before updating particle data, as most built-in kernels do. 