### PR TITLE
Grid.constant implementation

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -1,3 +1,4 @@
+from parcels.field import Field
 import ast
 import cgen as c
 from collections import OrderedDict
@@ -13,8 +14,12 @@ class IntrinsicNode(ast.AST):
 
 class GridNode(IntrinsicNode):
     def __getattr__(self, attr):
-        return FieldNode(getattr(self.obj, attr),
-                         ccode="%s->%s" % (self.ccode, attr))
+        if isinstance(getattr(self.obj, attr), Field):
+            return FieldNode(getattr(self.obj, attr),
+                             ccode="%s->%s" % (self.ccode, attr))
+        else:
+            return ConstNode(getattr(self.obj, attr),
+                             ccode="%s" % (attr))
 
 
 class FieldNode(IntrinsicNode):
@@ -27,6 +32,11 @@ class FieldEvalNode(IntrinsicNode):
         self.field = field
         self.args = args
         self.var = var
+
+
+class ConstNode(IntrinsicNode):
+    def __getitem__(self, attr):
+        return attr
 
 
 class MathNode(IntrinsicNode):
@@ -249,6 +259,7 @@ class KernelGenerator(ast.NodeVisitor):
         self.field_args = OrderedDict()
         # Hack alert: JIT requires U field to update grid indexes
         self.field_args['U'] = grid.U
+        self.const_args = OrderedDict()
 
     def generate(self, py_ast, funcvars):
         # Untangle Pythonic tuple-assignment statements
@@ -285,6 +296,8 @@ class KernelGenerator(ast.NodeVisitor):
                 c.Value("double", "time"), c.Value("float", "dt")]
         for field, _ in self.field_args.items():
             args += [c.Pointer(c.Value("CField", "%s" % field))]
+        for const, _ in self.const_args.items():
+            args += [c.Value("float", const)]
 
         # Create function body as C-code object
         body = [stmt.ccode for stmt in node.body]
@@ -471,6 +484,9 @@ class KernelGenerator(ast.NodeVisitor):
         """Record intrinsic fields used in kernel"""
         self.field_args[node.obj.name] = node.obj
 
+    def visit_ConstNode(self, node):
+        self.const_args[node.ccode] = node.obj
+
     def visit_FieldEvalNode(self, node):
         self.visit(node.field)
         self.visit(node.args)
@@ -501,7 +517,7 @@ class LoopGenerator(object):
         self.grid = grid
         self.ptype = ptype
 
-    def generate(self, funcname, field_args, kernel_ast):
+    def generate(self, funcname, field_args, const_args, kernel_ast):
         ccode = []
 
         # Add include for Parcels and math header
@@ -521,7 +537,9 @@ class LoopGenerator(object):
                 c.Value("double", "endtime"), c.Value("float", "dt")]
         for field, _ in field_args.items():
             args += [c.Pointer(c.Value("CField", "%s" % field))]
-        fargs_str = ", ".join(['particles[p].time', 'sign * __dt'] + list(field_args.keys()))
+        for const, _ in const_args.items():
+            args += [c.Value("float", const)]
+        fargs_str = ", ".join(['particles[p].time', 'sign * __dt'] + list(field_args.keys()) + list(const_args.keys()))
         # Inner loop nest for forward runs
         sign = c.Assign("sign", "dt > 0. ? 1. : -1.")
         dt_pos = c.Assign("__dt", "fmin(fabs(particles[p].dt), fabs(endtime - particles[p].time))")

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -475,3 +475,6 @@ class Constant(object):
     def __init__(self, name, data):
         self.name = name
         self.data = data
+
+    def __getitem__(self, key):
+        return self.data[key]

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -17,7 +17,7 @@ except:
     plt = None
 
 
-__all__ = ['CentralDifferences', 'Field', 'Geographic', 'GeographicPolar', 'Constant']
+__all__ = ['CentralDifferences', 'Field', 'Geographic', 'GeographicPolar']
 
 
 class FieldSamplingError(RuntimeError):
