### PR TITLE
WIP: Fix travis builds for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,26 +6,36 @@ notifications:
 matrix:
   include:
     - os: linux
-      python: 2.7
-      env: MINICONDA_NAME=Miniconda2-latest-Linux-x86_64.sh
+      language: generic
+      env:
+          - PY_VERSION=2
+          - MINICONDA_NAME=Miniconda3-latest-Linux-x86_64.sh
       sudo: required
     - os: linux
-      python: 3.6
-      env: MINICONDA_NAME=Miniconda3-latest-Linux-x86_64.sh
+      language: generic
+      env:
+          - PY_VERSION=3
+          - MINICONDA_NAME=Miniconda3-latest-Linux-x86_64.sh
       sudo: required
     - os: osx
       language: generic
-      env: MINICONDA_NAME=Miniconda2-latest-MacOSX-x86_64.sh
+      env:
+          - PY_VERSION=2
+          - MINICONDA_NAME=Miniconda3-latest-MacOSX-x86_64.sh
+    - os: osx
+      language: generic
+      env:
+          - PY_VERSION=3
+          - MINICONDA_NAME=Miniconda3-latest-MacOSX-x86_64.sh
 
 install:
     - wget http://repo.continuum.io/miniconda/${MINICONDA_NAME} -O miniconda.sh;
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
-    - conda update --yes conda
-    - conda env create --file environment_${TRAVIS_OS_NAME}.yml
-    - source activate py2_parcels
+    - conda env create --file environment_py${PY_VERSION}_${TRAVIS_OS_NAME}.yml
+    - source activate parcels
     - conda install --yes sphinx
-    - pip install -e .
+    - python setup.py install
 
 script:
     - |

--- a/environment_py2_linux.yml
+++ b/environment_py2_linux.yml
@@ -1,0 +1,28 @@
+name: parcels
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=2.7
+  - cachetools>=1.0.0
+  - cgen
+  - coverage
+  - enum34
+  - ffmpeg>=3.2.3,<3.2.6
+  - flake8>=2.1.0
+  - gcc_linux-64
+  - git
+  - jupyter
+  - matplotlib=2.0.2
+  - netcdf4>=1.1.9
+  - numpy>=1.9.1
+  - progressbar2
+  - py>=1.4.27
+  - pymbolic
+  - python-dateutil
+  - scipy>=0.16.0
+  - six >=1.10.0
+  - xarray>=0.5.1
+  - pip:
+      - pytest>=2.7.0
+      - nbval

--- a/environment_py2_osx.yml
+++ b/environment_py2_osx.yml
@@ -1,0 +1,28 @@
+name: parcels
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=2.7
+  - cachetools>=1.0.0
+  - cgen
+  - clang_osx-64
+  - coverage
+  - enum34
+  - ffmpeg>=3.2.3,<3.2.6
+  - flake8>=2.1.0
+  - git
+  - jupyter
+  - matplotlib=2.0.2
+  - netcdf4>=1.1.9
+  - numpy>=1.9.1
+  - progressbar2
+  - py>=1.4.27
+  - pymbolic
+  - python-dateutil
+  - scipy>=0.16.0
+  - six>=1.10.0
+  - xarray>=0.5.1
+  - pip:
+      - pytest>=2.7.0
+      - nbval

--- a/environment_py3_linux.yml
+++ b/environment_py3_linux.yml
@@ -1,15 +1,15 @@
-name: py2_parcels
+name: parcels
 channels:
+  - defaults
   - conda-forge
 dependencies:
-  - python=2.7
+  - python>=3.4
   - cachetools>=1.0.0
   - cgen
-  - clang_osx-64
   - coverage
-  - enum34
   - ffmpeg>=3.2.3,<3.2.6
   - flake8>=2.1.0
+  - gcc_linux-64
   - git
   - jupyter
   - matplotlib=2.0.2
@@ -20,7 +20,7 @@ dependencies:
   - pymbolic
   - python-dateutil
   - scipy>=0.16.0
-  - six>=1.10.0
+  - six >=1.10.0
   - xarray>=0.5.1
   - pip:
       - pytest>=2.7.0

--- a/environment_py3_osx.yml
+++ b/environment_py3_osx.yml
@@ -1,13 +1,15 @@
-name: py2_parcels
+name: parcels
 channels:
+  - defaults
   - conda-forge
 dependencies:
+  - python>=3.4
   - cachetools>=1.0.0
   - cgen
+  - clang_osx-64
   - coverage
   - ffmpeg>=3.2.3,<3.2.6
   - flake8>=2.1.0
-  - gcc_linux-64
   - git
   - jupyter
   - matplotlib=2.0.2
@@ -18,7 +20,7 @@ dependencies:
   - pymbolic
   - python-dateutil
   - scipy>=0.16.0
-  - six >=1.10.0
+  - six>=1.10.0
   - xarray>=0.5.1
   - pip:
       - pytest>=2.7.0


### PR DESCRIPTION
This introduces quite a few changes:

1. There is an env file per job now: `environment_py3_linux.yml`, ...

2. Travis runs all jobs with `language: generic` and picks the Python
version via an environment variable.

3. Travis uses Miniconda 3 for all jobs.

The resulting build fails with only one error in `test_kernel_language.py:test_print[jit]`.