### PR TITLE
Removing grid.fields{} list, as not used

### DIFF
--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -35,7 +35,6 @@ class Grid(object):
         self.V = V
         self.depth = depth
         self.time = time
-        self.fields = fields
 
         # Add additional fields as attributes
         for name, field in fields.items():
@@ -153,6 +152,6 @@ class Grid(object):
         self.U.write(filename, varname='vozocrtx')
         self.V.write(filename, varname='vomecrty')
 
-        for f in self.fields:
-            field = getattr(self, f)
-            field.write(filename)
+        for attr, value in self.__dict__.iteritems():
+            if isinstance(value, Field) and (attr is not 'U') and (attr is not 'V'):
+                value.write(filename)

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -131,6 +131,11 @@ class Grid(object):
         return cls.from_netcdf(filenames, variables=extra_vars,
                                dimensions=dimensions, **kwargs)
 
+    @property
+    def fields(self):
+        """List of fields associated with this grid"""
+        return [v for v in self.__dict__.values() if isinstance(v, Field)]
+
     def add_field(self, field):
         setattr(self, field.name, field)
 
@@ -151,6 +156,6 @@ class Grid(object):
         self.U.write(filename, varname='vozocrtx')
         self.V.write(filename, varname='vomecrty')
 
-        for attr, value in self.__dict__.iteritems():
-            if isinstance(value, Field) and (attr is not 'U') and (attr is not 'V'):
-                value.write(filename)
+        for v in self.fields:
+            if (v.name is not 'U') and (v.name is not 'V'):
+                v.write(filename)

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -132,7 +132,6 @@ class Grid(object):
                                dimensions=dimensions, **kwargs)
 
     def add_field(self, field):
-        self.fields.update({field.name: field})
         setattr(self, field.name, field)
 
     def ParticleSet(self, *args, **kwargs):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -46,6 +46,16 @@ def test_grid_from_nemo(xdim, ydim, tmpdir, filename='test_nemo'):
     assert np.allclose(grid.V.data[0, :], v_t, rtol=1e-12)
 
 
+@pytest.mark.parametrize('xdim', [100, 200])
+@pytest.mark.parametrize('ydim', [100, 200])
+def test_add_field(xdim, ydim):
+    u, v, lon, lat, depth, time = generate_grid(xdim, ydim)
+    grid = Grid.from_data(u, lon, lat, v, lon, lat, depth, time)
+    field = Field('newfld', grid.U.data, grid.U.lon, grid.U.lat)
+    grid.add_field(field)
+    assert grid.newfld.data.shape == grid.U.data.shape
+
+
 def createSimpleGrid(x, y, time):
     field = np.zeros((time.size, x, y), dtype=np.float32)
     ltri = np.triu_indices(n=x, m=y)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -48,12 +48,14 @@ def test_grid_from_nemo(xdim, ydim, tmpdir, filename='test_nemo'):
 
 @pytest.mark.parametrize('xdim', [100, 200])
 @pytest.mark.parametrize('ydim', [100, 200])
-def test_add_field(xdim, ydim):
+def test_add_field(xdim, ydim, tmpdir, filename='test_add'):
+    filepath = tmpdir.join(filename)
     u, v, lon, lat, depth, time = generate_grid(xdim, ydim)
     grid = Grid.from_data(u, lon, lat, v, lon, lat, depth, time)
     field = Field('newfld', grid.U.data, grid.U.lon, grid.U.lat)
     grid.add_field(field)
     assert grid.newfld.data.shape == grid.U.data.shape
+    grid.write(filepath)
 
 
 def createSimpleGrid(x, y, time):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -67,21 +67,21 @@ def createSimpleGrid(x, y, time):
 
 
 def test_grid_gradient():
-        x = 4
-        y = 6
-        time = np.linspace(0, 2, 3)
-        field = Field("Test", data=createSimpleGrid(x, y, time), time=time,
-                      lon=np.linspace(0, x-1, x, dtype=np.float32),
-                      lat=np.linspace(-y/2, y/2-1, y, dtype=np.float32))
+    x = 4
+    y = 6
+    time = np.linspace(0, 2, 3)
+    field = Field("Test", data=createSimpleGrid(x, y, time), time=time,
+                  lon=np.linspace(0, x-1, x, dtype=np.float32),
+                  lat=np.linspace(-y/2, y/2-1, y, dtype=np.float32))
 
-        # Calculate field gradients for testing against numpy gradients.
-        grad_fields = field.gradient()
+    # Calculate field gradients for testing against numpy gradients.
+    grad_fields = field.gradient()
 
-        # Create numpy fields.
-        r = 6.371e6
-        deg2rd = np.pi / 180.
-        numpy_grad_fields = np.gradient(np.transpose(field.data[0, :, :]), (r * np.diff(field.lat) * deg2rd)[0])
+    # Create numpy fields.
+    r = 6.371e6
+    deg2rd = np.pi / 180.
+    numpy_grad_fields = np.gradient(np.transpose(field.data[0, :, :]), (r * np.diff(field.lat) * deg2rd)[0])
 
-        # Arbitrarily set relative tolerance to 1%.
-        assert np.allclose(grad_fields[0].data[0, :, :], np.array(np.transpose(numpy_grad_fields[0])), rtol=1e-2)  # Field gradient dx.
-        assert np.allclose(grad_fields[1].data[0, :, :], np.array(np.transpose(numpy_grad_fields[1])), rtol=1e-2)  # Field gradient dy.
+    # Arbitrarily set relative tolerance to 1%.
+    assert np.allclose(grad_fields[0].data[0, :, :], np.array(np.transpose(numpy_grad_fields[0])), rtol=1e-2)  # Field gradient dx.
+    assert np.allclose(grad_fields[1].data[0, :, :], np.array(np.transpose(numpy_grad_fields[1])), rtol=1e-2)  # Field gradient dy.


### PR DESCRIPTION
Fixed an issue where there were two places where `extra_fields` were stored. Sometimes they were stored in `grid.fields{*}`, and sometimes in `grid.*`. 

Since the latter one is more widespread and simpler, and to avoid confusion, this PR removes `grid.fields{*}`