### PR TITLE
Field.show time_extrapolation bug-fig

### DIFF
--- a/parcels/examples/parcels_tutorial.ipynb
+++ b/parcels/examples/parcels_tutorial.ipynb
@@ -299,8 +299,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "P[0](lon=3.300000, lat=46.000000, depth=0.000000, time=0.000000)[xi=164, yi=49, zi=0]\n",
-      "P[1](lon=3.300000, lat=47.799999, depth=0.000000, time=0.000000)[xi=164, yi=139, zi=0]\n"
+      "P[0](lon=3.300000, lat=46.000000, depth=0.000000, time=not_yet_set)\n",
+      "P[1](lon=3.300000, lat=47.799999, depth=0.000000, time=not_yet_set)\n"
      ]
     }
    ],
@@ -315,7 +315,7 @@
     "editable": true
    },
    "source": [
-    "This output shows for each particle the (longitude, latitude, depth), and then in square brackets the fieldset indices of the longitude and latitude."
+    "This output shows for each particle the (longitude, latitude, depth, time). Note that in this case the time is `not_yet_set`, that is because we didn't specify a `time` when we defined the `pset`."
    ]
   },
   {
@@ -359,7 +359,7 @@
     "editable": true
    },
    "source": [
-    "The final step is to run (or 'execute') the `ParticelSet`. We run the particles using the `AdvectionRK4` kernel, which is a 4th order Runge-Kutte implementation that comes with Parcels. We run the particles for 6 days (using the `timedelta` function from `datetime`), at an RK4 timestep of 5 minutes. We store the trajectory information at an interval of 1 hour in a file called `EddyParticles.nc`."
+    "The final step is to run (or 'execute') the `ParticelSet`. We run the particles using the `AdvectionRK4` kernel, which is a 4th order Runge-Kutte implementation that comes with Parcels. We run the particles for 6 days (using the `timedelta` function from `datetime`), at an RK4 timestep of 5 minutes. We store the trajectory information at an interval of 1 hour in a file called `EddyParticles.nc`. Because `time` was `not_yet_set`, the particles will be advected from the first date available in the `fieldset`, which is the default behaviour."
    ]
   },
   {
@@ -410,8 +410,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "P[0](lon=2.024544, lat=46.088627, depth=0.000000, time=518400.000000)[xi=100, yi=54, zi=0]\n",
-      "P[1](lon=2.017195, lat=48.305283, depth=0.000000, time=518400.000000)[xi=100, yi=164, zi=0]\n"
+      "P[0](lon=2.024544, lat=46.088627, depth=0.000000, time=518400.000000)\n",
+      "P[1](lon=2.017195, lat=48.305283, depth=0.000000, time=518400.000000)\n"
      ]
     },
     {
@@ -437,7 +437,7 @@
     "editable": true
    },
    "source": [
-    "Note that both the particles (the black dots) and the `U` field have moved in the plot above."
+    "Note that both the particles (the black dots) and the `U` field have moved in the plot above. Also, the `time` of the particles is now 518400 seconds, which is 6 days."
    ]
   },
   {
@@ -1064,8 +1064,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "P[0](lon=3.299995, lat=45.999901, depth=0.000000, time=0.000000)[xi=164, yi=49, zi=0]\n",
-      "P[1](lon=3.299851, lat=47.799862, depth=0.000000, time=0.000000)[xi=164, yi=139, zi=0]\n"
+      "P[0](lon=3.299995, lat=45.999901, depth=0.000000, time=0.000000)\n",
+      "P[1](lon=3.299851, lat=47.799862, depth=0.000000, time=0.000000)\n"
      ]
     },
     {
@@ -1361,7 +1361,7 @@
     "editable": true
    },
    "source": [
-    "And finally execute the `ParticleSet` for 1 week using 4th order Runge-Kutta"
+    "And finally execute the `ParticleSet` for 10 days using 4th order Runge-Kutta"
    ]
   },
   {

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -570,7 +570,7 @@ class Field(object):
                          pointer(self.grid.ctypes_struct))
         return cstruct
 
-    def show(self, with_particles=False, animation=False, show_time=0, vmin=None, vmax=None):
+    def show(self, with_particles=False, animation=False, show_time=None, vmin=None, vmax=None):
         """Method to 'show' a :class:`Field` using matplotlib
 
         :param with_particles: Boolean whether particles are also plotted on Field
@@ -588,6 +588,7 @@ class Field(object):
             return
 
         if with_particles or (not animation):
+            show_time = self.grid.time[0] if show_time is None else show_time
             (idx, periods) = self.time_index(show_time)
             show_time -= periods*(self.grid.time[-1]-self.grid.time[0])
             if self.grid.time.size > 1:

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -183,8 +183,9 @@ class ScipyParticle(_Particle):
         super(ScipyParticle, self).__init__()
 
     def __repr__(self):
-        return "P[%d](lon=%f, lat=%f, depth=%f, time=%f)" % (self.id, self.lon, self.lat,
-                                                             self.depth, self.time)
+        time_string = 'not_yet_set' if self.time is None or np.isnan(self.time) else "{:f}".format(self.time)
+        return "P[%d](lon=%f, lat=%f, depth=%f, time=%s)" % (self.id, self.lon, self.lat,
+                                                             self.depth, time_string)
 
     def delete(self):
         self.state = ErrorCode.Delete
@@ -221,5 +222,6 @@ class JITParticle(ScipyParticle):
         self.CGridIndexSet = self.CGridIndexSetptr.value
 
     def __repr__(self):
-        return "P[%d](lon=%f, lat=%f, depth=%f, time=%f)" % (self.id, self.lon, self.lat,
-                                                             self.depth, self.time)
+        time_string = 'not_yet_set' if self.time is None or np.isnan(self.time) else "{:f}".format(self.time)
+        return "P[%d](lon=%f, lat=%f, depth=%f, time=%s)" % (self.id, self.lon, self.lat,
+                                                             self.depth, time_string)

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -353,7 +353,7 @@ class ParticleSet(object):
         if isinstance(show_time, delta):
             show_time = show_time.total_seconds()
         if np.isnan(show_time):
-            show_time = 0
+            show_time = self.fieldset.U.grid.time[0]
         if domain is not None:
             latN = nearest_index(self.fieldset.U.lat, domain[0])
             latS = nearest_index(self.fieldset.U.lat, domain[1])


### PR DESCRIPTION
Fixed a small bug in `Field.show()` where default `show_time` could be outside `grid.time`,  causing an error when `time_extrapolation=False`. This bug occurred for example in `example_globcurrent.py`

Changing default value of `show_time` from 0 to `self.grid.time[0]` fixes this