### PR TITLE
Setup: add include dir to install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ six>=1.10.0
 enum34
 progressbar2
 python-dateutil
+setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,14 @@ try:
     from setuptools import setup, find_packages
 except ImportError:
     from distutils.core import setup
-import numpy as np
 
 setup(name='parcels',
       version='0.0.1',
       description="""Framework for Lagrangian tracking of virtual
       ocean particles in the petascale age.""",
       author="Imperial College London",
-      packages=find_packages(exclude=['docs', 'examples', 'indlude', 'scripts', 'tests']),
-)
+      use_scm_version=True,
+      setup_requires=['setuptools_scm'],
+      packages=find_packages(exclude=['docs', 'examples', 'scripts', 'tests']) + ['include'],
+      include_package_data=True,
+      )


### PR DESCRIPTION
Instead of adding the source to the PYTHONPATH, using "python setup.py install" will add the include directory (with the parcels.h file) to the install. This is useful for conda installs and running the example notebooks from the conda installation.  This allows the notebook to find the .h file for the examples that use JIT compile.
