### PR TITLE
Allowing for advance time to update only a subset of the fields

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -243,8 +243,8 @@ class FieldSet(object):
         if len(fieldset_new.U.time) is not 1:
             raise RuntimeError('New FieldSet needs to have only one snapshot')
 
-        for v in self.fields:
-            vnew = getattr(fieldset_new, v.name)
+        for vnew in fieldset_new.fields:
+            v = getattr(self, vnew.name)
             if vnew.time > v.time[-1]:  # forward in time, so appending at end
                 v.data = np.concatenate((v.data[1:, :, :], vnew.data[:, :, :]), 0)
                 v.time = np.concatenate((v.time[1:], vnew.time))


### PR DESCRIPTION
There are use cases when not all `Fields` in a `FieldSet` need to be updated by advance time (e.g. if some are time-independent). Then, it makes more sense to update only those `Fields` that are in the new `FieldSet`, rather than all fields that are in the old `FieldSet`