### PR TITLE
Minor Field and ParticleFile updates

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -254,9 +254,9 @@ class Field(object):
                     filebuffer.name = name
 
                 if len(filebuffer.dataset[filebuffer.name].shape) is 3:
-                    data[tidx:, 0, :, :] = filebuffer.data[:, :, :]
+                    data[tidx:tidx+len(tslice), 0, :, :] = filebuffer.data[:, :, :]
                 else:
-                    data[tidx:, :, :, :] = filebuffer.data[:, :, :, :]
+                    data[tidx:tidx+len(tslice), :, :, :] = filebuffer.data[:, :, :, :]
             tidx += len(tslice)
         # Time indexing after the fact only
         if 'time' in indices:

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -631,7 +631,10 @@ class FileBuffer(object):
                 dt -= parse(str(offset))
             return list(map(timedelta.total_seconds, dt))
         else:
-            return self.dataset[self.dimensions['time']][:]
+            try:
+                return self.dataset[self.dimensions['time']][:]
+            except:
+                return [None]
 
     @property
     def time_units(self):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -552,6 +552,18 @@ class Field(object):
                                                           vname_depth: self.depth})
         dset.to_netcdf(filepath)
 
+    def advancetime(self, field_new):
+        if len(field_new.time) is not 1:
+            raise RuntimeError('New FieldSet needs to have only one snapshot')
+        if field_new.time > self.time[-1]:  # forward in time, so appending at end
+            self.data = np.concatenate((self.data[1:, :, :], field_new.data[:, :, :]), 0)
+            self.time = np.concatenate((self.time[1:], field_new.time))
+        elif field_new.time < self.time[0]:  # backward in time, so prepending at start
+            self.data = np.concatenate((field_new.data[:, :, :], self.data[:-1, :, :]), 0)
+            self.time = np.concatenate((field_new.time, self.time[:-1]))
+        else:
+            raise RuntimeError("Time of field_new in Field.advancetime() overlaps with times in old Field")
+
 
 class FileBuffer(object):
     """ Class that encapsulates and manages deferred access to file data. """

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -240,16 +240,6 @@ class FieldSet(object):
 
         :param fieldset_new: FieldSet snapshot with which the oldest time has to be replaced"""
 
-        if len(fieldset_new.U.time) is not 1:
-            raise RuntimeError('New FieldSet needs to have only one snapshot')
-
         for vnew in fieldset_new.fields:
             v = getattr(self, vnew.name)
-            if vnew.time > v.time[-1]:  # forward in time, so appending at end
-                v.data = np.concatenate((v.data[1:, :, :], vnew.data[:, :, :]), 0)
-                v.time = np.concatenate((v.time[1:], vnew.time))
-            elif vnew.time < v.time[0]:  # backward in time, so prepending at start
-                v.data = np.concatenate((vnew.data[:, :, :], v.data[:-1, :, :]), 0)
-                v.time = np.concatenate((vnew.time, v.time[:-1]))
-            else:
-                raise RuntimeError("Time of fieldset_new in FieldSet.advancetime() overlaps with times in old FieldSet")
+            v.advancetime(vnew)

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -35,6 +35,7 @@ class ParticleFile(object):
     def __init__(self, name, particleset, type='array'):
 
         self.type = type
+        self.name = name
         self.lasttime_written = None  # variable to check if time has been written already
         self.dataset = netCDF4.Dataset("%s.nc" % name, "w", format="NETCDF4")
         self.dataset.createDimension("obs", None)

--- a/parcels/scripts/convert_IndexedOutputToArray.py
+++ b/parcels/scripts/convert_IndexedOutputToArray.py
@@ -60,6 +60,7 @@ def convert_IndexedOutputToArray(file_in, file_out):
             var[v][i, 0:trajs.lengths[i]] = pfile_in.variables[v][ii]
 
     pfile_out.sync()
+    pfile_out.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A few minor updates to Parcels `Field` and `ParticleFile` methods

- Allowing concatenating of netcdf field that have more than one snapshot in `Field.from_netcdf`
- Moving `Fieldset.advancetime` to `Field.advancetime` so that method can also be used on individual `Fields`
- Adding `name` attribute to `ParticleFile` class
- Close `ParticleFile` at the end of `convert_IndexedOutputToArray` script
- Fix a bug when reading in `Field.from_netcdf` without time dimension