### PR TITLE
Agulhas tutorial to output only three plots, to avoid Travis timeout

### DIFF
--- a/examples/tutorial_Agulhasparticles.ipynb
+++ b/examples/tutorial_Agulhasparticles.ipynb
@@ -2,30 +2,21 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Tutorial showing how to create Parcels in Agulhas animated gif"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "This brief tutorial shows how to recreate the [animated gif](http://oceanparcels.org/animated-gifs/globcurrent_fullyseeded.gif) showing particles in the Agulhas region south of Africa."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We start with importing the relevant modules"
    ]
@@ -34,9 +25,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -47,10 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Now load the Globcurrent fields from the `GlobCurrent_example_data` directory"
    ]
@@ -58,11 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -87,10 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Now create vectors of Longitude and Latitude starting locations on a regular mesh, and use these to initialise a `ParticleSet` object."
    ]
@@ -98,11 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "lons, lats = np.meshgrid(range(15, 35), range(-40, -30))\n",
@@ -111,11 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Now we want to advect the particles. However, the Globcurrent data that we loaded in is only for a limited, regional domain and particles might be able to leave this domain. We therefore need to tell Parcels that particles that leave the domain need to be deleted. We do that using a `Recovery Kernel`, which will be invoked when a particle encounters an `ErrorOutOfBounds` error:"
    ]
@@ -124,9 +95,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -136,10 +105,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Now we can advect the particles. Note that we do this inside a `for`-loop, so we can save a plot every six hours (which is the value of `runtime`). See the [plotting tutorial](http://nbviewer.jupyter.org/github/OceanPARCELS/parcels/blob/master/examples/tutorial_plotting.ipynb) for more information on the `pset.show()` method."
    ]
@@ -147,11 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -159,6 +121,10 @@
      "text": [
       "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/mpl_toolkits/basemap/__init__.py:1767: MatplotlibDeprecationWarning: The get_axis_bgcolor function was deprecated in version 2.0. Use get_facecolor instead.\n",
       "  axisbgc = ax.get_axis_bgcolor()\n",
+      "/Users/erik/Codes/PARCELScode/parcels/particleset.py:402: RuntimeWarning: invalid value encountered in divide\n",
+      "  normU = U/speed\n",
+      "/Users/erik/Codes/PARCELScode/parcels/particleset.py:403: RuntimeWarning: invalid value encountered in divide\n",
+      "  normV = V/speed\n",
       "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/mpl_toolkits/basemap/__init__.py:3707: MatplotlibDeprecationWarning: The ishold function was deprecated in version 2.0.\n",
       "  b = ax.ishold()\n",
       "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/mpl_toolkits/basemap/__init__.py:3716: MatplotlibDeprecationWarning: axes.hold is deprecated.\n",
@@ -172,16 +138,14 @@
       "    for more details.\n",
       "  ax.hold(b)\n",
       "INFO: Plot saved to particles00.png\n",
-      "INFO: Compiled JITParticleAdvectionRK4 ==> /var/folders/r2/8593q8z93kd7t4j9kbb_f7p00000gn/T/parcels-501/27805ff3aa34ba12ddb373f3f2cb1d1b.so\n",
+      "INFO: Compiled JITParticleAdvectionRK4 ==> /var/folders/r2/8593q8z93kd7t4j9kbb_f7p00000gr/T/parcels-504/27805ff3aa34ba12ddb373f3f2cb1d1b.so\n",
       "INFO: Plot saved to particles01.png\n",
-      "INFO: Plot saved to particles02.png\n",
-      "INFO: Plot saved to particles03.png\n",
-      "INFO: Plot saved to particles04.png\n"
+      "INFO: Plot saved to particles02.png\n"
      ]
     }
    ],
    "source": [
-    "for cnt in range(5):\n",
+    "for cnt in range(3):\n",
     "    # First plot the particles\n",
     "    pset.show(savefile='particles'+str(cnt).zfill(2), field='vector', land=True, vmax=2.0)\n",
     "\n",
@@ -195,20 +159,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
-    "This now has created 5 plots. Note that the original animated gif contained 20 plots, but to keep running of this notebook fast we have reduced the number here. Of course, it is trivial to increase the number of plots by changing the value in the `range()` in the cell above."
+    "This now has created 3 plots. Note that the original animated gif contained 20 plots, but to keep running of this notebook fast we have reduced the number here. Of course, it is trivial to increase the number of plots by changing the value in the `range()` in the cell above."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "As a final step, you can use [ImageMagick](http://www.imagemagick.org/script/index.php) or an online tool to stitch these individual plots together in an animated gif."
    ]


### PR DESCRIPTION
`py.test` seemed to be timing out on travis in the last few days on the cell where the plots for the Agulhas animated gif are made. Reduced the number of plots in the example from 5 to 3 to circumvent the timeout