### PR TITLE
Printing logfile if compiler exits with error

### DIFF
--- a/parcels/compiler.py
+++ b/parcels/compiler.py
@@ -49,10 +49,13 @@ class Compiler(object):
 Please check if compiler exists: %s""" % self._cc
                 raise RuntimeError(err)
             except subprocess.CalledProcessError:
-                err = """Error during compilation:
+                with open(log, 'r') as logfile2:
+                    err = """Error during compilation:
 Compilation command: %s
 Source file: %s
-Log file: %s""" % (" ".join(cc), src, logfile.name)
+Log file: %s
+
+Log output: %s""" % (" ".join(cc), src, logfile.name, logfile2.read())
                 raise RuntimeError(err)
 
 

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -590,7 +590,7 @@ static inline ErrorCode temporal_interpolationUVrotation(float x, float y, float
 /*   Random number generation (RNG) functions     */
 /**************************************************/
 
-static void parcels_seed(int seed)
+static inline void parcels_seed(int seed)
 {
   srand(seed);
 }
@@ -617,7 +617,6 @@ static inline float parcels_normalvariate(float loc, float scale)
 /*     this software for any application provided this copyright notice is preserved.       */
 {
   float x1, x2, w, y1;
-  static float y2;
 
   do {
     x1 = 2.0 * (float)rand()/(float)(RAND_MAX) - 1.0;
@@ -627,7 +626,6 @@ static inline float parcels_normalvariate(float loc, float scale)
 
   w = sqrt( (-2.0 * log( w ) ) / w );
   y1 = x1 * w;
-  y2 = x2 * w;
   return( loc + y1 * scale );
 }
 #ifdef __cplusplus


### PR DESCRIPTION
This makes it easier to find out why compilation broke, and helps users with debugging

PR also slightly tweaked random functions in `parcels.h` to fix spurious Warnings in log-file