### PR TITLE
Use Anaconda-5 compilers and add OSX tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,55 @@
+language: python
+
 notifications:
   email: false
 
-language: python
-python:
-    - "2.7"
+matrix:
+  include:
+    - os: linux
+      python: 2.7
+      env: MINICONDA_NAME=Miniconda2-latest-Linux-x86_64.sh
+      sudo: required
+    - os: osx
+      language: generic
+      env: MINICONDA_NAME=Miniconda2-latest-MacOSX-x86_64.sh
 
-sudo: false
-
-before_install:
-    # Setup anaconda
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
+install:
+    - wget http://repo.continuum.io/miniconda/${MINICONDA_NAME} -O miniconda.sh;
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
     - conda update --yes conda
-
-install:
-    - conda env create --file environment.yml
+    - conda env create --file environment_${TRAVIS_OS_NAME}.yml
     - source activate py2_parcels
     - conda install --yes sphinx
     - pip install -e .
 
-before_script: # configure a headless display to test  plot generation
-    - "export DISPLAY=:99.0"
-    - "sh -e /etc/init.d/xvfb start"
-    - sleep 3 # give xvfb some time to start
-
 script:
-    - flake8 parcels
-    - flake8 tests
-    - parcels_get_examples examples/
+    - |
+      # Set up display to be able to plot in linux
+      if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
+        export DISPLAY=:99.0;
+        sh -e /etc/init.d/xvfb start;
+        sleep 3;
+      fi
     - py.test -v -s tests/
-    - py.test -v -s --nbval-lax examples/
-    - make linkcheck -C docs
+    - |
+      # only get examples on linux
+      if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
+        parcels_get_examples examples/;
+      fi
+    - |
+      # run linter on linux
+      if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
+        flake8 parcels;
+        flake8 tests;
+      fi
+    - |
+      # run link checks only on linux
+      if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
+        make linkcheck -C docs;
+      fi
+    - |
+      # evaluate example notebooks only on linux
+      if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
+        py.test -v -s --nbval-lax examples/;
+      fi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,7 +100,7 @@ The steps below are the installation instructions for Linux / macOS and for Wind
     activate root                              # Windows
 
     conda create -n py2_parcels -c conda-forge parcels jupyter basemap basemap-data-hires
-    
+
 3. Activate the newly created Parcels environment, get a copy of the the Parcels tutorials and examples, and run the simplest of the examples to validate that you have a working Parcels setup::
 
     source $HOME/miniconda2/bin/activate py2_parcels  # Linux / macOS
@@ -141,7 +141,11 @@ Then, just after step 2 of :ref:`installing-parcels` above, remove the conda-for
 Installation for developers
 ===========================
 
-Parcels depends on a working Python installation, a netCDF installation, a C compiler, and various Python packages.  If you prefer to maintain your own Python installation providing all this, ``git clone`` the `master branch of Parcels <https://github.com/OceanParcels/parcels>`_ and manually ``pip install`` all packages lister under ``dependencies`` in the `environment.yml <https://raw.githubusercontent.com/OceanParcels/parcels/master/environment.yml>`_ file.
+Parcels depends on a working Python installation, a netCDF installation, a C compiler, and various Python packages.  If you prefer to maintain your own Python installation providing all this, ``git clone`` the `master branch of Parcels <https://github.com/OceanParcels/parcels>`_ and manually ``pip install`` all packages lister under ``dependencies`` in the environment files
+
+    * `environment_linux.yml <https://raw.githubusercontent.com/OceanParcels/parcels/master/environment_linux.yml>`_ for Linux,
+    * `environment_osx.yml <https://raw.githubusercontent.com/OceanParcels/parcels/master/environment_osx.yml>`_ for OSX, or
+    * `environment_win.yml <https://raw.githubusercontent.com/OceanParcels/parcels/master/environment_win.yml>`_ for Windows.
 
 Then, install Parcels in an `editable way <https://pip.pypa.io/en/stable/reference/pip_install/?highlight=editable#cmdoption-e>`_ by running::
 

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -9,10 +9,10 @@ dependencies:
   - enum34
   - ffmpeg>=3.2.3,<3.2.6
   - flake8>=2.1.0
+  - gcc_linux-64
   - git
   - jupyter
-  - m2w64-toolchain
-  - matplotlib 2.0.2
+  - matplotlib=2.0.2
   - netcdf4>=1.1.9
   - numpy>=1.9.1
   - progressbar2
@@ -20,7 +20,7 @@ dependencies:
   - pymbolic
   - python-dateutil
   - scipy>=0.16.0
-  - six>=1.10.0
+  - six >=1.10.0
   - xarray>=0.5.1
   - pip:
       - pytest>=2.7.0

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -5,11 +5,12 @@ dependencies:
   - python=2.7
   - cachetools>=1.0.0
   - cgen
+  - clang_osx-64
+  - coverage
   - enum34
-  - ffmpeg
+  - ffmpeg>=3.2.3,<3.2.6
   - flake8>=2.1.0
   - git
-  - gcc
   - jupyter
   - matplotlib=2.0.2
   - netcdf4>=1.1.9
@@ -21,7 +22,6 @@ dependencies:
   - scipy>=0.16.0
   - six>=1.10.0
   - xarray>=0.5.1
-  - coverage
   - pip:
       - pytest>=2.7.0
       - nbval


### PR DESCRIPTION
(This is a rebased version of #283.)

This uses the new compiler suites that come with Anaconda 5, splits up the
example environment files into the three OSs Linux, OSX, Windows, and adapts
the documentation accordingly.