### PR TITLE
Fixing a bug when netcdf4 calendars are not 'proleptic_gregorian' or …

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -495,6 +495,7 @@ class FileBuffer(object):
         self.filename = filename
         self.dimensions = dimensions  # Dict with dimension keyes for file data
         self.dataset = None
+        self.calendar_warning_given = False
 
     def __enter__(self):
         self.dataset = Dataset(str(self.filename), 'r', format="NETCDF4")
@@ -552,6 +553,12 @@ class FileBuffer(object):
     def calendar(self):
         """ Derive calendar if the time dimension has calendar """
         try:
-            return self.dataset[self.dimensions['time']].calendar
+            calendar = self.dataset[self.dimensions['time']].calendar
+            if calendar is ('proleptic_gregorian' or 'standard' or 'gregorian'):
+                return calendar
+            else:
+                # Other calendars means the time can't be converted to datetime object
+                # See http://unidata.github.io/netcdf4-python/#netCDF4.num2date
+                return 'standard'
         except:
             return 'standard'


### PR DESCRIPTION
…'standard' or 'gregorian'

Netcdf4 can only cast times to date time objects if calendars are either 'proleptic_gregorian' or 'standard' or 'gregorian’. In all other cases, the time are stored as netcdf_datetime objects, which don’t allow addition or subtraction.

For parcels to work, time needs to be a proper date time, so now falling back to ‘standard’ calendar if the real calendar is something else