### PR TITLE
Adding time_origin to Basemap-less runs

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -367,6 +367,7 @@ class ParticleSet(object):
             plt.ylabel(ylbl)
         elif Basemap is None:
             logger.info("Visualisation is not possible. Basemap not found.")
+            time_origin = self.fieldset.U.time_origin
         else:
             time_origin = self.fieldset.U.time_origin
             idx = self.fieldset.U.time_index(show_time)


### PR DESCRIPTION
Addresses #222, by adding time_origin declaration to case when `Basemap` is not installed