### PR TITLE
Subsetting from NetCDF

### DIFF
--- a/examples/example_globcurrent.py
+++ b/examples/example_globcurrent.py
@@ -1,18 +1,19 @@
 from parcels import Grid, ScipyParticle, JITParticle, AdvectionRK4
 from datetime import timedelta as delta
+import numpy as np
 import pytest
 
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 
 
-def set_globcurrent_grid():
+def set_globcurrent_grid(indices={}):
     filenames = {'U': "examples/GlobCurrent_example_data/20*-GLOBCURRENT-L4-CUReul_hs-ALT_SUM-v02.0-fv01.0.nc",
                  'V': "examples/GlobCurrent_example_data/20*-GLOBCURRENT-L4-CUReul_hs-ALT_SUM-v02.0-fv01.0.nc"}
     variables = {'U': 'eastward_eulerian_current_velocity', 'V': 'northward_eulerian_current_velocity'}
     dimensions = {'lat': 'lat', 'lon': 'lon',
                   'time': 'time'}
-    return Grid.from_netcdf(filenames, variables, dimensions)
+    return Grid.from_netcdf(filenames, variables, dimensions, indices)
 
 
 def test_globcurrent_grid():
@@ -23,6 +24,13 @@ def test_globcurrent_grid():
     assert(grid.V.lon.size == 81)
     assert(grid.V.lat.size == 41)
     assert(grid.V.data.shape == (365, 41, 81))
+
+    indices = {'lon': [5], 'lat': range(20, 30)}
+    gridsub = set_globcurrent_grid(indices=indices)
+    assert np.allclose(gridsub.U.lon, grid.U.lon[indices['lon']])
+    assert np.allclose(gridsub.U.lat, grid.U.lat[indices['lat']])
+    assert np.allclose(gridsub.V.lon, grid.V.lon[indices['lon']])
+    assert np.allclose(gridsub.V.lat, grid.V.lat[indices['lat']])
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -181,12 +181,8 @@ class Field(object):
         if not isinstance(filenames, Iterable):
             filenames = [filenames]
         with FileBuffer(filenames[0], dimensions) as filebuffer:
-            lon = filebuffer.lon
-            indslon = indices['lon'] if 'lon' in indices else range(lon.size)
-            lon = lon[indslon]
-            lat = filebuffer.lat
-            indslat = indices['lat'] if 'lat' in indices else range(lat.size)
-            lat = lat[indslat]
+            lon, indslon = filebuffer.read_dimension('lon', indices)
+            lat, indslat = filebuffer.read_dimension('lat', indices)
             # Assign time_units if the time dimension has units and calendar
             time_units = filebuffer.time_units
             calendar = filebuffer.calendar
@@ -424,6 +420,11 @@ class FileBuffer(object):
 
     def __exit__(self, type, value, traceback):
         self.dataset.close()
+
+    def read_dimension(self, dimname, indices):
+        dim = getattr(self, dimname)
+        inds = indices[dimname] if dimname in indices else range(dim.size)
+        return dim[inds], inds
 
     @property
     def lon(self):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -424,6 +424,8 @@ class FileBuffer(object):
     def read_dimension(self, dimname, indices):
         dim = getattr(self, dimname)
         inds = indices[dimname] if dimname in indices else range(dim.size)
+        if not isinstance(inds, list):
+            raise RuntimeError('Index for '+dimname+' needs to be a list')
         return dim[inds], inds
 
     @property

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -168,7 +168,7 @@ class Field(object):
         self.time_index_cache = LRUCache(maxsize=2)
 
     @classmethod
-    def from_netcdf(cls, name, dimensions, filenames, indices, **kwargs):
+    def from_netcdf(cls, name, dimensions, filenames, indices={}, **kwargs):
         """Create field from netCDF file using NEMO conventions
 
         :param name: Name of the field to create

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -168,11 +168,12 @@ class Field(object):
         self.time_index_cache = LRUCache(maxsize=2)
 
     @classmethod
-    def from_netcdf(cls, name, dimensions, filenames, **kwargs):
+    def from_netcdf(cls, name, dimensions, filenames, indices, **kwargs):
         """Create field from netCDF file using NEMO conventions
 
         :param name: Name of the field to create
         :param dimensions: Variable names for the relevant dimensions
