### PR TITLE
Updating initialisation of netcdf output file

### DIFF
--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -62,15 +62,9 @@ class ParticleFile(object):
         self.lon.units = "degrees_east"
         self.lon.axis = "X"
 
-        self.z = self.dataset.createVariable("z", "f4", ("trajectory", "obs"), fill_value=np.nan)
-        self.z.long_name = ""
-        self.z.standard_name = "depth"
-        self.z.units = "m"
-        self.z.positive = "down"
-
         self.user_vars = []
         for v in particleset.ptype.variables:
-            if v.name in ['time', 'lat', 'lon', 'z']:
+            if v.name in ['time', 'lat', 'lon']:
                 continue
             if v.to_write is True:
                 setattr(self, v.name, self.dataset.createVariable(v.name, "f4", ("trajectory", "obs"), fill_value=0.))
@@ -78,6 +72,10 @@ class ParticleFile(object):
                 getattr(self, v.name).standard_name = v.name
                 getattr(self, v.name).units = "unknown"
                 self.user_vars += [v.name]
+                if v.name in ['z', 'depth']:
+                    getattr(self, v.name).positive = "down"
+                    getattr(self, v.name).units = "m"
+                
 
         self.idx = 0
 
@@ -92,7 +90,6 @@ class ParticleFile(object):
         self.time[:, self.idx] = time
         self.lat[:, self.idx] = np.array([p.lat for p in pset])
         self.lon[:, self.idx] = np.array([p.lon for p in pset])
-        self.z[:, self.idx] = np.zeros(pset.size, dtype=np.float32)
         for var in self.user_vars:
             getattr(self, var)[:, self.idx] = np.array([getattr(p, var) for p in pset])
 

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -75,12 +75,8 @@ class ParticleFile(object):
                 if v.name in ['z', 'depth']:
                     getattr(self, v.name).positive = "down"
                     getattr(self, v.name).units = "m"
-                
 
         self.idx = 0
-
-        if initial_dump:
-            self.write(particleset, 0.)
 
     def __del__(self):
         self.dataset.close()

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -7,7 +7,7 @@ __all__ = ['ParticleFile']
 
 class ParticleFile(object):
 
-    def __init__(self, name, particleset, initial_dump=True):
+    def __init__(self, name, particleset):
         """Initialise netCDF4.Dataset for trajectory output.
 
         The output follows the format outlined in the Discrete
@@ -23,7 +23,6 @@ class ParticleFile(object):
 
         :param name: Basename of the output file
         :param particlset: ParticleSet to output
-        :param initial_dump: Perform initial output at time 0.
         :param user_vars: A list of additional user defined particle variables to write
         """
         self.dataset = netCDF4.Dataset("%s.nc" % name, "w", format="NETCDF4")

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -244,6 +244,11 @@ class ParticleSet(object):
         for p in self:
             p.time = starttime
             p.dt = dt
+
+        # Write initial data to file
+        if output_file:
+            output_file.write(self, starttime)
+
         # Execute time loop in sub-steps (timeleaps)
         timeleaps = int((endtime - starttime) / interval)
         assert(timeleaps >= 0)

--- a/scripts/plotParticles.py
+++ b/scripts/plotParticles.py
@@ -14,7 +14,6 @@ def plotTrajectoriesFile(filename, tracerfile=None, tracerlon='x', tracerlat='y'
     pfile = Dataset(filename, 'r')
     lon = pfile.variables['lon']
     lat = pfile.variables['lat']
-    z = pfile.variables['z']
 
     if(recordedvar is not None):
         record = pfile.variables[recordedvar]
@@ -27,6 +26,7 @@ def plotTrajectoriesFile(filename, tracerfile=None, tracerlon='x', tracerlat='y'
         plt.contourf(np.squeeze(X), np.squeeze(Y), np.squeeze(P))
 
     if mode == '3d':
+        z = pfile.variables['z']
         fig = plt.figure(1)
         ax = fig.gca(projection='3d')
         for p in range(len(lon)):


### PR DESCRIPTION
This PR does two things to the ParticleFile in netcdf
1) Makes sure the first time written out is the `starttime` of the `.execute`, rather than the default 0
2) Does not by default allocate `z` anymore. Depth is now treated as any other variable, that does not need to be written into output