### PR TITLE
Forcing conda not to update matplotlib on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
 install:
     - conda env create --file environment.yml
     - source activate py2_parcels
-    - conda install --yes python=$TRAVIS_PYTHON_VERSION sphinx
     - pip install -e .
 
 before_script: # configure a headless display to test  plot generation

--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - scipy>=0.16.0
   - six>=1.10.0
   - xarray>=0.5.1
+  - sphinx
   - pip:
       - pytest>=2.7.0
       - nbval


### PR DESCRIPTION
The latest version of matplotlib does not support the `plt.pause()` method anymore, that we use to generate animations in Parcels. In order for Travis CI to not flag errors, we force travis to run with matplotlib version 2.0.2. 

This is a workaround for now, and I will add comments to #221 that we need to make sure Parcels also works with the latest matplotlib