### PR TITLE
Removing grid.time and grid.depth

### DIFF
--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -33,8 +33,6 @@ class Grid(object):
     def __init__(self, U, V, depth, time, fields={}):
         self.U = U
         self.V = V
-        self.depth = depth
-        self.time = time
 
         # Add additional fields as attributes
         for name, field in fields.items():

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -114,7 +114,7 @@ class ParticleSet(object):
             assert(size == len(lon) and size == len(lat))
 
             for i in range(size):
-                self.particles[i] = pclass(lon[i], lat[i], grid=grid, cptr=cptr(i), time=grid.time[0])
+                self.particles[i] = pclass(lon[i], lat[i], grid=grid, cptr=cptr(i), time=grid.U.time[0])
         else:
             raise ValueError("Latitude and longitude required for generating ParticleSet")
 
@@ -215,12 +215,12 @@ class ParticleSet(object):
         if runtime is not None and endtime is not None:
             raise RuntimeError('Only one of (endtime, runtime) can be specified')
         if starttime is None:
-            starttime = self.grid.time[0] if dt > 0 else self.grid.time[-1]
+            starttime = self.grid.U.time[0] if dt > 0 else self.grid.U.time[-1]
         if runtime is not None:
             endtime = starttime + runtime
         else:
             if endtime is None:
-                endtime = self.grid.time[-1] if dt > 0 else self.grid.time[0]
+                endtime = self.grid.U.time[-1] if dt > 0 else self.grid.U.time[0]
         if interval is None:
             interval = endtime - starttime
 


### PR DESCRIPTION
Since `grids` are simply a collection of `fields`, it doesn’t make sense to have both a `grid.time` and a `grid.`(field)`.time`, where (field) is any of 'U', 'V' etc. Same for `grid.depth` and `grid.`(field)`.depth`. We already store `lon` and `lat` on the fields only, the same should be done with `depth` and `time`.

This also allows for easier mixing of fields of different shapes/dimensions (e.g. #41), and is important also in relation to the implementation of vertical velocities (#39)