### PR TITLE
Small addition to Field.gradient()

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -281,8 +281,10 @@ class Field(object):
             dVdx[t, :, :] = np.array(np.transpose(grad[0]))
             dVdy[t, :, :] = np.array(np.transpose(grad[1]))
 
-        return([Field(name + '_dx', dVdx, lon, lat, self.depth, time),
-                Field(name + '_dy', dVdy, lon, lat, self.depth, time)])
+        return([Field(name + '_dx', dVdx, lon, lat, self.depth, time,
+                      interp_method=self.interp_method, allow_time_extrapolation=self.allow_time_extrapolation),
+                Field(name + '_dy', dVdy, lon, lat, self.depth, time,
+                      interp_method=self.interp_method, allow_time_extrapolation=self.allow_time_extrapolation)])
 
     @cachedmethod(operator.attrgetter('interpolator_cache'))
     def interpolator2D(self, t_idx):


### PR DESCRIPTION
Gradient fields returned by `Field.gradient()` do not currently inherit the `interp_method` and
`allow_time_extrapolation` attributes of the field they were calculated
from. At present, the user must manually alter these attributes after field creation. This trivial PR fixes this.

I’m not aware of other field or grid functions that return new `Field` objects, but we should be aware of ensuring that Fields calculated from other fields should, by default, inherit these kinds of attributes
