### PR TITLE
Asking user input when example directory already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ gh-pages/*
 *.pyc
 *.dSYM/*
 
+config_parcels.yml
+
 .idea/*
 Profile.prof
 .ipynb_checkpoints/*

--- a/parcels/scripts/get_examples.py
+++ b/parcels/scripts/get_examples.py
@@ -5,6 +5,8 @@ from datetime import datetime, timedelta
 import os
 import pkg_resources
 from progressbar import ProgressBar
+import ConfigParser
+
 try:
     # For Python 3.0 and later
     from urllib.request import urlopen
@@ -40,6 +42,15 @@ def _maybe_create_dir(path):
             raise
 
 
+def _update_config_file(path):
+    config = ConfigParser.RawConfigParser()
+    config.add_section('parcels-example-data')
+    config.set('parcels-example-data', 'example-data-location',
+               os.path.join(os.getcwd(), path))
+    with open('config_parcels.yml', 'wb') as configfile:
+        config.write(configfile)
+
+
 def copy_data_and_examples_from_package_to(target_path):
     """Copy example data from Parcels directory.
 
@@ -53,6 +64,15 @@ def copy_data_and_examples_from_package_to(target_path):
     except Exception as e:
         print(e)
         pass
+
+
+def get_example_data_location():
+    """Get the location where example-data is stored,
+    from config_parcels.yml file"""
+    config = ConfigParser.RawConfigParser()
+    config.read('config_parcels.yml')
+    example_path = config.get('parcels-example-data', 'example-data-location')
+    return example_path
 
 
 def _still_to_download(file_names, target_path):
@@ -97,6 +117,9 @@ def main(target_path=None):
         answer = raw_input("Warning: {} already exists. Continue and overwrite existing example files [y/N]?".format(target_path)).lower()
         if answer not in ['y', 'Y', 'yes']:
             return
+
+    # update the location of examples data in Parcels config file
+    _update_config_file(target_path)
 
     # copy data and examples
     copy_data_and_examples_from_package_to(target_path)

--- a/parcels/scripts/get_examples.py
+++ b/parcels/scripts/get_examples.py
@@ -78,6 +78,11 @@ def get_example_data_location():
         example_path = 'examples'
         if not os.path.isdir(example_path):
             example_path = os.path.join('parcels', 'examples')
+            if not os.path.isdir(example_path):
+                answer = raw_input('Can not find directory with examples data. '
+                                   'Do you want to download the data and save to `examples` [y/N]?').lower()
+                if answer in ['y', 'yes']:
+                    main(target_path='examples')
     return example_path
 
 

--- a/parcels/scripts/get_examples.py
+++ b/parcels/scripts/get_examples.py
@@ -94,7 +94,7 @@ def main(target_path=None):
         target_path = args.target_path
 
     if os.path.exists(target_path):
-        answer = raw_input("Warning: {} already exists. Continue [y/n]?".format(target_path)).lower()
+        answer = raw_input("Warning: {} already exists. Continue and overwrite existing example files [y/N]?".format(target_path)).lower()
         if answer not in ['y', 'Y', 'yes']:
             return
 

--- a/parcels/scripts/get_examples.py
+++ b/parcels/scripts/get_examples.py
@@ -43,7 +43,7 @@ def _maybe_create_dir(path):
 def copy_data_and_examples_from_package_to(target_path):
     """Copy example data from Parcels directory.
 
-    Return thos parths of the list `file_names` that were not found in the
+    Return those parts of the list `file_names` that were not found in the
     package.
 
     """
@@ -94,8 +94,9 @@ def main(target_path=None):
         target_path = args.target_path
 
     if os.path.exists(target_path):
-        print("Error: {} already exists.".format(target_path))
-        return
+        answer = raw_input("Warning: {} already exists. Continue [y/n]?".format(target_path)).lower()
+        if answer not in ['y', 'Y', 'yes']:
+            return
 
     # copy data and examples
     copy_data_and_examples_from_package_to(target_path)

--- a/parcels/scripts/get_examples.py
+++ b/parcels/scripts/get_examples.py
@@ -70,8 +70,14 @@ def get_example_data_location():
     """Get the location where example-data is stored,
     from config_parcels.yml file"""
     config = ConfigParser.RawConfigParser()
-    config.read('config_parcels.yml')
-    example_path = config.get('parcels-example-data', 'example-data-location')
+    try:
+        config.read('config_parcels.yml')
+        example_path = config.get('parcels-example-data', 'example-data-location')
+    except:
+        # if no config_parcels.yml, then assume either 'examples' or 'parcels/examples'
+        example_path = 'examples'
+        if not os.path.isdir(example_path):
+            example_path = os.path.join('parcels', 'examples')
     return example_path
 
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -1,5 +1,6 @@
 from parcels import FieldSet, ParticleSet, ScipyParticle, JITParticle, Variable, AdvectionRK4_3D
 from parcels.field import Field
+from parcels.scripts.get_examples import get_example_data_location
 from datetime import timedelta as delta
 import numpy as np
 import pytest
@@ -101,7 +102,7 @@ def test_fieldset_from_file_subsets(indslon, indslat, tmpdir, filename='test_sub
 
 @pytest.mark.parametrize('indstime', [range(2, 8), [4]])
 def test_moving_eddies_file_subsettime(indstime):
-    fieldsetfile = path.join(path.dirname(__file__), pardir, 'parcels', 'examples', 'MovingEddies_data', 'moving_eddies')
+    fieldsetfile = path.join(get_example_data_location(), 'MovingEddies_data', 'moving_eddies')
     fieldsetfull = FieldSet.from_nemo(fieldsetfile, extra_fields={'P': 'P'})
     fieldsetsub = FieldSet.from_nemo(fieldsetfile, extra_fields={'P': 'P'}, indices={'time': indstime})
     assert np.allclose(fieldsetsub.P.time, fieldsetfull.P.time[indstime])

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -4,7 +4,7 @@ from parcels.scripts.get_examples import get_example_data_location
 from datetime import timedelta as delta
 import numpy as np
 import pytest
-from os import path, pardir
+from os import path
 
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -101,7 +101,7 @@ def test_fieldset_from_file_subsets(indslon, indslat, tmpdir, filename='test_sub
 
 @pytest.mark.parametrize('indstime', [range(2, 8), [4]])
 def test_moving_eddies_file_subsettime(indstime):
-    fieldsetfile = path.join(path.dirname(__file__), pardir, 'examples', 'MovingEddies_data', 'moving_eddies')
+    fieldsetfile = path.join(path.dirname(__file__), pardir, 'parcels', 'examples', 'MovingEddies_data', 'moving_eddies')
     fieldsetfull = FieldSet.from_nemo(fieldsetfile, extra_fields={'P': 'P'})
     fieldsetsub = FieldSet.from_nemo(fieldsetfile, extra_fields={'P': 'P'}, indices={'time': indstime})
     assert np.allclose(fieldsetsub.P.time, fieldsetfull.P.time[indstime])

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,14 +1,14 @@
 from parcels import (FieldSet, ParticleSet, JITParticle, AdvectionRK4,
                      plotTrajectoriesFile, convert_IndexedOutputToArray)
+from parcels.scripts.get_examples import get_example_data_location
 from datetime import timedelta as delta
 import numpy as np
 import pytest
-from os import path, pardir
+from os import path
 
 
 def create_outputfiles(dir):
-    datafile = path.join(path.dirname(__file__), pardir, 'examples',
-                         'Peninsula_data', 'peninsula')
+    datafile = path.join(get_example_data_location(), 'Peninsula_data', 'peninsula')
 
     fieldset = FieldSet.from_nemo(datafile, allow_time_extrapolation=True)
     pset = ParticleSet(fieldset=fieldset, lon=[], lat=[], pclass=JITParticle)


### PR DESCRIPTION
Previously, `get_examples.py` did not work for users who worked off a `git clone` directly (rather than the `pip install` in Anaconda), because `parcels/examples` already exists. Now, we ask the user if they want to continue anyways