### PR TITLE
Particle set size as optional argument

### DIFF
--- a/examples/PARCELStutorial.ipynb
+++ b/examples/PARCELStutorial.ipynb
@@ -377,8 +377,7 @@
    },
    "outputs": [],
    "source": [
-    "pset = grid.ParticleSet(size=2,             # the number of particles\n",
-    "                        pclass=JITParticle, # the type of particles (JITParticle or ScipyParticle)\n",
+    "pset = grid.ParticleSet(pclass=JITParticle, # the type of particles (JITParticle or ScipyParticle)\n",
     "                        lon=[ 3.3,  3.3],   # a vector of release longitudes \n",
     "                        lat=[46.0, 47.8])   # a vector of release latitudes"
    ]
@@ -1247,7 +1246,7 @@
     }
    ],
    "source": [
-    "pset = grid.ParticleSet(size=2, pclass=JITParticle, lon=[3.3, 3.3], lat=[46.0, 47.8])\n",
+    "pset = grid.ParticleSet(pclass=JITParticle, lon=[3.3, 3.3], lat=[46.0, 47.8])\n",
     "\n",
     "k_WestVel = pset.Kernel(WestVel)       # casting the WestVel function to a kernel object\n",
     "\n",
@@ -1395,8 +1394,8 @@
    },
    "outputs": [],
    "source": [
-    "pset = grid.ParticleSet(size=5,           # releasing 5 particles\n",
-    "                        pclass=JITParticle,\n",
+    "pset = grid.ParticleSet(pclass=JITParticle,\n",
+    "                        size=5,           # releasing 5 particles\n",
     "                        start=(28, -33),  # releasing on a line: the start longitude and latitude\n",
     "                        finish=(30, -33)) # releasing on a line: the end longitude and latitude"
    ]
