### PR TITLE
Clarify that local variables can be reused in Kernels

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -128,6 +128,8 @@ However, there are some key limitations to the Kernels that everyone who wants t
   
   * ``print`` statements. Note however that in JIT mode these only work well for variables that are either floats or any of the inbuilt Particle properties
 
+* Local variables can be used in Kernels, and these variables will be accessible in all concatenated Kernels. Note that these local variables are not shared between particles, and also not between time steps.
+
 All other functions and methods are not supported yet in Parcels Kernels. If there is a functionality that can not be programmed with this limited set of commands, please create an `Issue ticket <https://github.com/OceanParcels/parcels/issues>`_.
 
 Parcels funding and support


### PR DESCRIPTION
Since Kernels are concatenated before execution, local variables defined in one Kernel can be accessed within another Kernel (for the same particle and same timestep).
This possibility has now been clarified in the documentation, as well as in a unit test in `test_kernel_execution.py`