@@ -463,18 +463,3 @@ class FileBuffer(object):
             return self.dataset[self.dimensions['time']].calendar
         except:
             return 'standard'
-
-
-class Constant(object):
-    """Class that holds constants used in kernels.
-
-    :param name: Name of the constant
-    :param data: float64 data
-    """
-
-    def __init__(self, name, data):
-        self.name = name
-        self.data = data
-
-    def __getitem__(self, key):
-        return self.data[key]

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -17,7 +17,7 @@ except:
     plt = None
 
 
-__all__ = ['CentralDifferences', 'Field', 'Geographic', 'GeographicPolar']
+__all__ = ['CentralDifferences', 'Field', 'Geographic', 'GeographicPolar', 'Constant']
 
 
 class FieldSamplingError(RuntimeError):
@@ -463,3 +463,15 @@ class FileBuffer(object):
             return self.dataset[self.dimensions['time']].calendar
         except:
             return 'standard'
+
+
+class Constant(object):
+    """Class that holds constants used in kernels.
+
+    :param name: Name of the constant
+    :param data: float64 data
+    """
+
+    def __init__(self, name, data):
+        self.name = name
+        self.data = data

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -136,8 +136,8 @@ class Grid(object):
         self.fields.update({field.name: field})
         setattr(self, field.name, field)
 
-    def add_constant(self, constant):
-        setattr(self, constant.name, constant)
+    def add_constant(self, name, value):
+        setattr(self, name, value)
 
     def ParticleSet(self, *args, **kwargs):
         return ParticleSet(*args, grid=self, **kwargs)

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -136,6 +136,9 @@ class Grid(object):
         self.fields.update({field.name: field})
         setattr(self, field.name, field)
 
+    def add_constant(self, constant):
+        setattr(self, constant.name, constant)
+
     def ParticleSet(self, *args, **kwargs):
         return ParticleSet(*args, grid=self, **kwargs)
 

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -80,8 +80,9 @@ class Kernel(object):
             kernel_ccode = kernelgen.generate(deepcopy(self.py_ast),
                                               self.funcvars)
             self.field_args = kernelgen.field_args
+            self.const_args = kernelgen.const_args
             loopgen = LoopGenerator(grid, ptype)
