### PR TITLE
Fixed a bug for the parameter show_time in particleset.show()

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -271,7 +271,7 @@ class ParticleSet(object):
             if output_file:
                 output_file.write(self, leaptime)
             if show_movie:
-                self.show(field=show_movie, t=leaptime)
+                self.show(field=show_movie, show_time=leaptime)
             leaptime += interval
             self.kernel.execute(self, endtime=leaptime, dt=dt,
                                 recovery=recovery)


### PR DESCRIPTION
The parameter `show_time` in `ParticleSet.show()` was still `t`, a left-over of PR #145

Thanks @mlange05 for reporting!