### PR TITLE
Fix empty funcvars bug

### DIFF
--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -48,7 +48,12 @@ class Kernel(object):
 
         # Derive meta information from pyfunc, if not given
         self.funcname = funcname or pyfunc.__name__
-        self.funcvars = funcvars or list(pyfunc.__code__.co_varnames)
+        if funcvars is not None:
+            self.funcvars = funcvars
+        elif hasattr(pyfunc, '__code__'):
+            self.funcvars = list(pyfunc.__code__.co_varnames)
+        else:
+            self.funcvars = None
         self.funccode = funccode or inspect.getsource(pyfunc.__code__)
         # Parse AST if it is not provided explicitly
         self.py_ast = py_ast or parse(fix_indentation(self.funccode)).body[0]

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -156,3 +156,18 @@ def test_execution_delete_out_of_bounds(grid, mode, npart=10):
     pset.execute(MoveRight, starttime=0., endtime=10., dt=1.,
                  recovery={ErrorCode.ErrorOutOfBounds: DeleteMe})
     assert len(pset) == 0
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_kernel_add_no_new_variables(grid, mode):
+    def MoveEast(particle, grid, time, dt):
+        particle.lon += 0.1
+
+    def MoveNorth(particle, grid, time, dt):
+        particle.lat += 0.1
+
+    pset = ParticleSet(grid, pclass=ptype[mode], lon=[0.5], lat=[0.5])
+    pset.execute(pset.Kernel(MoveEast) + pset.Kernel(MoveNorth),
+                 starttime=0., endtime=1., dt=1.)
+    assert np.allclose([p.lon for p in pset], 0.6, rtol=1e-5)
+    assert np.allclose([p.lat for p in pset], 0.6, rtol=1e-5)


### PR DESCRIPTION
Fixing Issue #163 when merging two kernels that don't have any new variables declared. 

Also added a unit test for this case to `test_kernel_execution.py`