### PR TITLE
Fixed a bug where custom  64-bit Variables might not be aligned for cptr in JIT mode

### DIFF
--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -61,15 +61,16 @@ class ParticleType(object):
 
         self.name = pclass.__name__
         self.uses_jit = issubclass(pclass, JITParticle)
-        # Pick Variable objects out of __dict__. First pick all the 64-bit ones so that
-        # they are aligned for the JIT cptr
-        self.variables = [v for v in pclass.__dict__.values() if isinstance(v, Variable) and v.is64bit()] + \
-                         [v for v in pclass.__dict__.values() if isinstance(v, Variable) and not v.is64bit()]
+        # Pick Variable objects out of __dict__.
+        self.variables = [v for v in pclass.__dict__.values() if isinstance(v, Variable)]
         for cls in pclass.__bases__:
             if issubclass(cls, ScipyParticle):
                 # Add inherited particle variables
                 ptype = cls.getPType()
                 self.variables = ptype.variables + self.variables
+        # Sort variables with all the 64-bit first so that they are aligned for the JIT cptr
+        self.variables = [v for v in self.variables if v.is64bit()] + \
+                         [v for v in self.variables if not v.is64bit()]
 
     def __repr__(self):
         return "PType<%s>::%s" % (self.name, self.variables)

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -26,13 +26,15 @@ def test_variable_init(fieldset, mode, npart=10):
     pset = ParticleSet(fieldset, pclass=TestParticle,
                        lon=np.linspace(0, 1, npart, dtype=np.float32),
                        lat=np.linspace(1, 0, npart, dtype=np.float32))
-    pset.execute(AdvectionRK4, runtime=1., dt=1.)
-    assert np.array([isinstance(p.p_float, np.float32) for p in pset]).all()
-    assert np.allclose([p.p_float for p in pset], 10., rtol=1e-12)
-    assert np.array([isinstance(p.p_double, np.float64) for p in pset]).all()
-    assert np.allclose([p.p_double for p in pset], 11., rtol=1e-12)
-    assert np.array([isinstance(p.p_int, np.int32) for p in pset]).all()
-    assert np.allclose([p.p_int for p in pset], 12, rtol=1e-12)
+
+    def addOne(particle, fieldset, time, dt):
+        particle.p_float += 1.
+        particle.p_double += 1.
+        particle.p_int += 1
+    pset.execute(pset.Kernel(AdvectionRK4)+addOne, runtime=1., dt=1.)
+    assert np.allclose([p.p_float for p in pset], 11., rtol=1e-12)
+    assert np.allclose([p.p_double for p in pset], 12., rtol=1e-12)
+    assert np.allclose([p.p_int for p in pset], 13, rtol=1e-12)
 
 
 @pytest.mark.parametrize('mode', ['jit'])


### PR DESCRIPTION
Sorting of Variables is now done *after* the whole list of variables is assembled. This is important for custom variables that are float64 or int64; otherwise they might not be copied correctly to JIT