### PR TITLE
A suggestion for multiprocessing

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=2.7
   - cachetools>=1.0.0
   - cgen
+  - openmp
   - enum34
   - ffmpeg
   - flake8>=2.1.0

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - flake8>=2.1.0
   - git
   - gcc
+  - gsl
   - jupyter
   - matplotlib=2.0.2
   - netcdf4>=1.1.9

--- a/environment_win.yml
+++ b/environment_win.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=2.7
   - cachetools>=1.0.0
   - cgen
+  - openmp
   - enum34
   - ffmpeg
   - flake8>=2.1.0

--- a/environment_win.yml
+++ b/environment_win.yml
@@ -11,6 +11,8 @@ dependencies:
   - flake8>=2.1.0
   - git
   - m2w64-toolchain
+  - gsl
+  - m2w64-gsl
   - jupyter
   - matplotlib=2.0.2
   - netcdf4>=1.1.9

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -552,7 +552,8 @@ class LoopGenerator(object):
             shared += [field]
         for const, _ in const_args.items():
             args += [c.Value("float", const)]
-        fargs_str = ", ".join(['particles[p].time', 'sign_dt * __dt'] + list(field_args.keys()) + list(const_args.keys()))
+        fargs_str = ", ".join(['particles[p].time', 'sign_dt * __dt']
+                              + list(field_args.keys()) + list(const_args.keys()))
         # Inner loop nest for forward runs
         sign_dt = c.Assign("sign_dt", "dt > 0. ? 1 : -1")
         sign_end_part = c.Assign("sign_end_part", "endtime - particles[p].time > 0 ? 1 : -1")

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -529,6 +529,9 @@ class LoopGenerator(object):
         ccode += [str(c.Include("math.h", system=False))]
         ccode += [str(c.Include("time.h", system=False))]
 
+        # Define and assign extern varriable
+        ccode += ["gsl_rng *prng_state = (gsl_rng *)NULL;\n"]
+
         # Generate type definition for particle type
         vdecl = []
         for v in self.ptype.variables:
@@ -544,12 +547,12 @@ class LoopGenerator(object):
 
         # Generate outer loop for repeated kernel invocation
         args = [c.Value("int", "num_particles"),
-                c.Pointer(c.Value(self.ptype.name, "particles")),
-                c.Value("double", "endtime"), c.Value("float", "dt")]
-        shared = ["particles"]
+                c.Pointer(c.Value(self.ptype.name, "particles")), c.Value("double", "endtime"), c.Value("float", "dt"),
+                c.Value("int", "seed"), c.Value("int", "numbers_pulled")]
+        # shared = ["particles"]
         for field, _ in field_args.items():
             args += [c.Pointer(c.Value("CField", "%s" % field))]
-            shared += [field]
+            # shared += [field]
         for const, _ in const_args.items():
             args += [c.Value("float", const)]
         fargs_str = ", ".join(['particles[p].time', 'sign_dt * __dt']
@@ -569,16 +572,26 @@ class LoopGenerator(object):
                       c.Statement("break"))]
 
         time_loop = c.While("__dt > __tol || particles[p].dt == 0", c.Block(body))
-        part_loop = c.Block([c.Statement("srand((int)time(NULL) ^ omp_get_thread_num())"),
-                             c.Pragma("omp for schedule(static)"),
-                             c.For("p = 0", "p < num_particles", "++p",
-                                   c.Block([sign_end_part, notstarted_continue, dt_pos, time_loop]))])
+        part_loop = c.For("p = 0", "p < num_particles", "++p",
+                          c.Block([sign_end_part, notstarted_continue, dt_pos, time_loop]))
+        check_rng = c.If("prng_state == NULL || prev_seed != seed",
+                         c.Block([c.Statement("gsl_rng_env_setup()"),
+                                  c.Assign("rng_type", "gsl_rng_default"),
+                                  c.Assign("prng_state", "gsl_rng_alloc(rng_type)"),
+                                  c.Statement('gsl_rng_set(prng_state, (unsigned long int)seed)'),
+                                  c.Assign("prev_seed", "seed"),
+                                  c.Assign("rand_c", "0")]))
         fbody = c.Block([c.Value("int", "p, sign_dt, sign_end_part"),
+                         c.Assign("static int rand_c", "0"),
+                         c.Assign("static int prev_seed", "0"),
+                         c.Pointer(c.Value("gsl_rng_type", "rng_type")),
                          c.Value("ErrorCode", "res"),
                          c.Value("double", "__dt, __tol"),
                          c.Assign("__tol", "1.e-6"),
+                         check_rng,
+                         c.For("", "rand_c < numbers_pulled", "++rand_c",c.Statement("gsl_rng_get(prng_state)")),
                          c.Statement("omp_set_num_threads(omp_get_num_procs())"),
-                         sign_dt, c.Pragma("omp parallel private(p,__dt,res)"),
+                         sign_dt, c.Pragma("omp parallel for private(p,__dt,res,sign_end_part) schedule(static)"),
                          part_loop])
         fdecl = c.FunctionDeclaration(c.Value("void", "particle_loop"), args)
         ccode += [str(c.FunctionBody(fdecl, fbody))]

--- a/parcels/compiler.py
+++ b/parcels/compiler.py
@@ -66,6 +66,6 @@ class GNUCompiler(Compiler):
         opt_flags = ['-g', '-O3']
         arch_flag = ['-m64' if calcsize("P") is 8 else '-m32']
         cppargs = ['-Wall', '-fPIC', '-I%s' % path.join(get_package_dir(), 'include')] + opt_flags + cppargs