+        :param indices: indices for each dimension to read from file
         :param dataset: Single or multiple netcdf.Dataset object(s)
         containing field data. If multiple datasets are present they
         will be concatenated along the time axis
@@ -181,7 +182,11 @@ class Field(object):
             filenames = [filenames]
         with FileBuffer(filenames[0], dimensions) as filebuffer:
             lon = filebuffer.lon
+            indslon = indices['lon'] if 'lon' in indices else range(lon.size)
+            lon = lon[indslon]
             lat = filebuffer.lat
+            indslat = indices['lat'] if 'lat' in indices else range(lat.size)
+            lat = lat[indslat]
             # Assign time_units if the time dimension has units and calendar
             time_units = filebuffer.time_units
             calendar = filebuffer.calendar
@@ -205,6 +210,8 @@ class Field(object):
         tidx = 0
         for tslice, fname in zip(timeslices, filenames):
             with FileBuffer(fname, dimensions) as filebuffer:
+                filebuffer.indslat = indslat
+                filebuffer.indslon = indslon
                 data[tidx:(tidx+len(tslice)), 0, :, :] = filebuffer.data[:, :, :]
             tidx += len(tslice)
         return cls(name, data, lon, lat, depth=depth, time=time,
@@ -431,9 +438,9 @@ class FileBuffer(object):
     @property
     def data(self):
         if len(self.dataset[self.dimensions['data']].shape) == 3:
-            return self.dataset[self.dimensions['data']][:, :, :]
+            return self.dataset[self.dimensions['data']][:, self.indslat, self.indslon]
         else:
-            return self.dataset[self.dimensions['data']][:, 0, :, :]
+            return self.dataset[self.dimensions['data']][:, 0, self.indslat, self.indslon]
 
     @property
     def time(self):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -210,6 +210,10 @@ class Field(object):
                 filebuffer.indslon = indslon
                 data[tidx:(tidx+len(tslice)), 0, :, :] = filebuffer.data[:, :, :]
             tidx += len(tslice)
+        # Time indexing after the fact only
+        if 'time' in indices:
+            time = time[indices['time']]
+            data = data[indices['time'], :, :, :]
         return cls(name, data, lon, lat, depth=depth, time=time,
                    time_origin=time_origin, **kwargs)
 

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -78,7 +78,7 @@ class Grid(object):
         return cls(ufield, vfield, depth, time, fields=fields)
 
     @classmethod
-    def from_netcdf(cls, filenames, variables, dimensions,
+    def from_netcdf(cls, filenames, variables, dimensions, indices={},
                     mesh='spherical', **kwargs):
         """Initialises grid data from files using NEMO conventions.
 
@@ -88,6 +88,9 @@ class Grid(object):
         names in the netCDF file(s).
         :param dimensions: Dictionary mapping data dimensions (lon,
         lat, depth, time, data) to dimensions in the netCF file(s).
+        :param indices: Optional dictionary of indices for each dimension
+        to read from file(s), to allow for reading of subset of data.
+        Default is to read the full extent of each dimension.
         :param mesh: String indicating the type of mesh coordinates and
                      units used during velocity interpolation:
                        * sperical (default): Lat and lon in degree, with a
@@ -109,7 +112,7 @@ class Grid(object):
                 if not fp.exists():
                     raise IOError("Grid file not found: %s" % str(fp))
             dimensions['data'] = name
-            fields[var] = Field.from_netcdf(var, dimensions, paths,
+            fields[var] = Field.from_netcdf(var, dimensions, paths, indices,
                                             units=units[var], **kwargs)
         u = fields.pop('U')
         v = fields.pop('V')
@@ -117,18 +120,21 @@ class Grid(object):
 
     @classmethod
     def from_nemo(cls, basename, uvar='vozocrtx', vvar='vomecrty',
-                  extra_vars={}, **kwargs):
+                  indices={}, extra_vars={}, **kwargs):
         """Initialises grid data from files using NEMO conventions.
 
         :param basename: Base name of the file(s); may contain
         wildcards to indicate multiple files.
+        :param indices: Optional dictionary of indices for each dimension
+        to read from file(s), to allow for reading of subset of data.
+        Default is to read the full extent of each dimension.
         """
         dimensions = {'lon': 'nav_lon', 'lat': 'nav_lat',
                       'depth': 'depth', 'time': 'time_counter'}
         extra_vars.update({'U': uvar, 'V': vvar})
         filenames = dict([(v, str(path.local("%s%s.nc" % (basename, v))))
                           for v in extra_vars.keys()])
-        return cls.from_netcdf(filenames, variables=extra_vars,
+        return cls.from_netcdf(filenames, indices=indices, variables=extra_vars,
                                dimensions=dimensions, **kwargs)
 
     @property

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -66,6 +66,14 @@ def test_grid_from_file_subsets(indslon, indslat, tmpdir, filename='test_subsets
     assert np.allclose(gridsub.V.data, gridfull.V.data[ixgrid])
 
 
+@pytest.mark.parametrize('indstime', [range(10, 20), [4]])
+def test_moving_eddies_file_subsettime(indstime, gridfile='examples/MovingEddies_data/moving_eddies'):
+    gridfull = Grid.from_nemo(gridfile, extra_vars={'P': 'P'})
+    gridsub = Grid.from_nemo(gridfile, extra_vars={'P': 'P'}, indices={'time': indstime})
+    assert np.allclose(gridsub.P.time, gridfull.P.time[indstime])
+    assert np.allclose(gridsub.P.data, gridfull.P.data[indstime, :, :])
+
+
 @pytest.mark.parametrize('xdim', [100, 200])
 @pytest.mark.parametrize('ydim', [100, 200])
 def test_add_field(xdim, ydim, tmpdir, filename='test_add'):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -46,6 +46,26 @@ def test_grid_from_nemo(xdim, ydim, tmpdir, filename='test_nemo'):
     assert np.allclose(grid.V.data[0, :], v_t, rtol=1e-12)
 
 
+@pytest.mark.parametrize('indslon', [range(10, 20), [1]])
+@pytest.mark.parametrize('indslat', [range(30, 60), [22]])
+def test_grid_from_file_subsets(indslon, indslat, tmpdir, filename='test_subsets'):
+    """ Test for subsetting grid from file using indices dict. """
+    u, v, lon, lat, depth, time = generate_grid(100, 100)
+    filepath = tmpdir.join(filename)
+    gridfull = Grid.from_data(u, lon, lat, v, lon, lat, depth, time)
+    gridfull.write(filepath)
+    indices = {'lon': indslon, 'lat': indslat}
+    gridsub = Grid.from_nemo(filepath, indices=indices)
+    assert np.allclose(gridsub.U.lon, gridfull.U.lon[indices['lon']])
+    assert np.allclose(gridsub.U.lat, gridfull.U.lat[indices['lat']])
+    assert np.allclose(gridsub.V.lon, gridfull.V.lon[indices['lon']])
+    assert np.allclose(gridsub.V.lat, gridfull.V.lat[indices['lat']])
+
+    ixgrid = np.ix_([0], indices['lat'], indices['lon'])
+    assert np.allclose(gridsub.U.data, gridfull.U.data[ixgrid])
+    assert np.allclose(gridsub.V.data, gridfull.V.data[ixgrid])
+
+
 @pytest.mark.parametrize('xdim', [100, 200])
 @pytest.mark.parametrize('ydim', [100, 200])
 def test_add_field(xdim, ydim, tmpdir, filename='test_add'):


### PR DESCRIPTION
Adding option to only read in subset of the data of netCDF files, by providing `indices` dictionary to `grid.from_file` and/or `grid.from_nemo`. This fixes issue #75 and addresses issue #106 (more to come on that in a PR in a few days)

This PR currently only works for `lon`, `lat` and `time`. `depth` will be added once we have support for vertical velocities (issue #39).