### PR TITLE
Particle attributes

### DIFF
--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -160,7 +160,7 @@ class Kernel(object):
         for p in pset.particles:
             # Compute min/max dt for first timestep
             dt_pos = min(abs(p.dt), abs(endtime - p.time))
-            while dt_pos >= 0:
+            while dt_pos > 1e-6 or dt == 0:
                 try:
                     res = self.pyfunc(p, pset.fieldset, p.time, sign * dt_pos)
                 except FieldSamplingError as fse:
@@ -179,7 +179,7 @@ class Kernel(object):
                     # Update time and repeat
                     p.time += sign * dt_pos
                     dt_pos = min(abs(p.dt), abs(endtime - p.time))
-                    if dt_pos == 0:
+                    if dt == 0:
                         break
                     continue
                 elif res == ErrorCode.Repeat:

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -160,7 +160,7 @@ class ParticleFile(object):
                 self.idx += 1
             elif self.type is 'indexed':
                 if self.user_vars_once:
-                    logger.warning("Option to_write='once' is not fully functional in indexed mode! Particle properties of newly added particles are not written.")
+                    logger.warning("Option to_write='once' is not fully functional in indexed mode! Particle properties of such variables are not written for newly added particles.")
                 ind = np.arange(pset.size) + self.idx
                 self.id[ind] = np.array([p.id for p in pset])
                 self.time[ind] = time

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -28,8 +28,6 @@ class ParticleFile(object):
 
     :param name: Basename of the output file
     :param particleset: ParticleSet to output
-    :param user_vars: A list of additional user defined particle variables to write for all particles and all times
-    :param user_vars_once: A list of additional user defined particle variables to write for all particle only once at initial time
     :param type: Either 'array' for default matrix style, or 'indexed' for indexed ragged array
     """
 
@@ -89,6 +87,12 @@ class ParticleFile(object):
         self.z.standard_name = "depth"
         self.z.units = "m"
         self.z.positive = "down"
+
+
+        """
+        :user_vars: list of additional user defined particle variables to write for all particles and all times
+        :user_vars_once: list of additional user defined particle variables to write for all particles only once at initial time. Only fully functional for type='array'
+        """
 
         self.user_vars = []
         self.user_vars_once = []
@@ -155,6 +159,8 @@ class ParticleFile(object):
 
                 self.idx += 1
             elif self.type is 'indexed':
+                if self.user_vars_once:
+                    logger.warning("Option to_write='once' is not fully functional in indexed mode! Particle properties of newly added particles are not written.")
                 ind = np.arange(pset.size) + self.idx
                 self.id[ind] = np.array([p.id for p in pset])
                 self.time[ind] = time

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -92,7 +92,7 @@ class ParticleFile(object):
 
         self.user_vars = []
         self.user_vars_once = []
-        
+
         for v in particleset.ptype.variables:
             if v.name in ['time', 'lat', 'lon', 'depth', 'z', 'id']:
                 continue

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -88,14 +88,12 @@ class ParticleFile(object):
         self.z.units = "m"
         self.z.positive = "down"
 
-
+        self.user_vars = []
+        self.user_vars_once = []
         """
         :user_vars: list of additional user defined particle variables to write for all particles and all times
         :user_vars_once: list of additional user defined particle variables to write for all particles only once at initial time. Only fully functional for type='array'
         """
-
-        self.user_vars = []
-        self.user_vars_once = []
 
         for v in particleset.ptype.variables:
             if v.name in ['time', 'lat', 'lon', 'depth', 'z', 'id']:

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -294,20 +294,21 @@ def test_pset_execute_dt_0(fieldset, mode, endtime, dt, npart=2):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
-@pytest.mark.parametrize(('npart','interval'),[(1,0.2),(5,0.2),(1,1.0),(5,1.0)])
-def test_variable_written_once(fieldset, mode, interval, tmpdir, npart):
+@pytest.mark.parametrize('npart', [1, 2, 5])
+def test_variable_written_once(fieldset, mode, tmpdir, npart):
     filepath = tmpdir.join("pfile_once_written_variables")
+
     def Update_v(particle, fieldset, time, dt):
         particle.v_once += 1.
-    def SetLat(particle, fieldset, time, dt):
-        particle.lat = .6
-    class MyParticle(ptype[mode]): 
-        v_once = Variable('v_once', dtype=np.float32, initial=1.,to_write='once')
+
+    class MyParticle(ptype[mode]):
+        v_once = Variable('v_once', dtype=np.float32, initial=1., to_write='once')
     lon = np.linspace(0, 1, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)
     pset = ParticleSet(fieldset, pclass=MyParticle, lon=lon, lat=lat)
-    pset.execute(pset.Kernel(SetLat)+pset.Kernel(Update_v), starttime=0., endtime=1, dt=0.1, interval=interval,output_file=pset.ParticleFile(name=filepath))
-    ncfile = Dataset(filepath+".nc", 'r', 'NETCDF4') 
+    pset.execute(pset.Kernel(Update_v), starttime=0., endtime=1, dt=0.1, interval=0.2, output_file=pset.ParticleFile(name=filepath))
+    ncfile = Dataset(filepath+".nc", 'r', 'NETCDF4')
     V_once = ncfile.variables['v_once'][:]
-    assert (V_once.shape == (npart,))
+    assert np.all([p.v_once == 11.0 for p in pset])
+    assert (V_once.shape == (npart, ))
     assert (V_once[0] == 1.)


### PR DESCRIPTION
Can now add particle attributes, depending on the particle id ("trajectory") only and written only once in the netcdf with Variable(...,to_write='once')