-        cppargs += arch_flag
+        cppargs += arch_flag + ['-lgomp', '-fopenmp']
         ldargs = ['-shared'] + ldargs + arch_flag
         super(GNUCompiler, self).__init__("gcc", cppargs=cppargs, ldargs=ldargs)

--- a/parcels/compiler.py
+++ b/parcels/compiler.py
@@ -65,7 +65,6 @@ class GNUCompiler(Compiler):
     def __init__(self, cppargs=[], ldargs=[]):
         opt_flags = ['-g', '-O3']
         arch_flag = ['-m64' if calcsize("P") is 8 else '-m32']
-        cppargs = ['-Wall', '-fPIC', '-I%s' % path.join(get_package_dir(), 'include')] + opt_flags + cppargs
-        cppargs += arch_flag + ['-lgomp', '-fopenmp']
-        ldargs = ['-shared'] + ldargs + arch_flag
+        cppargs = ['-Wall', '-fPIC', '-I%s' % path.join(get_package_dir(), 'include')] + opt_flags + cppargs + arch_flag
+        ldargs = ['-shared'] + ldargs + arch_flag + ['-lgomp', '-lgsl', '-lgslcblas', '-fopenmp']
         super(GNUCompiler, self).__init__("gcc", cppargs=cppargs, ldargs=ldargs)

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -4,6 +4,7 @@
 extern "C" {
 #endif
 
+#include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -353,7 +354,6 @@ static inline ErrorCode temporal_interpolation_linear(float x, float y, float z,
 /**************************************************/
 /*   Random number generation (RNG) functions     */
 /**************************************************/
-
 static void parcels_seed(int seed)
 {
   srand(seed);
@@ -370,7 +370,7 @@ static inline float parcels_uniform(float low, float high)
 }
 
 static inline int parcels_randint(int low, int high)
-{
+{	
   return (rand() % (high-low)) + low;
 }
 

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -4,6 +4,7 @@ from parcels.kernels.error import ErrorCode, recovery_map as recovery_base_map
 from parcels.field import FieldSamplingError
 from parcels.loggers import logger
 from parcels.kernels.advection import AdvectionRK4_3D
+from parcels.rng import _parcels_random_info
 from os import path, remove
 import numpy as np
 import numpy.ctypeslib as npct
@@ -155,7 +156,8 @@ class Kernel(object):
         fargs += [c_float(f) for f in self.const_args.values()]
         particle_data = pset._particle_data.ctypes.data_as(c_void_p)
         self._function(c_int(len(pset)), particle_data,
-                       c_double(endtime), c_float(dt), *fargs)
+                       c_double(endtime), c_float(dt), c_int(_parcels_random_info()[0]),
+                       c_int(_parcels_random_info()[1]), *fargs)
 
     def execute_python(self, pset, endtime, dt):
         """Performs the core update loop via Python"""


### PR DESCRIPTION
# A simple implementation of multiprocessing
One of the big hurdles I have experienced in working with parcels is that the execution of the kernels happens only on one logical core. This is somewhat problematic, because this causes quite a bottle neck for the program as the number of particles in your `ParticleSet` increases. To find a fix for this problem a simple implementation for multiprocessing was sought for kernel execution in JIT mode. With this is simply meant that the implementation ought not to burden the end user and be done automatically in parcels itself.

To that end code was added in the c code generator and to the `parcels.h` file to allow for automatic parallelisation of the for loop which contains the execution of a particle's kernel. This concurrent running of different particle kernels at the same time across cores causes roughly a 60 per cent decrease in processing time when instead of one logical core, eight can be used. I, therefore, think this pull request is a good inital take to get parcels to run faster through accessing more of the resources available on a given system.

## How the implementation was done
The `omp.h` header which is provided in the gcc toolchain allows easy parellisation through the addition of preprocessor statements and some lines of c code. In this case the necessary commands to multiprocess a piece of code were placed around the for loop which iterates over each particle. The new lines of code effectively tell the compiler to write a program which automatically splits the to-be-done work into equal chunks to be shared among the cores. For more information about gcc's implementation of this automatic parallelisation, see the [openmp specification](https://gcc.gnu.org/wiki/openmp) on the gcc website.

# A known problem
Multitprocessing brings to the table a new problem in parcels. The big current issue, which is semi-solved in this pull request, is a problem which is related to the `random` module in parcels. As you would likely know, parcels uses a special module to interface the demands for random numbers in Python to the random number generator in standard c which is basically the functions `rand()` and `srand(int seed)`. Well, when multiprocessing is implemented, a problem will start to occur: all the different cores will be assigned their own running version seeded with the seed which was set in the main thread. This is problematic as it will cause all the different threads to run the same sequence of *random* numbers.

To fix this, each thread was given a seed as defined by the function `time(NUL) ^ omp_get_thread_num()`. This provides us again with safe random numbers which are not dependent on one and another. However, what was lost in this fix, was the ability to set a seed and then to pull the same random numbers from the `random` module and a `Kernel`. This loss is reflected in thrown assertion errors in the test file which checks the kernel's language interpreter: it will say that the numbers from `random` and a kernel are not the same; which is of course true. A true fix then ought to be sought which maybe allows the parellised loop to pull from a shared number generator which can also be accessed through the `random` module. 

Anyway, the goal here is not to dictate what ought to be done, but to sketch what is certainly amiss within the current implementation of random numbers and to make clear that some decisions must be made concerning this. However, I do think that this pull request is a nice starting point to get robust parellisation into parcels.