### PR TITLE
Alternative spatial interpolation in JIT

### DIFF
--- a/include/parcels.h
+++ b/include/parcels.h
@@ -6,6 +6,11 @@ typedef enum
     SUCCESS=0, REPEAT=1, DELETE=2, ERROR=3, ERROR_OUT_OF_BOUNDS=4
   } ErrorCode;
 
+typedef enum
+  {
+    LINEAR=0, NEAREST=1
+  } InterpCode;
+
 #define CHECKERROR(res) do {if (res != SUCCESS) return res;} while (0)
 
 typedef struct
@@ -81,13 +86,13 @@ static inline ErrorCode temporal_interpolation_linear(float x, float y, int xi, 
   err = search_linear_double(time, f->tdim, f->time, &(f->tidx));
   if (f->tidx < f->tdim-1 && time > f->time[f->tidx]) {
     t0 = f->time[f->tidx]; t1 = f->time[f->tidx+1];
-    if (interp_method==0){
+    if (interp_method == LINEAR){
       err = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat,
                                           (float**)(data[f->tidx]), &f0);
       err = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat,
                                           (float**)(data[f->tidx+1]), &f1);
     }
-    else if  (interp_method==1){
+    else if  (interp_method == NEAREST){
       err = spatial_interpolation_nearest2D(x, y, i, j, f->xdim, f->lon, f->lat,
                                            (float**)(data[f->tidx]), &f0);
       err = spatial_interpolation_nearest2D(x, y, i, j, f->xdim, f->lon, f->lat,
@@ -99,11 +104,11 @@ static inline ErrorCode temporal_interpolation_linear(float x, float y, int xi, 
     *value = f0 + (f1 - f0) * (float)((time - t0) / (t1 - t0));
     return SUCCESS;
   } else {
-    if (interp_method==0){
+    if (interp_method == LINEAR){
       err = spatial_interpolation_bilinear(x, y, i, j, f->xdim, f->lon, f->lat,
                                           (float**)(data[f->tidx]), value);
     }
-    else if (interp_method==1){
+    else if (interp_method == NEAREST){
       err = spatial_interpolation_nearest2D(x, y, i, j, f->xdim, f->lon, f->lat,
                                            (float**)(data[f->tidx]), value);
     }

--- a/include/parcels.h
+++ b/include/parcels.h
@@ -49,6 +49,20 @@ static inline ErrorCode spatial_interpolation_bilinear(float x, float y, int i, 
   return SUCCESS;
 }
 
+/* Nearest neighbour interpolation routine for 2D grid */
+static inline ErrorCode spatial_interpolation_nearest2D(float x, float y, int i, int j, int xdim,
+                                                        float *lon, float *lat, float **f_data,
+                                                        float *value)
+{
+  /* Cast data array into data[lat][lon] as per NEMO convention */
+  float (*data)[xdim] = (float (*)[xdim]) f_data;
+  int ii, jj;
+  if (x - lon[i] < lon[i+1] - x) {ii = i;} else {ii = i + 1;}
+  if (y - lat[j] < lat[j+1] - y) {jj = j;} else {jj = j + 1;}
+  *value = data[jj][ii];
+  return SUCCESS;
+}
+
 /* Linear interpolation along the time axis */
 static inline ErrorCode temporal_interpolation_linear(float x, float y, int xi, int yi,
                                                       double time, CField *f, float *value)

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -254,7 +254,8 @@ class Field(object):
         out-of-bounds coordinates.
         """
         return RegularGridInterpolator((self.lat, self.lon), self.data[t_idx, :],
-                                       bounds_error=False, fill_value=np.nan, method=self.interp_method)
+                                       bounds_error=False, fill_value=np.nan,
+                                       method=self.interp_method)
 
     def temporal_interpolate_fullfield(self, tidx, time):
         t0 = self.time[tidx-1]
@@ -310,13 +311,10 @@ class Field(object):
         return self.units.to_target(value, x, y)
 
     def ccode_eval(self, var, t, x, y):
-        # Casting interp_method to int as easier to pass on in C-code
-        if self.interp_method is 'linear':
-            interp_method = 0
-        elif self.interp_method is 'nearest':
-            interp_method = 1
+        # Casting interp_methd to int as easier to pass on in C-code
         return "temporal_interpolation_linear(%s, %s, %s, %s, %s, %s, &%s, %s)" \
-            % (x, y, "particle->xi", "particle->yi", t, self.name, var, interp_method)
+            % (x, y, "particle->xi", "particle->yi", t, self.name, var,
+               self.interp_method.upper())
 
     def ccode_convert(self, _, x, y):
         return self.units.ccode_to_target(x, y)

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -310,8 +310,13 @@ class Field(object):
         return self.units.to_target(value, x, y)
 
     def ccode_eval(self, var, t, x, y):
-        return "temporal_interpolation_linear(%s, %s, %s, %s, %s, %s, &%s)" \
-            % (x, y, "particle->xi", "particle->yi", t, self.name, var)
+        # Casting interp_method to int as easier to pass on in C-code
+        if self.interp_method is 'linear':
+            interp_method = 0
+        elif self.interp_method is 'nearest':
+            interp_method = 1
+        return "temporal_interpolation_linear(%s, %s, %s, %s, %s, %s, &%s, %s)" \
+            % (x, y, "particle->xi", "particle->yi", t, self.name, var, interp_method)
 
     def ccode_convert(self, _, x, y):
         return self.units.ccode_to_target(x, y)

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -266,3 +266,20 @@ def test_sampling_out_of_bounds_time(mode, k_sample_p, xdim=10, ydim=10, tdim=10
     assert np.allclose(np.array([p.p for p in pset]), 1.0, rtol=1e-5)
     pset.execute(k_sample_p, starttime=2.0, endtime=2.1, dt=0.1)
     assert np.allclose(np.array([p.p for p in pset]), 1.0, rtol=1e-5)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_nearest_neighbour_interpolation(mode, k_sample_p, xdim=2, ydim=2):
+    lon = np.linspace(0., 1., xdim, dtype=np.float32)
+    lat = np.linspace(0., 1., ydim, dtype=np.float32)
+    U = np.zeros((xdim, ydim), dtype=np.float32)
+    V = np.zeros((xdim, ydim), dtype=np.float32)
+    P = np.zeros((xdim, ydim), dtype=np.float32)
+    P[0, 0] = 1.
+    grid = Grid.from_data(U, lon, lat, V, lon, lat, mesh='flat',
+                          field_data={'P': np.asarray(P, dtype=np.float32)})
+    grid.P.interp_method = 'nearest'
+    pset = grid.ParticleSet(size=1, pclass=pclass(mode),
+                            start=(0.25, 0.25), finish=(0.25, 0.25))
+    pset.execute(k_sample_p, endtime=1, dt=1)
+    assert np.allclose(np.array([p.p for p in pset]), 1.0, rtol=1e-5)

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -99,6 +99,23 @@ def test_grid_sample_eval(grid, xdim=60, ydim=60):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_nearest_neighbour_interpolation(mode, k_sample_p, xdim=2, ydim=2):
+    lon = np.linspace(0., 1., xdim, dtype=np.float32)
+    lat = np.linspace(0., 1., ydim, dtype=np.float32)
+    U = np.zeros((xdim, ydim), dtype=np.float32)
+    V = np.zeros((xdim, ydim), dtype=np.float32)
+    P = np.zeros((xdim, ydim), dtype=np.float32)
+    P[0, 0] = 1.
+    grid = Grid.from_data(U, lon, lat, V, lon, lat, mesh='flat',
+                          field_data={'P': np.asarray(P, dtype=np.float32)})
+    grid.P.interp_method = 'nearest'
+    pset = grid.ParticleSet(size=1, pclass=pclass(mode),
+                            start=(0.25, 0.25), finish=(0.25, 0.25))
+    pset.execute(k_sample_p, endtime=1, dt=1)
+    assert np.allclose(np.array([p.p for p in pset]), 1.0, rtol=1e-5)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_grid_sample_particle(grid, mode, k_sample_uv, npart=120):
     """ Sample the grid using an array of particles.
 
@@ -265,21 +282,4 @@ def test_sampling_out_of_bounds_time(mode, k_sample_p, xdim=10, ydim=10, tdim=10
     pset.execute(k_sample_p, starttime=1.0, endtime=1.1, dt=0.1)
     assert np.allclose(np.array([p.p for p in pset]), 1.0, rtol=1e-5)
     pset.execute(k_sample_p, starttime=2.0, endtime=2.1, dt=0.1)
-    assert np.allclose(np.array([p.p for p in pset]), 1.0, rtol=1e-5)
-
-
-@pytest.mark.parametrize('mode', ['scipy', 'jit'])
-def test_nearest_neighbour_interpolation(mode, k_sample_p, xdim=2, ydim=2):
-    lon = np.linspace(0., 1., xdim, dtype=np.float32)
-    lat = np.linspace(0., 1., ydim, dtype=np.float32)
-    U = np.zeros((xdim, ydim), dtype=np.float32)
-    V = np.zeros((xdim, ydim), dtype=np.float32)
-    P = np.zeros((xdim, ydim), dtype=np.float32)
-    P[0, 0] = 1.
-    grid = Grid.from_data(U, lon, lat, V, lon, lat, mesh='flat',
-                          field_data={'P': np.asarray(P, dtype=np.float32)})
-    grid.P.interp_method = 'nearest'
-    pset = grid.ParticleSet(size=1, pclass=pclass(mode),
-                            start=(0.25, 0.25), finish=(0.25, 0.25))
-    pset.execute(k_sample_p, endtime=1, dt=1)
     assert np.allclose(np.array([p.p for p in pset]), 1.0, rtol=1e-5)

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -99,12 +99,13 @@ def test_grid_sample_eval(grid, xdim=60, ydim=60):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
-def test_nearest_neighbour_interpolation(mode, k_sample_p, xdim=2, ydim=2, npart=81):
-    lon = np.linspace(0., 1., xdim, dtype=np.float32)
-    lat = np.linspace(0., 1., ydim, dtype=np.float32)
-    U = np.zeros((xdim, ydim), dtype=np.float32)
-    V = np.zeros((xdim, ydim), dtype=np.float32)
-    P = np.zeros((xdim, ydim), dtype=np.float32)
+def test_nearest_neighbour_interpolation(mode, k_sample_p, npart=81):
+    dims = (2, 2)
+    lon = np.linspace(0., 1., dims[0], dtype=np.float32)
+    lat = np.linspace(0., 1., dims[1], dtype=np.float32)
+    U = np.zeros(dims, dtype=np.float32)
+    V = np.zeros(dims, dtype=np.float32)
+    P = np.zeros(dims, dtype=np.float32)
     P[0, 0] = 1.
     grid = Grid.from_data(U, lon, lat, V, lon, lat, mesh='flat',
                           field_data={'P': np.asarray(P, dtype=np.float32)})


### PR DESCRIPTION
This PR fixes issue #125 where alternative spatial interpolations (via `Field.interp_method`) will now also work in JIT

It also implements a simple linear nearest neighbour interpolation

**Note that this PR was branched from PR #122, so best to land that one first.**