@@ -1537,7 +1536,7 @@
    "outputs": [],
    "source": [
     "grid = Grid.from_nemo(\"MovingEddies_data/moving_eddies\")\n",
-    "pset = grid.ParticleSet(size=2, pclass=DistParticle, lon=[3.3, 3.3], lat=[46.0, 47.8])"
+    "pset = grid.ParticleSet(pclass=DistParticle, lon=[3.3, 3.3], lat=[46.0, 47.8])"
    ]
   },
   {

--- a/examples/example_decaying_moving_eddy.py
+++ b/examples/example_decaying_moving_eddy.py
@@ -49,7 +49,7 @@ def true_values(t, x_0, y_0):  # Calculate the expected values for particles at 
 
 
 def decaying_moving_example(grid, mode='scipy', method=AdvectionRK4):
-    pset = grid.ParticleSet(size=1, pclass=ptype[mode], lon=start_lon, lat=start_lat)
+    pset = grid.ParticleSet(pclass=ptype[mode], lon=start_lon, lat=start_lat)
 
     endtime = delta(days=2)
     dt = delta(minutes=5)

--- a/examples/example_delay_start.py
+++ b/examples/example_delay_start.py
@@ -23,7 +23,7 @@ def test_delay_start_example(mode, npart=10, show_movie=False):
     y = (grid.U.lat[0] + x, grid.U.lat[-1] - x)  # latitude range, including offsets
 
     lat = np.linspace(y[0], y[1], npart, dtype=np.float32)
-    pset = grid.ParticleSet(0, lon=[], lat=[], pclass=ptype[mode])
+    pset = grid.ParticleSet(lon=[], lat=[], pclass=ptype[mode])
 
     delaytime = delta(hours=1)  # delay time between particle releases
     for t in range(npart):

--- a/examples/example_globcurrent.py
+++ b/examples/example_globcurrent.py
@@ -40,7 +40,7 @@ def test_globcurrent_particles(mode):
     lonstart = [25]
     latstart = [-35]
 
-    pset = grid.ParticleSet(len(lonstart), pclass=ptype[mode], lon=lonstart, lat=latstart)
+    pset = grid.ParticleSet(pclass=ptype[mode], lon=lonstart, lat=latstart)
 
     pset.execute(AdvectionRK4, runtime=delta(days=1), dt=delta(minutes=5),
                  interval=delta(hours=1))

--- a/examples/example_ofam.py
+++ b/examples/example_ofam.py
@@ -32,7 +32,7 @@ def test_ofam_particles(mode):
     lonstart = [180]
     latstart = [10]
 
-    pset = grid.ParticleSet(len(lonstart), pclass=ptype[mode], lon=lonstart, lat=latstart)
+    pset = grid.ParticleSet(pclass=ptype[mode], lon=lonstart, lat=latstart)
 
     pset.execute(AdvectionRK4, runtime=delta(days=10), dt=delta(minutes=5),
                  interval=delta(hours=6))

--- a/examples/example_peninsula.py
+++ b/examples/example_peninsula.py
@@ -98,7 +98,7 @@ def pensinsula_example(grid, npart, mode='jit', degree=1,
     # Initialise particles
     x = 3. * (1. / 1.852 / 60)  # 3 km offset from boundary
     y = (grid.U.lat[0] + x, grid.U.lat[-1] - x)  # latitude range, including offsets
-    pset = grid.ParticleSet(npart, pclass=MyParticle, start=(x, y[0]), finish=(x, y[1]))
+    pset = grid.ParticleSet(size=npart, pclass=MyParticle, start=(x, y[0]), finish=(x, y[1]))
     for particle in pset:
         particle.p_start = grid.P[0., particle.lon, particle.lat]
 

--- a/examples/tutorial_periodic_boundaries.ipynb
+++ b/examples/tutorial_periodic_boundaries.ipynb
@@ -127,7 +127,7 @@
     }
    ],
    "source": [
-    "pset = grid.ParticleSet(10, pclass=JITParticle, start=(0.7, 0.1), finish=(0.7, 0.4))\n",
+    "pset = grid.ParticleSet(pclass=JITParticle, size=10, start=(0.7, 0.1), finish=(0.7, 0.4))\n",
     "output_file = pset.ParticleFile(name=\"PeriodicParticle\")\n",
     "pset.execute(AdvectionRK4 + pset.Kernel(periodicBC), \n",
     "             runtime=delta(hours=24), dt=delta(minutes=5), \n",

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -146,8 +146,8 @@ class Grid(object):
     def add_constant(self, name, value):
         setattr(self, name, value)
 
-    def ParticleSet(self, *args, **kwargs):
-        return ParticleSet(*args, grid=self, **kwargs)
+    def ParticleSet(self, **kwargs):
+        return ParticleSet(grid=self, **kwargs)
 
     def add_periodic_halo(self, zonal=False, meridional=False, halosize=5):
         """Add a 'halo' to all Fields in a grid, through extending the Field (and lon/lat)

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -69,22 +69,25 @@ class ParticleSet(object):
     Please note that this currently only supports fixed size particle
     sets.
 
-    :param size: Initial size of particle set
     :param grid: Grid object from which to sample velocity
     :param pclass: Optional class object that defines custom particle
-    :param lon: List of initial longitude values for particles
-    :param lat: List of initial latitude values for particles
+    :param lon: Optional list of initial longitude values for particles
+    :param lat: Optional list of initial latitude values for particles
     :param start: Optional starting point for initilisation of particles
                  on a straight line. Use start/finish instead of lat/lon.
     :param finish: Optional end point for initilisation of particles on a
                  straight line. Use start/finish instead of lat/lon.
     :param start_field: Optional field for initialising particles stochastically
                  according to the presented density field. Use instead of lat/lon.
+    :param size: Optional initial size of particle set, only required when using
+                 start/finish or start_field arguments
     """
 
-    def __init__(self, size, grid, pclass=JITParticle,
-                 lon=None, lat=None, start=None, finish=None, start_field=None):
+    def __init__(self, grid, pclass=JITParticle, lon=None, lat=None,
+                 start=None, finish=None, start_field=None, size=None):
         self.grid = grid
+        size = len(lon) if size is None else size
+
         self.particles = np.empty(size, dtype=pclass)
         self.ptype = pclass.getPType()
         self.kernel = None
@@ -102,11 +105,12 @@ class ParticleSet(object):
 
         if start is not None and finish is not None:
             # Initialise from start/finish coordinates with equidistant spacing
-            assert(lon is None and lat is None)
+            assert(lon is None and lat is None and size is not None)
             lon = np.linspace(start[0], finish[0], size, dtype=np.float32)
             lat = np.linspace(start[1], finish[1], size, dtype=np.float32)
 
         if start_field is not None:
+            assert(size is not None)
             lon, lat = positions_from_density_field(size, start_field)
 
         if lon is not None and lat is not None:

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -37,7 +37,7 @@ def test_advection_zonal(lon, lat, mode, npart=10):
     V = np.zeros((lon.size, lat.size), dtype=np.float32)
     grid = Grid.from_data(U, lon, lat, V, lon, lat, mesh='spherical')
 
-    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset = grid.ParticleSet(pclass=ptype[mode],
                             lon=np.zeros(npart, dtype=np.float32) + 20.,
                             lat=np.linspace(0, 80, npart, dtype=np.float32))
     pset.execute(AdvectionRK4, endtime=delta(hours=2), dt=delta(seconds=30))
@@ -53,7 +53,7 @@ def test_advection_meridional(lon, lat, mode, npart=10):
     V = np.ones((lon.size, lat.size), dtype=np.float32)
     grid = Grid.from_data(U, lon, lat, V, lon, lat, mesh='spherical')
 
-    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset = grid.ParticleSet(pclass=ptype[mode],
                             lon=np.linspace(-60, 60, npart, dtype=np.float32),
                             lat=np.linspace(0, 30, npart, dtype=np.float32))
     delta_lat = np.diff(np.array([p.lat for p in pset]))
@@ -81,7 +81,7 @@ def test_advection_periodic_zonal(mode, xdim=100, ydim=100, halosize=3):
     grid.add_periodic_halo(zonal=True, halosize=halosize)
     assert(len(grid.U.lon) == xdim + 2 * halosize)
 
-    pset = grid.ParticleSet(1, pclass=ptype[mode], lon=[0.5], lat=[0.5])
+    pset = grid.ParticleSet(pclass=ptype[mode], lon=[0.5], lat=[0.5])
     pset.execute(AdvectionRK4 + pset.Kernel(periodicBC), endtime=delta(hours=20), dt=delta(seconds=30))
     assert abs(pset[0].lon - 0.15) < 0.1
 
@@ -92,7 +92,7 @@ def test_advection_periodic_meridional(mode, xdim=100, ydim=100):
     grid.add_periodic_halo(meridional=True)
     assert(len(grid.U.lat) == ydim + 10)  # default halo size is 5 grid points
 
-    pset = grid.ParticleSet(1, pclass=ptype[mode], lon=[0.5], lat=[0.5])
+    pset = grid.ParticleSet(pclass=ptype[mode], lon=[0.5], lat=[0.5])
     pset.execute(AdvectionRK4 + pset.Kernel(periodicBC), endtime=delta(hours=20), dt=delta(seconds=30))
     assert abs(pset[0].lat - 0.15) < 0.1
 
@@ -106,7 +106,7 @@ def test_advection_periodic_zonal_meridional(mode, xdim=100, ydim=100):
     assert np.allclose(np.diff(grid.U.lat), grid.U.lat[1]-grid.U.lat[0], rtol=0.001)
     assert np.allclose(np.diff(grid.U.lon), grid.U.lon[1]-grid.U.lon[0], rtol=0.001)
 
-    pset = grid.ParticleSet(1, pclass=ptype[mode], lon=[0.4], lat=[0.5])
+    pset = grid.ParticleSet(pclass=ptype[mode], lon=[0.4], lat=[0.5])
     pset.execute(AdvectionRK4 + pset.Kernel(periodicBC), endtime=delta(hours=20), dt=delta(seconds=30))
     assert abs(pset[0].lon - 0.05) < 0.1
     assert abs(pset[0].lat - 0.15) < 0.1
@@ -144,7 +144,7 @@ def test_stationary_eddy(grid_stationary, mode, method, rtol, npart=1):
     grid = grid_stationary
     lon = np.linspace(12000, 21000, npart, dtype=np.float32)
     lat = np.linspace(12500, 12500, npart, dtype=np.float32)
-    pset = grid.ParticleSet(size=npart, pclass=ptype[mode], lon=lon, lat=lat)
+    pset = grid.ParticleSet(pclass=ptype[mode], lon=lon, lat=lat)
     endtime = delta(hours=6).total_seconds()
     pset.execute(kernel[method], dt=delta(minutes=3), endtime=endtime)
     exp_lon = [truth_stationary(x, y, endtime)[0] for x, y, in zip(lon, lat)]
@@ -185,7 +185,7 @@ def test_moving_eddy(grid_moving, mode, method, rtol, npart=1):
     grid = grid_moving
     lon = np.linspace(12000, 21000, npart, dtype=np.float32)
     lat = np.linspace(12500, 12500, npart, dtype=np.float32)
-    pset = grid.ParticleSet(size=npart, pclass=ptype[mode], lon=lon, lat=lat)
+    pset = grid.ParticleSet(pclass=ptype[mode], lon=lon, lat=lat)
     endtime = delta(hours=6).total_seconds()
     pset.execute(kernel[method], dt=delta(minutes=3), endtime=endtime)
     exp_lon = [truth_moving(x, y, endtime)[0] for x, y, in zip(lon, lat)]
@@ -232,7 +232,7 @@ def test_decaying_eddy(grid_decaying, mode, method, rtol, npart=1):
     grid = grid_decaying
     lon = np.linspace(12000, 21000, npart, dtype=np.float32)
     lat = np.linspace(12500, 12500, npart, dtype=np.float32)
-    pset = grid.ParticleSet(size=npart, pclass=ptype[mode], lon=lon, lat=lat)
+    pset = grid.ParticleSet(pclass=ptype[mode], lon=lon, lat=lat)
     endtime = delta(hours=6).total_seconds()
     pset.execute(kernel[method], dt=delta(minutes=3), endtime=endtime)
     exp_lon = [truth_decaying(x, y, endtime)[0] for x, y, in zip(lon, lat)]

--- a/tests/test_grid_sampling.py
+++ b/tests/test_grid_sampling.py
@@ -129,12 +129,12 @@ def test_grid_sample_particle(grid, mode, k_sample_uv, npart=120):
     lon = np.linspace(-170, 170, npart, dtype=np.float32)
     lat = np.linspace(-80, 80, npart, dtype=np.float32)
 
-    pset = grid.ParticleSet(npart, pclass=pclass(mode), lon=lon,
+    pset = grid.ParticleSet(pclass=pclass(mode), lon=lon,
                             lat=np.zeros(npart, dtype=np.float32) + 70.)
     pset.execute(pset.Kernel(k_sample_uv), endtime=1., dt=1.)
     assert np.allclose(np.array([p.v for p in pset]), lon, rtol=1e-6)
 
-    pset = grid.ParticleSet(npart, pclass=pclass(mode), lat=lat,
+    pset = grid.ParticleSet(pclass=pclass(mode), lat=lat,
                             lon=np.zeros(npart, dtype=np.float32) - 45.)
     pset.execute(pset.Kernel(k_sample_uv), endtime=1., dt=1.)
     assert np.allclose(np.array([p.u for p in pset]), lat, rtol=1e-6)
@@ -147,12 +147,12 @@ def test_grid_sample_geographic(grid_geometric, mode, k_sample_uv, npart=120):
     lon = np.linspace(-170, 170, npart, dtype=np.float32)
     lat = np.linspace(-80, 80, npart, dtype=np.float32)
 
-    pset = grid.ParticleSet(npart, pclass=pclass(mode), lon=lon,
+    pset = grid.ParticleSet(pclass=pclass(mode), lon=lon,
                             lat=np.zeros(npart, dtype=np.float32) + 70.)
     pset.execute(pset.Kernel(k_sample_uv), endtime=1., dt=1.)
     assert np.allclose(np.array([p.v for p in pset]), lon, rtol=1e-6)
 
-    pset = grid.ParticleSet(npart, pclass=pclass(mode), lat=lat,
+    pset = grid.ParticleSet(pclass=pclass(mode), lat=lat,
                             lon=np.zeros(npart, dtype=np.float32) - 45.)
     pset.execute(pset.Kernel(k_sample_uv), endtime=1., dt=1.)
     assert np.allclose(np.array([p.u for p in pset]), lat, rtol=1e-6)
@@ -165,12 +165,12 @@ def test_grid_sample_geographic_polar(grid_geometric_polar, mode, k_sample_uv, n
     lon = np.linspace(-170, 170, npart, dtype=np.float32)
     lat = np.linspace(-80, 80, npart, dtype=np.float32)
 
-    pset = grid.ParticleSet(npart, pclass=pclass(mode), lon=lon,
+    pset = grid.ParticleSet(pclass=pclass(mode), lon=lon,
                             lat=np.zeros(npart, dtype=np.float32) + 70.)
     pset.execute(pset.Kernel(k_sample_uv), endtime=1., dt=1.)
     assert np.allclose(np.array([p.v for p in pset]), lon, rtol=1e-6)
 
-    pset = grid.ParticleSet(npart, pclass=pclass(mode), lat=lat,
+    pset = grid.ParticleSet(pclass=pclass(mode), lat=lat,
                             lon=np.zeros(npart, dtype=np.float32) - 45.)
     pset.execute(pset.Kernel(k_sample_uv), endtime=1., dt=1.)
     # Note: 1.e-2 is a very low rtol, so there seems to be a rather
@@ -197,7 +197,7 @@ def test_meridionalflow_sperical(mode, xdim=100, ydim=200):
     lonstart = [0, 45]
     latstart = [0, 45]
     endtime = delta(hours=24)
-    pset = grid.ParticleSet(2, pclass=pclass(mode), lon=lonstart, lat=latstart)
+    pset = grid.ParticleSet(pclass=pclass(mode), lon=lonstart, lat=latstart)
     pset.execute(pset.Kernel(AdvectionRK4), endtime=endtime, dt=delta(hours=1))
 
     assert(pset[0].lat - (latstart[0] + endtime.total_seconds() * maxvel / 1852 / 60) < 1e-4)
@@ -228,7 +228,7 @@ def test_zonalflow_sperical(mode, k_sample_p, xdim=100, ydim=200):
     lonstart = [0, 45]
     latstart = [0, 45]
     endtime = delta(hours=24)
-    pset = grid.ParticleSet(2, pclass=pclass(mode), lon=lonstart, lat=latstart)
+    pset = grid.ParticleSet(pclass=pclass(mode), lon=lonstart, lat=latstart)
     pset.execute(pset.Kernel(AdvectionRK4) + k_sample_p,
                  endtime=endtime, dt=delta(hours=1))
 

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -34,7 +34,7 @@ def grid(xdim=20, ydim=20):
     (20., -10., 7, -2.),
 ])
 def test_execution_endtime(grid, mode, start, end, substeps, dt, npart=10):
-    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset = grid.ParticleSet(pclass=ptype[mode],
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.linspace(1, 0, npart, dtype=np.float32))
     pset.execute(DoNothing, starttime=start, endtime=end, dt=dt)
@@ -51,7 +51,7 @@ def test_execution_endtime(grid, mode, start, end, substeps, dt, npart=10):
     (20., -10., 7, -2.),
 ])
 def test_execution_runtime(grid, mode, start, end, substeps, dt, npart=10):
-    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset = grid.ParticleSet(pclass=ptype[mode],
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.linspace(1, 0, npart, dtype=np.float32))
     t_step = (end - start) / substeps
@@ -69,7 +69,7 @@ def test_execution_fail_timed(grid, mode, npart=10):
         else:
             return ErrorCode.Success
 
-    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset = grid.ParticleSet(pclass=ptype[mode],
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.linspace(1, 0, npart, dtype=np.float32))
     error_thrown = False
@@ -90,7 +90,7 @@ def test_execution_fail_python_exception(grid, mode, npart=10):
         else:
             return ErrorCode.Success
 
-    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset = grid.ParticleSet(pclass=ptype[mode],
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.linspace(1, 0, npart, dtype=np.float32))
     error_thrown = False
@@ -109,7 +109,7 @@ def test_execution_fail_out_of_bounds(grid, mode, npart=10):
         grid.U[time, particle.lon + 0.1, particle.lat]
         particle.lon += 0.1
 
-    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset = grid.ParticleSet(pclass=ptype[mode],
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.linspace(1, 0, npart, dtype=np.float32))
     error_thrown = False
@@ -133,7 +133,7 @@ def test_execution_recover_out_of_bounds(grid, mode, npart=2):
 
     lon = np.linspace(0.05, 0.95, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)
-    pset = grid.ParticleSet(npart, pclass=ptype[mode], lon=lon, lat=lat)
+    pset = grid.ParticleSet(pclass=ptype[mode], lon=lon, lat=lat)
     pset.execute(MoveRight, starttime=0., endtime=10., dt=1.,
                  recovery={ErrorCode.ErrorOutOfBounds: MoveLeft})
     assert len(pset) == npart
@@ -152,7 +152,7 @@ def test_execution_delete_out_of_bounds(grid, mode, npart=10):
 
     lon = np.linspace(0.05, 0.95, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)
-    pset = grid.ParticleSet(npart, pclass=ptype[mode], lon=lon, lat=lat)
+    pset = grid.ParticleSet(pclass=ptype[mode], lon=lon, lat=lat)
     pset.execute(MoveRight, starttime=0., endtime=10., dt=1.,
                  recovery={ErrorCode.ErrorOutOfBounds: DeleteMe})
     assert len(pset) == 0

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -38,7 +38,7 @@ def test_expression_int(grid, mode, name, expr, result, npart=10):
     """ Test basic arithmetic expressions """
     class TestParticle(ptype[mode]):
         p = Variable('p', dtype=np.float32)
-    pset = grid.ParticleSet(npart, pclass=TestParticle,
+    pset = grid.ParticleSet(pclass=TestParticle,
                             lon=np.linspace(0., 1., npart, dtype=np.float32),
                             lat=np.zeros(npart, dtype=np.float32) + 0.5)
     pset.execute(expr_kernel('Test%s' % name, pset, expr), endtime=1., dt=1.)
@@ -56,7 +56,7 @@ def test_expression_float(grid, mode, name, expr, result, npart=10):
     """ Test basic arithmetic expressions """
     class TestParticle(ptype[mode]):
         p = Variable('p', dtype=np.float32)
-    pset = grid.ParticleSet(npart, pclass=TestParticle,
+    pset = grid.ParticleSet(pclass=TestParticle,
                             lon=np.linspace(0., 1., npart, dtype=np.float32),
                             lat=np.zeros(npart, dtype=np.float32) + 0.5)
     pset.execute(expr_kernel('Test%s' % name, pset, expr), endtime=1., dt=1.)
@@ -79,7 +79,7 @@ def test_expression_bool(grid, mode, name, expr, result, npart=10):
     """ Test basic arithmetic expressions """
     class TestParticle(ptype[mode]):
         p = Variable('p', dtype=np.float32)
-    pset = grid.ParticleSet(npart, pclass=TestParticle,
+    pset = grid.ParticleSet(pclass=TestParticle,
                             lon=np.linspace(0., 1., npart, dtype=np.float32),
                             lat=np.zeros(npart, dtype=np.float32) + 0.5)
     pset.execute(expr_kernel('Test%s' % name, pset, expr), endtime=1., dt=1.)
@@ -108,7 +108,7 @@ def test_random_float(grid, mode, rngfunc, rngargs, npart=10):
     """ Test basic random number generation """
     class TestParticle(ptype[mode]):
         p = Variable('p', dtype=np.float32 if rngfunc == 'randint' else np.float32)
-    pset = grid.ParticleSet(npart, pclass=TestParticle,
+    pset = grid.ParticleSet(pclass=TestParticle,
                             lon=np.linspace(0., 1., npart, dtype=np.float32),
                             lat=np.zeros(npart, dtype=np.float32) + 0.5)
     series = random_series(npart, rngfunc, rngargs, mode)

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -21,7 +21,7 @@ def grid(xdim=100, ydim=100):
 def test_pset_create_lon_lat(grid, mode, npart=100):
     lon = np.linspace(0, 1, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)
-    pset = grid.ParticleSet(npart, lon=lon, lat=lat, pclass=ptype[mode])
+    pset = grid.ParticleSet(lon=lon, lat=lat, pclass=ptype[mode])
     assert np.allclose([p.lon for p in pset], lon, rtol=1e-12)
     assert np.allclose([p.lat for p in pset], lat, rtol=1e-12)
 
@@ -30,7 +30,7 @@ def test_pset_create_lon_lat(grid, mode, npart=100):
 def test_pset_create_line(grid, mode, npart=100):
     lon = np.linspace(0, 1, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)
-    pset = grid.ParticleSet(npart, start=(0, 1), finish=(1, 0), pclass=ptype[mode])
+    pset = grid.ParticleSet(size=npart, start=(0, 1), finish=(1, 0), pclass=ptype[mode])
     assert np.allclose([p.lon for p in pset], lon, rtol=1e-12)
     assert np.allclose([p.lat for p in pset], lat, rtol=1e-12)
 
@@ -41,7 +41,7 @@ def test_pset_create_field(grid, mode, npart=100):
     shape = (grid.U.lon.size, grid.U.lat.size)
     K = Field('K', lon=grid.U.lon, lat=grid.U.lat,
               data=np.ones(shape, dtype=np.float32))
-    pset = grid.ParticleSet(npart, pclass=ptype[mode], start_field=K)
+    pset = grid.ParticleSet(size=npart, pclass=ptype[mode], start_field=K)
     assert (np.array([p.lon for p in pset]) <= 1.).all()
     assert (np.array([p.lon for p in pset]) >= 0.).all()
     assert (np.array([p.lat for p in pset]) <= 1.).all()
@@ -52,7 +52,7 @@ def test_pset_create_field(grid, mode, npart=100):
 def test_pset_access(grid, mode, npart=100):
     lon = np.linspace(0, 1, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)
-    pset = grid.ParticleSet(npart, lon=lon, lat=lat, pclass=ptype[mode])
+    pset = grid.ParticleSet(lon=lon, lat=lat, pclass=ptype[mode])
     assert(pset.size == 100)
     assert np.allclose([pset[i].lon for i in range(pset.size)], lon, rtol=1e-12)
     assert np.allclose([pset[i].lat for i in range(pset.size)], lat, rtol=1e-12)
@@ -68,7 +68,7 @@ def test_pset_custom_ptype(grid, mode, npart=100):
             self.p = 0.33
             self.n = 2
 
-    pset = grid.ParticleSet(npart, pclass=TestParticle,
+    pset = grid.ParticleSet(pclass=TestParticle,
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.linspace(1, 0, npart, dtype=np.float32))
     assert(pset.size == 100)
@@ -81,7 +81,7 @@ def test_pset_custom_ptype(grid, mode, npart=100):
 def test_pset_add_explicit(grid, mode, npart=100):
     lon = np.linspace(0, 1, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)
-    pset = grid.ParticleSet(0, lon=[], lat=[], pclass=ptype[mode])
+    pset = grid.ParticleSet(lon=[], lat=[], pclass=ptype[mode])
     for i in range(npart):
         particle = ptype[mode](lon=lon[i], lat=lat[i], grid=grid)
         pset.add(particle)
@@ -94,7 +94,7 @@ def test_pset_add_explicit(grid, mode, npart=100):
 def test_pset_add_shorthand(grid, mode, npart=100):
     lon = np.linspace(0, 1, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)
-    pset = grid.ParticleSet(0, lon=[], lat=[], pclass=ptype[mode])
+    pset = grid.ParticleSet(lon=[], lat=[], pclass=ptype[mode])
     for i in range(npart):
         pset += ptype[mode](lon=lon[i], lat=lat[i], grid=grid)
     assert(pset.size == 100)
@@ -107,7 +107,7 @@ def test_pset_add_execute(grid, mode, npart=10):
     def AddLat(particle, grid, time, dt):
         particle.lat += 0.1
 
-    pset = grid.ParticleSet(0, lon=[], lat=[], pclass=ptype[mode])
+    pset = grid.ParticleSet(lon=[], lat=[], pclass=ptype[mode])
     for i in range(npart):
         pset += ptype[mode](lon=0.1, lat=0.1, grid=grid)
     for _ in range(3):
@@ -117,10 +117,10 @@ def test_pset_add_execute(grid, mode, npart=10):
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pset_merge_inplace(grid, mode, npart=100):
-    pset1 = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset1 = grid.ParticleSet(pclass=ptype[mode],
                              lon=np.linspace(0, 1, npart, dtype=np.float32),
                              lat=np.linspace(1, 0, npart, dtype=np.float32))
-    pset2 = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset2 = grid.ParticleSet(pclass=ptype[mode],
                              lon=np.linspace(0, 1, npart, dtype=np.float32),
                              lat=np.linspace(0, 1, npart, dtype=np.float32))
     assert(pset1.size == 100)
@@ -132,10 +132,10 @@ def test_pset_merge_inplace(grid, mode, npart=100):
 @pytest.mark.xfail(reason="ParticleSet duplication has not been implemented yet")
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pset_merge_duplicate(grid, mode, npart=100):
-    pset1 = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset1 = grid.ParticleSet(pclass=ptype[mode],
                              lon=np.linspace(0, 1, npart, dtype=np.float32),
                              lat=np.linspace(1, 0, npart, dtype=np.float32))
-    pset2 = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset2 = grid.ParticleSet(pclass=ptype[mode],
                              lon=np.linspace(0, 1, npart, dtype=np.float32),
                              lat=np.linspace(0, 1, npart, dtype=np.float32))
     pset3 = pset1 + pset2
@@ -148,7 +148,7 @@ def test_pset_merge_duplicate(grid, mode, npart=100):
 def test_pset_remove_index(grid, mode, npart=100):
     lon = np.linspace(0, 1, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)
-    pset = grid.ParticleSet(npart, lon=lon, lat=lat, pclass=ptype[mode])
+    pset = grid.ParticleSet(lon=lon, lat=lat, pclass=ptype[mode])
     for ilon, ilat in zip(lon[::-1], lat[::-1]):
         p = pset.remove(-1)
         assert(p.lon == ilon)
@@ -161,7 +161,7 @@ def test_pset_remove_index(grid, mode, npart=100):
 def test_pset_remove_particle(grid, mode, npart=100):
     lon = np.linspace(0, 1, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)
-    pset = grid.ParticleSet(npart, lon=lon, lat=lat, pclass=ptype[mode])
+    pset = grid.ParticleSet(lon=lon, lat=lat, pclass=ptype[mode])
     for ilon, ilat in zip(lon[::-1], lat[::-1]):
         p = pset.remove(pset[-1])
         assert(p.lon == ilon)
@@ -175,7 +175,7 @@ def test_pset_remove_kernel(grid, mode, npart=100):
         if particle.lon >= .4:
             particle.delete()
 
-    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset = grid.ParticleSet(pclass=ptype[mode],
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.linspace(1, 0, npart, dtype=np.float32))
     pset.execute(pset.Kernel(DeleteKernel), starttime=0., endtime=1., dt=1.0)
@@ -187,7 +187,7 @@ def test_pset_multi_execute(grid, mode, npart=10, n=5):
     def AddLat(particle, grid, time, dt):
         particle.lat += 0.1
 
-    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset = grid.ParticleSet(pclass=ptype[mode],
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.zeros(npart, dtype=np.float32))
     k_add = pset.Kernel(AddLat)
@@ -201,7 +201,7 @@ def test_pset_multi_execute_delete(grid, mode, npart=10, n=5):
     def AddLat(particle, grid, time, dt):
         particle.lat += 0.1
 
-    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset = grid.ParticleSet(pclass=ptype[mode],
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.zeros(npart, dtype=np.float32))
     k_add = pset.Kernel(AddLat)
@@ -213,7 +213,7 @@ def test_pset_multi_execute_delete(grid, mode, npart=10, n=5):
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_density(grid, mode, npart=10):
-    pset = grid.ParticleSet(npart, pclass=ptype[mode],
+    pset = grid.ParticleSet(pclass=ptype[mode],
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=0.5*np.ones(npart, dtype=np.float32))
     arr = pset.density(area_scale=False)

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -23,7 +23,7 @@ def test_variable_init(grid, mode, npart=10):
         p_float = Variable('p_float', dtype=np.float32, initial=10.)
         p_double = Variable('p_double', dtype=np.float64, initial=11.)
         p_int = Variable('p_int', dtype=np.int32, initial=12.)
-    pset = grid.ParticleSet(npart, pclass=TestParticle,
+    pset = grid.ParticleSet(pclass=TestParticle,
                             lon=np.linspace(0, 1, npart, dtype=np.float32),
                             lat=np.linspace(1, 0, npart, dtype=np.float32))
     assert np.array([isinstance(p.p_float, np.float32) for p in pset]).all()
@@ -53,7 +53,7 @@ def test_variable_init_relative(grid, mode, npart=10):
             self.p_offset += 2.
     lon = np.linspace(0, 1, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)
-    pset = grid.ParticleSet(npart, pclass=TestParticle, lon=lon, lat=lat)
+    pset = grid.ParticleSet(pclass=TestParticle, lon=lon, lat=lat)
     # Adjust base variable to test for aliasing effects
     for p in pset:
         p.p_base += 3.


### PR DESCRIPTION
Since the size of the `ParticleSet` can be obtained from the length of the `lon` and `lat` vector on `ParticleSet.__init__`, it doesn’t need to be a compulsory argument.

The PR makes `size` an optional argument, only required when using `start`/`finish` or `start_field` arguments. 

Note that this required a lot of small changes in the `tests/*.py` and `examples/*.py` files, as almost every call to `ParticleSet` assumed `size` a compulsory argument