### PR TITLE
make time steps integers

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -102,7 +102,7 @@ def createSimpleGrid(x, y, time):
 def test_grid_gradient():
     x = 4
     y = 6
-    time = np.linspace(0, 2, 3)
+    time = np.linspace(0, 2, 3, dtype=np.int)
     field = Field("Test", data=createSimpleGrid(x, y, time), time=time,
                   lon=np.linspace(0, x-1, x, dtype=np.float32),
                   lat=np.linspace(-y/2, y/2-1, y, dtype=np.float32))


### PR DESCRIPTION
at test_grid.py:98, the time step is used as an array index. However line 105 of the same file creates the time steps as floats. On sufficiently recent numpy versions, this is an error. This commit fixes this.