### PR TITLE
Better print for jit

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -158,7 +158,7 @@ However, there are some key limitations to the Kernels that everyone who wants t
 
   * Functions from the ``maths`` standard library and from the custom ``random`` library at :mod:`parcels.rng`
   
-  * ``print`` statements. Simple print statements can be written, such as::
+  * Simple ``print`` statements, such as::
 
       print("Some print")
       print(particle.lon)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -158,7 +158,12 @@ However, there are some key limitations to the Kernels that everyone who wants t
 
   * Functions from the ``maths`` standard library and from the custom ``random`` library at :mod:`parcels.rng`
   
-  * ``print`` statements. Note however that in JIT mode these only work well for variables that are either floats or any of the inbuilt Particle properties
+  * ``print`` statements. Simple print statements can be written, such as::
+
+      print("Some print")
+      print(particle.lon)
+      print("particle id: %d" % particle.id)
+      print("lon: %f, lat: %f" % (particle.lon, particle.lat))
 
 * Local variables can be used in Kernels, and these variables will be accessible in all concatenated Kernels. Note that these local variables are not shared between particles, and also not between time steps.
 

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -536,7 +536,7 @@ class KernelGenerator(ast.NodeVisitor):
             args = node.values[0].right.ccode
             s = ('printf("%s\\n"' % node.values[0].left.ccode)
             for arg in args:
-                s = s + (", %s" % arg) 
+                s = s + (", %s" % arg)
             s = s + ")"
             node.ccode = c.Statement(s)
             return

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -434,6 +434,7 @@ class KernelGenerator(ast.NodeVisitor):
         self.visit(node.op)
         self.visit(node.right)
         node.ccode = "(%s %s %s)" % (node.left.ccode, node.op.ccode, node.right.ccode)
+        node.s_print = True
 
     def visit_Add(self, node):
         node.ccode = "+"
@@ -452,6 +453,9 @@ class KernelGenerator(ast.NodeVisitor):
 
     def visit_Div(self, node):
         node.ccode = "/"
+
+    def visit_Mod(self, node):
+        node.ccode = "%"
 
     def visit_Num(self, node):
         node.ccode = str(node.n)
@@ -525,6 +529,16 @@ class KernelGenerator(ast.NodeVisitor):
     def visit_Print(self, node):
         for n in node.values:
             self.visit(n)
+        if hasattr(node.values[0], 's'):
+            node.ccode = c.Statement('printf("%s\\n")' % (n.ccode))
+            return
+        if hasattr(node.values[0], 's_print'):
+            args = node.values[0].right.ccode
+            args_list = (node.values[0].left.ccode,)
+            for arg in args:
+                args_list = args_list + (arg,)
+            node.ccode = c.Statement('printf("%s\\n",  %s, %s)' % args_list)
+            return
         vars = ', '.join([n.ccode for n in node.values])
         int_vars = ['particle->id', 'particle->xi', 'particle->yi', 'particle->zi']
         stat = ', '.join(["%d" if n.ccode in int_vars else "%f" for n in node.values])

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -534,10 +534,11 @@ class KernelGenerator(ast.NodeVisitor):
             return
         if hasattr(node.values[0], 's_print'):
             args = node.values[0].right.ccode
-            args_list = (node.values[0].left.ccode,)
+            s = ('printf("%s\\n"' % node.values[0].left.ccode)
             for arg in args:
-                args_list = args_list + (arg,)
-            node.ccode = c.Statement('printf("%s\\n",  %s, %s)' % args_list)
+                s = s + (", %s" % arg) 
+            s = s + ")"
+            node.ccode = c.Statement(s)
             return
         vars = ', '.join([n.ccode for n in node.values])
         int_vars = ['particle->id', 'particle->xi', 'particle->yi', 'particle->zi']

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -535,9 +535,12 @@ class KernelGenerator(ast.NodeVisitor):
         if hasattr(node.values[0], 's_print'):
             args = node.values[0].right.ccode
             s = ('printf("%s\\n"' % node.values[0].left.ccode)
-            for arg in args:
-                s = s + (", %s" % arg)
-            s = s + ")"
+            if isinstance(args, str):
+                s = s + (", %s)" % args)
+            else:
+                for arg in args:
+                    s = s + (", %s" % arg)
+                s = s + ")"
             node.ccode = c.Statement(s)
             return
         vars = ', '.join([n.ccode for n in node.values])

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -107,7 +107,6 @@ def test_while_if_break(fieldset, mode):
     assert np.allclose(np.array([p.p for p in pset]), 20., rtol=1e-12)
 
 
-@pytest.mark.xfail(reason="JIT stdout printing not accesible to py.test")
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_print(fieldset, mode, capfd):
     """Test print statements"""
@@ -118,7 +117,7 @@ def test_print(fieldset, mode, capfd):
     def kernel(particle, fieldset, time, dt):
         val = fieldset.U[time, particle.lon, particle.lat, particle.depth]
         particle.p = val
-        print particle.id, val
+        print("%d %f" % (particle.id, val))
     pset.execute(kernel, endtime=1., dt=1.)
     out, err = capfd.readouterr()
     lst = out.split(' ')

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -115,9 +115,8 @@ def test_print(fieldset, mode, capfd):
     pset = ParticleSet(fieldset, pclass=TestParticle, lon=[0.5], lat=[0.5])
 
     def kernel(particle, fieldset, time, dt):
-        val = fieldset.U[time, particle.lon, particle.lat, particle.depth]
-        particle.p = val
-        print("%d %f" % (particle.id, val))
+        particle.p = fieldset.U[time, particle.lon, particle.lat, particle.depth]
+        print("%d %f" % (particle.id, particle.p))
     pset.execute(kernel, endtime=1., dt=1.)
     out, err = capfd.readouterr()
     lst = out.split(' ')


### PR DESCRIPTION
Some improvement of the print functionalities in the python kernels for JIT.

For example, such kernel is now possible:

def UpdateP(particle, fieldset, time, dt):
    particle.p = fieldset.P[time, particle.lon, particle.lat, particle.depth]
    print(particle.p)
    b = particle.p
    xi = particle.xi
    print("I will print my Particle data")
    print("particle.p  %f %d" % (b, xi))

