### PR TITLE
Fix two minor bugs in FieldSet and Grid

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -21,8 +21,10 @@ class FieldSet(object):
     """
     def __init__(self, U, V, fields={}):
         self.gridset = GridSet()
-        self.add_field(U)
-        self.add_field(V)
+        if U:
+            self.add_field(U)
+        if V:
+            self.add_field(V)
         UV = Field('UV', None)
         UV.fieldset = self
         self.UV = UV
@@ -137,8 +139,8 @@ class FieldSet(object):
             fields[var] = Field.from_netcdf(var, dims, paths, inds, mesh=mesh,
                                             allow_time_extrapolation=allow_time_extrapolation,
                                             time_periodic=time_periodic, **kwargs)
-        u = fields.pop('U')
-        v = fields.pop('V')
+        u = fields.pop('U', None)
+        v = fields.pop('V', None)
         return cls(u, v, fields=fields)
 
     @classmethod

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -200,14 +200,14 @@ class RectilinearSGrid(RectilinearGrid):
 class CurvilinearGrid(Grid):
 
     def __init__(self, lon, lat, time=None, time_origin=0, mesh='flat'):
-        assert(isinstance(lon, np.ndarray) and len(lon.shape) == 2), 'lon is not a 2D numpy array'
-        assert(isinstance(lat, np.ndarray) and len(lat.shape) == 2), 'lat is not a 2D numpy array'
+        assert(isinstance(lon, np.ndarray) and len(lon.squeeze().shape) == 2), 'lon is not a 2D numpy array'
+        assert(isinstance(lat, np.ndarray) and len(lat.squeeze().shape) == 2), 'lat is not a 2D numpy array'
         assert (isinstance(time, np.ndarray) or not time), 'time is not a numpy array'
         if isinstance(time, np.ndarray):
             assert(len(time.shape) == 1), 'time is not a vector'
 
-        self.lon = lon
-        self.lat = lat
+        self.lon = lon.squeeze()
+        self.lat = lat.squeeze()
         self.time = np.zeros(1, dtype=np.float64) if time is None else time
         if not self.lon.dtype == np.float32:
             logger.warning_once("Casting lon data to np.float32")


### PR DESCRIPTION
- Allow for `FieldSet.from_netcdf()` to have no `U` and `V`, like `FieldSet.from_data()`
- Allow for `Grid` dimensions with single-dimension entries (such as time-dimension of length 1) by using `np.squeeze()`