### PR TITLE
Single execute no time advance

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -553,14 +553,15 @@ class LoopGenerator(object):
         # Inner loop nest for forward runs
         sign = c.Assign("sign", "dt > 0. ? 1. : -1.")
         dt_pos = c.Assign("__dt", "fmin(fabs(particles[p].dt), fabs(endtime - particles[p].time))")
+        dt_0_break = c.If("particles[p].dt == 0", c.Statement("break"))
         body = [c.Assign("res", "%s(&(particles[p]), %s)" % (funcname, fargs_str))]
         body += [c.Assign("particles[p].state", "res")]  # Store return code on particle
         body += [c.If("res == SUCCESS", c.Block([c.Statement("particles[p].time += sign * __dt"),
-                                                 dt_pos, c.Statement("continue")]))]
+                                                 dt_pos, dt_0_break, c.Statement("continue")]))]
         body += [c.If("res == REPEAT", c.Block([dt_pos, c.Statement("continue")]),
                       c.Statement("break"))]
 
-        time_loop = c.While("__dt > __tol", c.Block(body))
+        time_loop = c.While("__dt > __tol || particles[p].dt == 0", c.Block(body))
         part_loop = c.For("p = 0", "p < num_particles", "++p", c.Block([dt_pos, time_loop]))
         fbody = c.Block([c.Value("int", "p"), c.Value("ErrorCode", "res"),
                          c.Value("double", "__dt, __tol, sign"), c.Assign("__tol", "1.e-6"),

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -160,7 +160,7 @@ class Kernel(object):
         for p in pset.particles:
             # Compute min/max dt for first timestep
             dt_pos = min(abs(p.dt), abs(endtime - p.time))
-            while dt_pos > 0 or p.dt == 0:
+            while dt_pos >= 0:
                 try:
                     res = self.pyfunc(p, pset.fieldset, p.time, sign * dt_pos)
                 except FieldSamplingError as fse:
@@ -179,7 +179,7 @@ class Kernel(object):
                     # Update time and repeat
                     p.time += sign * dt_pos
                     dt_pos = min(abs(p.dt), abs(endtime - p.time))
-                    if p.dt == 0:
+                    if dt_pos == 0:
                         break
                     continue
                 elif res == ErrorCode.Repeat:

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -160,7 +160,7 @@ class Kernel(object):
         for p in pset.particles:
             # Compute min/max dt for first timestep
             dt_pos = min(abs(p.dt), abs(endtime - p.time))
-            while dt_pos > 0:
+            while dt_pos > 0 or p.dt == 0:
                 try:
                     res = self.pyfunc(p, pset.fieldset, p.time, sign * dt_pos)
                 except FieldSamplingError as fse:
@@ -179,6 +179,8 @@ class Kernel(object):
                     # Update time and repeat
                     p.time += sign * dt_pos
                     dt_pos = min(abs(p.dt), abs(endtime - p.time))
+                    if p.dt == 0:
+                        break
                     continue
                 elif res == ErrorCode.Repeat:
                     # Try again without time update

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -273,7 +273,7 @@ class ParticleSet(object):
             if interval < 0:
                 interval *= -1.
                 logger.warning("Negating interval because running in time-forward mode")
-        if endtime < starttime:  # Time-backward mode
+        elif endtime < starttime:  # Time-backward mode
             if dt > 0.:
                 dt *= -1.
                 logger.warning("Negating dt because running in time-backward mode")
@@ -281,12 +281,19 @@ class ParticleSet(object):
                 interval *= -1.
                 logger.warning("Negating interval because running in time-backward mode")
 
+        if np.allclose(endtime, starttime) or interval == 0 or dt == 0 or runtime == 0:
+            timeleaps = 1
+            dt = 0
+            runtime = 0
+            endtime = starttime
+        else:
+            timeleaps = int((endtime - starttime) / interval)
+
         # Initialise particle timestepping
         for p in self:
             p.time = starttime
             p.dt = dt
         # Execute time loop in sub-steps (timeleaps)
-        timeleaps = int((endtime - starttime) / interval)
         assert(timeleaps >= 0)
         leaptime = starttime
         for _ in range(timeleaps):

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -286,6 +286,7 @@ class ParticleSet(object):
             dt = 0
             runtime = 0
             endtime = starttime
+            logger.warning_once("dt = 0 and endtime == starttime. The kernels will be executed once, without incrementing time")
         else:
             timeleaps = int((endtime - starttime) / interval)
 

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -277,3 +277,23 @@ def test_pfile_array_remove_all_particles(fieldset, mode, tmpdir, pfile_type, np
         pset.remove(-1)
     pfile.write(pset, 1)
     pfile.write(pset, 2)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+@pytest.mark.parametrize('test', ['dt', 'endtime'])
+def test_pset_execute_dt_0(fieldset, mode, test, npart=2):
+    def SetLat(particle, fieldset, time, dt):
+        particle.lat = .6
+    pset = ParticleSet(fieldset, pclass=ptype[mode],
+                       lon=np.linspace(0, 1, npart, dtype=np.float32),
+                       lat=np.linspace(1, 0, npart, dtype=np.float32))
+    if test == 'dt':
+        pset.execute(pset.Kernel(SetLat), starttime=0., endtime=1., dt=0.)
+    elif test == 'endtime':
+        pset.execute(pset.Kernel(SetLat), starttime=0., endtime=0., dt=1.)
+    assert np.allclose(pset.particles[0].lat, .6)
+    assert np.allclose(pset.particles[1].lat, .6)
+    assert np.allclose(pset.particles[0].lon, 0)
+    assert np.allclose(pset.particles[1].lon, 1)
+    assert np.allclose(pset.particles[1].time, 0)
+    assert np.allclose(pset.particles[0].time, 0)

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -280,20 +280,14 @@ def test_pfile_array_remove_all_particles(fieldset, mode, tmpdir, pfile_type, np
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
-@pytest.mark.parametrize('test', ['dt', 'endtime'])
-def test_pset_execute_dt_0(fieldset, mode, test, npart=2):
+@pytest.mark.parametrize(('endtime', 'dt'), [(1., 0.), (0., 1.)])
+def test_pset_execute_dt_0(fieldset, mode, endtime, dt, npart=2):
     def SetLat(particle, fieldset, time, dt):
         particle.lat = .6
-    pset = ParticleSet(fieldset, pclass=ptype[mode],
-                       lon=np.linspace(0, 1, npart, dtype=np.float32),
-                       lat=np.linspace(1, 0, npart, dtype=np.float32))
-    if test == 'dt':
-        pset.execute(pset.Kernel(SetLat), starttime=0., endtime=1., dt=0.)
-    elif test == 'endtime':
-        pset.execute(pset.Kernel(SetLat), starttime=0., endtime=0., dt=1.)
-    assert np.allclose(pset.particles[0].lat, .6)
-    assert np.allclose(pset.particles[1].lat, .6)
-    assert np.allclose(pset.particles[0].lon, 0)
-    assert np.allclose(pset.particles[1].lon, 1)
-    assert np.allclose(pset.particles[1].time, 0)
-    assert np.allclose(pset.particles[0].time, 0)
+    lon = np.linspace(0, 1, npart, dtype=np.float32)
+    lat = np.linspace(1, 0, npart, dtype=np.float32)
+    pset = ParticleSet(fieldset, pclass=ptype[mode], lon=lon, lat=lat)
+    pset.execute(pset.Kernel(SetLat), starttime=0., endtime=endtime, dt=dt)
+    assert np.allclose([p.lon for p in pset], lon)
+    assert np.allclose([p.lat for p in pset], .6)
+    assert np.allclose([p.time for p in pset], 0)


### PR DESCRIPTION
The kernel will be executed only once, with dt=0.

This should then not be used for advection.

Works with both jit and scipy.