### PR TITLE
Graceful failing if matplotlib or Basemap is not installed

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -404,7 +404,8 @@ class Field(object):
             import matplotlib.animation as animation_plt
             from matplotlib import rc
         except:
-            raise RuntimeError("Visualisation not possible: matplotlib not found!")
+            print("Visualisation is not possible. Matplotlib not found.")
+            return
 
         if with_particles or (not animation):
             idx = self.time_index(show_time)
@@ -495,7 +496,6 @@ class FileBuffer(object):
         self.filename = filename
         self.dimensions = dimensions  # Dict with dimension keyes for file data
         self.dataset = None
-        self.calendar_warning_given = False
 
     def __enter__(self):
         self.dataset = Dataset(str(self.filename), 'r', format="NETCDF4")

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -295,11 +295,13 @@ class ParticleSet(object):
         try:
             import matplotlib.pyplot as plt
         except:
-            plt = None
+            print("Visualisation is not possible. Matplotlib not found.")
+            return
         try:
             from mpl_toolkits.basemap import Basemap
         except:
             Basemap = None
+
         plon = np.array([p.lon for p in self])
         plat = np.array([p.lat for p in self])
         show_time = self[0].time if show_time is None else show_time
@@ -315,8 +317,6 @@ class ParticleSet(object):
         else:
             latN, latS, lonE, lonW = (-1, 0, -1, 0)
         if field is not 'vector':
-            if plt is None:
-                raise RuntimeError("Visualisation not possible: matplotlib not found!")
             plt.ion()
             plt.clf()
             if particles:
@@ -341,9 +341,9 @@ class ParticleSet(object):
             ylbl = 'Meridional distance [m]' if type(self.grid.U.units) is UnitConverter else 'Latitude [degrees]'
             plt.xlabel(xlbl)
             plt.ylabel(ylbl)
+        elif Basemap is None:
+            print("Visualisation is not possible. Basemap not found.")
         else:
-            if Basemap is None:
-                raise RuntimeError("Visualisation not possible: Basemap module not found!")
             time_origin = self.grid.U.time_origin
             idx = self.grid.U.time_index(show_time)
             U = np.array(self.grid.U.temporal_interpolate_fullfield(idx, show_time))

--- a/scripts/plotParticles.py
+++ b/scripts/plotParticles.py
@@ -1,15 +1,22 @@
 #!/usr/bin/env python
 from netCDF4 import Dataset
 import numpy as np
-import matplotlib.pyplot as plt
 from argparse import ArgumentParser
-import matplotlib.animation as animation
-from matplotlib import rc
+try:
+    import matplotlib.pyplot as plt
+    import matplotlib.animation as animation
+    from matplotlib import rc
+except:
+    plt = None
 
 
 def plotTrajectoriesFile(filename, tracerfile=None, tracerlon='x', tracerlat='y',
                          tracerfield='P', recordedvar=None, mode='2d'):
     """Quick and simple plotting of PARCELS trajectories"""
+
+    if plt is None:
+        print("Visualisation is not possible. Matplotlib not found.")
+        return
 
     pfile = Dataset(filename, 'r')
     lon = pfile.variables['lon']


### PR DESCRIPTION
Rather than throwing errors, Parcels now displays a message when matplotlib or Basemap are not installed. This means tests don’t fail on machines without these modules pre-installed

See also #148. Thanks to @dham for reporting this Issue