### PR TITLE
Fix the periodic_boudaries_tutorial.

### DIFF
--- a/examples/tutorial_periodic_boundaries.ipynb
+++ b/examples/tutorial_periodic_boundaries.ipynb
@@ -111,7 +111,7 @@
     "editable": true
    },
    "source": [
-    "The other item we need is a custom Kernel that can move the particle from one side of the domain to the other. Fot this we use `math.fmod` (note not to use the `%` operator, as in C this is only defined for integers, so will cause errors during JIT compilation)."
+    "The other item we need is a custom Kernel that can move the particle from one side of the domain to the other."
    ]
   },
   {
@@ -125,9 +125,10 @@
    "outputs": [],
    "source": [
     "def periodicBC(particle, fieldset, time, dt):\n",
-    "    particle.lon = particle.lon - fieldset.halo_west\n",
-    "    particle.lon = math.fmod(particle.lon, fieldset.halo_east - fieldset.halo_west)\n",
-    "    particle.lon = particle.lon + fieldset.halo_west"
+    "    if particle.lon < fieldset.halo_west:\n",
+    "        particle.lon += fieldset.halo_east - fieldset.halo_west\n",
+    "    elif particle.lon > fieldset.halo_east:\n",
+    "        particle.lon -= fieldset.halo_east - fieldset.halo_west\n"
    ]
   },
   {


### PR DESCRIPTION
Previously, periodicBC function was using fmod, that works when the particles leaves the
domain by the eastern boundary, but not by the western boundary.
(because fmod(-1,5) = -1, not 4)