### PR TITLE
Multiple small setup fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
     - conda update --yes conda
 
 install:
-    - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy netcdf4 matplotlib basemap
+    - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy hdf4 netcdf4 matplotlib basemap
     - pip install --upgrade pip
     - pip install -r requirements.txt
     - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
     - conda update --yes conda
 
 install:
-    - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy netcdf4 pandas matplotlib basemap
+    - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy netcdf4 matplotlib basemap
     - pip install --upgrade pip
     - pip install -r requirements.txt
     - git submodule update --init --recursive

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ pymbolic
 cgen
 cachetools>=1.0.0
 xray>=0.5.1
-pandas>=0.18.1
 six>=1.10.0
 enum34
 progressbar2

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
 try:
-    from setuptools import setup, Extension
+    from setuptools import setup, find_packages
 except ImportError:
     from distutils.core import setup
-    from distutils.extension import Extension
 import numpy as np
 
 setup(name='parcels',
-      version = '0.0.1',
-      description = """Framework for Lagrangian tracking of virtual
+      version='0.0.1',
+      description="""Framework for Lagrangian tracking of virtual
       ocean particles in the petascale age.""",
-      author = "Imperial College London",
-      packages = ['parcels'],
+      author="Imperial College London",
+      packages=['parcels'],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(name='parcels',
       description="""Framework for Lagrangian tracking of virtual
       ocean particles in the petascale age.""",
       author="Imperial College London",
-      packages=['parcels'],
+      packages=find_packages(exclude=['docs', 'examples', 'indlude', 'scripts', 'tests']),
 )


### PR DESCRIPTION
This merge:
* Fixes Travis installation troubles relating to netCDF and HDF4
* Removes the outdated `pandas` dependency
* Fixes `setup.py` to honour sub-packages like `parcels.kernels`