### PR TITLE
Fixing a bug when Netcdf4 returns masked arrays rather than ndarrays

### DIFF
--- a/examples/example_ofam.py
+++ b/examples/example_ofam.py
@@ -26,6 +26,12 @@ def test_ofam_fieldset():
     assert(fieldset.V.data.shape == (4, 601, 2001))
 
 
+def test_ofam_fieldset_fillvalues():
+    fieldset = set_ofam_fieldset()
+    # V.data[0, 0, 150] is a landpoint, that makes NetCDF4 generate a masked array, instead of an ndarray
+    assert(fieldset.V.data[0, 0, 150] == 0)
+
+
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_ofam_particles(mode):
     fieldset = set_ofam_fieldset()

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -579,9 +579,13 @@ class FileBuffer(object):
     @property
     def data(self):
         if len(self.dataset[self.dimensions['data']].shape) == 3:
-            return self.dataset[self.dimensions['data']][:, self.indslat, self.indslon]
+            data = self.dataset[self.dimensions['data']][:, self.indslat, self.indslon]
         else:
-            return self.dataset[self.dimensions['data']][:, self.indsdepth, self.indslat, self.indslon]
+            data = self.dataset[self.dimensions['data']][:, self.indsdepth, self.indslat, self.indslon]
+
+        if np.ma.is_masked(data):  # convert masked array to ndarray
+            data = np.ma.filled(data, np.nan)
+        return data
 
     @property
     def time(self):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -240,8 +240,7 @@ class Field(object):
                 filebuffer.indslat = indslat
                 filebuffer.indslon = indslon
                 filebuffer.indsdepth = indsdepth
-                tmp = filebuffer.data
-                if len(tmp.shape) is 3:
+                if len(filebuffer.dataset[filebuffer.dimensions['data']].shape) is 3:
                     data[tidx:, 0, :, :] = filebuffer.data[:, :, :]
                 else:
                     data[tidx:, :, :, :] = filebuffer.data[:, :, :, :]


### PR DESCRIPTION
Now explicitly convert a numpy.masked_array to a numpy.ndarray.

Also provides a unit test in examples_ofam, where this was an issue.

This (hopefully) fixes #192. Thanks to @hart-davis for noticing this bug!