### PR TITLE
Checking whether to recompile when pyfunc is a Kernel object

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -221,7 +221,9 @@ class ParticleSet(object):
                          kernel errors.
         :param show_movie: True shows particles; name of field plots that field as background
         """
-        if self.kernel is None or self.kernel.pyfunc is not pyfunc:
+
+        # check if pyfunc has changed since last compile. If so, recompile
+        if self.kernel is None or (self.kernel.pyfunc is not pyfunc and self.kernel is not pyfunc):
             # Generate and store Kernel
             if isinstance(pyfunc, Kernel):
                 self.kernel = pyfunc


### PR DESCRIPTION
PR #206 to recompile kernels worked only if `pyfunc` was a function. When `pyfync` was a `Kernel` object, the kernels were always recompiled.

This commit fixed this, now checking if `pyfunc` has changed, regardless of whether it is a `Kernel` object or function