### PR TITLE
Fixing a bug when starttime and endtime are very large

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -281,7 +281,7 @@ class ParticleSet(object):
                 interval *= -1.
                 logger.warning("Negating interval because running in time-backward mode")
 
-        if np.allclose(endtime, starttime) or interval == 0 or dt == 0 or runtime == 0:
+        if abs(endtime-starttime) < 1e-5 or interval == 0 or dt == 0 or runtime == 0:
             timeleaps = 1
             dt = 0
             runtime = 0


### PR DESCRIPTION
Fixing a bug created in PR #240 (allowing for a `dt=0` execution). This bug appears when endtime and starttime are close and very large

When `time_origin` is for example 1 jan 1900, then starttime and endtime can become very large (order 10^10 seconds).

In that case, `np.allclose()` gives True even when `starttime` and `endtime` are minutes or hours apart. This causes `pset.execute()` to inadvertently go into ‘once-only mode’.

This bug is fixed here by simply calculating absolute difference between `endtime` and `starttime`, rather than using `np.allclose()`