-            self.ccode = loopgen.generate(self.funcname, self.field_args,
+            self.ccode = loopgen.generate(self.funcname, self.field_args, self.const_args,
                                           kernel_ccode)
 
             basename = path.join(get_cache_dir(), self._cache_key)
@@ -111,6 +112,7 @@ class Kernel(object):
     def execute_jit(self, pset, endtime, dt):
         """Invokes JIT engine to perform the core update loop"""
         fargs = [byref(f.ctypes_struct) for f in self.field_args.values()]
+        fargs += [c_float(f) for f in self.const_args.values()]
         particle_data = pset._particle_data.ctypes.data_as(c_void_p)
         self._function(c_int(len(pset)), particle_data,
                        c_double(endtime), c_float(dt), *fargs)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -87,7 +87,6 @@ def test_grid_gradient():
     deg2rd = np.pi / 180.
     numpy_grad_fields = np.gradient(np.transpose(field.data[0, :, :]), (r * np.diff(field.lat) * deg2rd)[0])
 
-
     # Arbitrarily set relative tolerance to 1%.
     assert np.allclose(grad_fields[0].data[0, :, :], np.array(np.transpose(numpy_grad_fields[0])),
                        rtol=1e-2)  # Field gradient dx.

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -81,7 +81,7 @@ def test_grid_gradient():
 
 
 def addConst(particle, grid, time, dt):
-    particle.lon = particle.lon + grid.movewest
+    particle.lon = particle.lon + grid.movewest + grid.moveeast
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
@@ -89,10 +89,12 @@ def test_grid_constant(mode):
     u, v, lon, lat, depth, time = generate_grid(100, 100)
     grid = Grid.from_data(u, lon, lat, v, lon, lat, depth, time)
     westval = -0.2
+    eastval = 0.3
     grid.add_constant('movewest', westval)
+    grid.add_constant('moveeast', eastval)
     assert grid.movewest == westval
 
     pset = grid.ParticleSet(size=1, pclass=ptype[mode],
                             start=(0.5, 0.5), finish=(0.5, 0.5))
     pset.execute(pset.Kernel(addConst), dt=1, runtime=1)
-    assert abs(pset[0].lon - (0.5 + westval)) < 1e-4
+    assert abs(pset[0].lon - (0.5 + westval + eastval)) < 1e-4

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,7 +1,10 @@
-from parcels import Grid
-from parcels.field import Field
+from parcels import Grid, ScipyParticle, JITParticle
+from parcels.field import Field, Constant
 import numpy as np
 import pytest
+
+
+ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 
 
 def generate_grid(xdim, ydim, zdim=1, tdim=1):
@@ -75,3 +78,23 @@ def test_grid_gradient():
         # Arbitrarily set relative tolerance to 1%.
         assert np.allclose(grad_fields[0].data[0, :, :], np.array(np.transpose(numpy_grad_fields[0])), rtol=1e-2)  # Field gradient dx.
         assert np.allclose(grad_fields[1].data[0, :, :], np.array(np.transpose(numpy_grad_fields[1])), rtol=1e-2)  # Field gradient dy.
+
+
+@pytest.fixture
+def addConst(particle, grid, time, dt):
+    particle.lon = particle.lon + grid.movewest
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_grid_constant(mode):
+    u, v, lon, lat, depth, time = generate_grid(100, 100)
+    grid = Grid.from_data(u, lon, lat, v, lon, lat, depth, time)
+    constval = 0.2
+    const = Constant('movewest', constval)
+    grid.add_constant(const)
+    assert grid.movewest.data == constval
+
+    pset = grid.ParticleSet(size=1, pclass=ptype[mode],
+                            start=(0.5, 0.5), finish=(0.5, 0.5))
+    pset.execute(pset.Kernel(addConst), dt=1, runtime=1)
+    assert pset[0].lon == 0.5 + constval

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -82,19 +82,19 @@ def test_grid_gradient():
 
 @pytest.fixture
 def addConst(particle, grid, time, dt):
-    particle.lon = particle.lon + grid.movewest
+    particle.lon = particle.lon + grid.movewest[0]
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_grid_constant(mode):
     u, v, lon, lat, depth, time = generate_grid(100, 100)
     grid = Grid.from_data(u, lon, lat, v, lon, lat, depth, time)
-    constval = 0.2
+    constval = [0.2]
     const = Constant('movewest', constval)
     grid.add_constant(const)
-    assert grid.movewest.data == constval
+    assert grid.movewest[0] == constval[0]
 
     pset = grid.ParticleSet(size=1, pclass=ptype[mode],
                             start=(0.5, 0.5), finish=(0.5, 0.5))
     pset.execute(pset.Kernel(addConst), dt=1, runtime=1)
-    assert pset[0].lon == 0.5 + constval
+    assert pset[0].lon == 0.5 + constval[0]


### PR DESCRIPTION
Implementation of grid.constants. Now done using simple `setattr(grid, constant_name, constant_value)` method (rather than full `Constant` class), as that makes `__eval__` for constants in scipy trivial (e.g. `particle.lon = particle.lon + grid.moveeast` is simple if `grid.moveeast` is a float)

Implementation also works for JIT, and also for multiple constants (as in `test_grid_constant()`)

Ideally merge this PR before the periodic boundary condition one (PR #133), as having `grid.constants` can make the `periodicBC` kernel in `tutorial_periodic_boundaries` much more elegant (using `grid.westboundary` and `grid.eastboundary`, which can be automatically set in `grid.add_periodic_halo()`)