### PR TITLE
better error message when shape of field.data is not as expected

### DIFF
--- a/parcels/examples/example_brownian.py
+++ b/parcels/examples/example_brownian.py
@@ -13,8 +13,8 @@ def zeros_fieldset(xdim=2, ydim=2):
     lat = np.linspace(-20, 20, ydim, dtype=np.float32)
 
     dimensions = {'lon': lon, 'lat': lat}
-    data = {'U': np.zeros((xdim, ydim), dtype=np.float32),
-            'V': np.zeros((xdim, ydim), dtype=np.float32)}
+    data = {'U': np.zeros((ydim, xdim), dtype=np.float32),
+            'V': np.zeros((ydim, xdim), dtype=np.float32)}
     return FieldSet.from_data(data, dimensions, mesh='spherical')
 
 

--- a/parcels/examples/example_decaying_moving_eddy.py
+++ b/parcels/examples/example_decaying_moving_eddy.py
@@ -31,12 +31,12 @@ def decaying_moving_eddy_fieldset(xdim=2, ydim=2):  # Define 2D flat, square fie
     lon = np.linspace(0, 20000, xdim, dtype=np.float32)
     lat = np.linspace(5000, 12000, ydim, dtype=np.float32)
 
-    U = np.zeros((lon.size, lat.size, time.size), dtype=np.float32)
-    V = np.zeros((lon.size, lat.size, time.size), dtype=np.float32)
+    U = np.zeros((time.size, lat.size, lon.size), dtype=np.float32)
+    V = np.zeros((time.size, lat.size, lon.size), dtype=np.float32)
 
     for t in range(time.size):
-        U[:, :, t] = u_g*np.exp(-gamma_g*time[t]) + (u_0-u_g)*np.exp(-gamma*time[t])*np.cos(f*time[t])
-        V[:, :, t] = -(u_0-u_g)*np.exp(-gamma*time[t])*np.sin(f*time[t])
+        U[t, :, :] = u_g*np.exp(-gamma_g*time[t]) + (u_0-u_g)*np.exp(-gamma*time[t])*np.cos(f*time[t])
+        V[t, :, :] = -(u_0-u_g)*np.exp(-gamma*time[t])*np.sin(f*time[t])
 
     data = {'U': U, 'V': V}
     dimensions = {'lon': lon, 'lat': lat, 'depth': depth, 'time': time}

--- a/parcels/examples/example_moving_eddies.py
+++ b/parcels/examples/example_moving_eddies.py
@@ -66,7 +66,7 @@ def moving_eddies_fieldset(xdim=200, ydim=350):
 
     data = {'U': U, 'V': V, 'P': P}
     dimensions = {'lon': lon, 'lat': lat, 'depth': depth, 'time': time}
-    return FieldSet.from_data(data, dimensions)
+    return FieldSet.from_data(data, dimensions, transpose=True)
 
 
 def moving_eddies_example(fieldset, npart=2, mode='jit', verbose=False,

--- a/parcels/examples/example_peninsula.py
+++ b/parcels/examples/example_peninsula.py
@@ -40,17 +40,17 @@ def peninsula_fieldset(xdim, ydim):
 
     # Define arrays U (zonal), V (meridional), W (vertical) and P (sea
     # surface height) all on A-grid
-    U = np.zeros((xdim, ydim), dtype=np.float32)
-    V = np.zeros((xdim, ydim), dtype=np.float32)
-    W = np.zeros((xdim, ydim), dtype=np.float32)
-    P = np.zeros((xdim, ydim), dtype=np.float32)
+    U = np.zeros((ydim, xdim), dtype=np.float32)
+    V = np.zeros((ydim, xdim), dtype=np.float32)
+    W = np.zeros((ydim, xdim), dtype=np.float32)
+    P = np.zeros((ydim, xdim), dtype=np.float32)
 
     u0 = 1
     x0 = 50.
     R = 0.32 * 50.
 
     # Create the fields
-    x, y = np.meshgrid(La, Wa, sparse=True, indexing='ij')
+    x, y = np.meshgrid(La, Wa, sparse=True, indexing='xy')
     P = u0*R**2*y/((x-x0)**2+y**2)-u0*y
     U = u0-u0*R**2*((x-x0)**2-y**2)/(((x-x0)**2+y**2)**2)
     V = -2*u0*R**2*((x-x0)*y)/(((x-x0)**2+y**2)**2)

--- a/parcels/examples/example_radial_rotation.py
+++ b/parcels/examples/example_radial_rotation.py
@@ -16,8 +16,8 @@ def radial_rotation_fieldset(xdim=200, ydim=200):  # Define 2D flat, square fiel
     x0 = 30.                                   # Define the origin to be the centre of the Field.
     y0 = 30.
 
-    U = np.zeros((xdim, ydim), dtype=np.float32)
-    V = np.zeros((xdim, ydim), dtype=np.float32)
+    U = np.zeros((ydim, xdim), dtype=np.float32)
+    V = np.zeros((ydim, xdim), dtype=np.float32)
 
     T = delta(days=1)
     omega = 2*np.pi/T.total_seconds()          # Define the rotational period as 1 day.
@@ -32,8 +32,8 @@ def radial_rotation_fieldset(xdim=200, ydim=200):  # Define 2D flat, square fiel
             theta = math.atan2((lat[j]-y0), (lon[i]-x0))  # Define the polar angle.
             assert(abs(theta) <= np.pi)
 
-            U[i, j] = r * math.sin(theta) * omega
-            V[i, j] = -r * math.cos(theta) * omega
+            U[j, i] = r * math.sin(theta) * omega
+            V[j, i] = -r * math.cos(theta) * omega
 
     data = {'U': U, 'V': V}
     dimensions = {'lon': lon, 'lat': lat}

--- a/parcels/examples/example_recursive_errorhandling.py
+++ b/parcels/examples/example_recursive_errorhandling.py
@@ -24,8 +24,8 @@ def test_recursive_errorhandling(mode, xdim=2, ydim=2):
 
     dimensions = {'lon': np.linspace(0., 1., xdim, dtype=np.float32),
                   'lat': np.linspace(0., 1., ydim, dtype=np.float32)}
-    data = {'U': np.zeros((xdim, ydim), dtype=np.float32),
-            'V': np.zeros((xdim, ydim), dtype=np.float32)}
+    data = {'U': np.zeros((ydim, xdim), dtype=np.float32),
+            'V': np.zeros((ydim, xdim), dtype=np.float32)}
     fieldset = FieldSet.from_data(data, dimensions, mesh='flat')
 
     # Set minimum value for valid longitudes (i.e. all longitudes < minlon are 'land')

--- a/parcels/examples/example_stommel.py
+++ b/parcels/examples/example_stommel.py
@@ -61,7 +61,7 @@ def stommel_fieldset(xdim=200, ydim=200):
 
     data = {'U': U, 'V': V, 'P': P}
     dimensions = {'lon': lon, 'lat': lat, 'depth': depth, 'time': time}
-    return FieldSet.from_data(data, dimensions, mesh='flat')
+    return FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
 
 
 def UpdateP(particle, fieldset, time, dt):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -143,7 +143,12 @@ class Field(object):
     """Class that encapsulates access to field data.
 
     :param name: Name of the field
-    :param data: 2D, 3D or 4D numpy array of field data
+    :param data: 2D, 3D or 4D numpy array of field data.
+           1. If data shape is [xdim, ydim], [xdim, ydim, zdim], [xdim, ydim, tdim] or [xdim, ydim, zdim, tdim],
+              Use the flag transpose=True
+           2. If data shape is [ydim, xdim], [zdim, ydim, xdim], [tdim, ydim, xdim] or [tdim, zdim, ydim, xdim],
+              Use the flat transpose=False
+           3. If data has any other shape, you first need to reorder it
     :param lon: Longitude coordinates (numpy vector or array) of the field (only if grid is None)
     :param lat: Latitude coordinates (numpy vector or array) of the field (only if grid is None)
     :param depth: Depth coordinates (numpy vector or array) of the field (only if grid is None)

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -145,9 +145,10 @@ class Field(object):
     :param name: Name of the field
     :param data: 2D, 3D or 4D numpy array of field data.
            1. If data shape is [xdim, ydim], [xdim, ydim, zdim], [xdim, ydim, tdim] or [xdim, ydim, zdim, tdim],
-              Use the flag transpose=True
+              whichever is relevant for the dataset,
+              use the flag transpose=True
            2. If data shape is [ydim, xdim], [zdim, ydim, xdim], [tdim, ydim, xdim] or [tdim, zdim, ydim, xdim],
-              Use the flat transpose=False
+              use the flag transpose=False
            3. If data has any other shape, you first need to reorder it
     :param lon: Longitude coordinates (numpy vector or array) of the field (only if grid is None)
     :param lat: Latitude coordinates (numpy vector or array) of the field (only if grid is None)
@@ -228,14 +229,10 @@ class Field(object):
                 self.data = self.data.reshape(sum(((self.data.shape[0],), self.data.shape[2:]), ()))
         if len(self.data.shape) == 4:
             assert self.data.shape == (self.grid.tdim, self.grid.zdim, self.grid.ydim, self.grid.xdim), \
-                                      ('Field %s expect a data shape of a [tdim, zdim, ydim, xdim] = [%d %d %d %d], but data is [%d %d %d %d]' %
-                                       (self.name, self.grid.tdim, self.grid.zdim, self.grid.ydim, self.grid.xdim,
-                                        self.data.shape[0], self.data.shape[1], self.data.shape[2], self.data.shape[3]))
+                                      ('Field %s expecting a data shape of a [ydim, xdim], [zdim, ydim, xdim], [tdim, ydim, xdim] or [tdim, zdim, ydim, xdim]. Flag transpose=True could help to reorder the data.')
         else:
             assert self.data.shape == (self.grid.tdim, self.grid.ydim, self.grid.xdim), \
-                                      ('Field %s expect a data shape of a [tdim, ydim, xdim] = [%d %d %d], but data is [%d %d %d]' %
-                                       (self.name, self.grid.tdim, self.grid.ydim, self.grid.xdim,
-                                        self.data.shape[0], self.data.shape[1], self.data.shape[2]))
+                                      ('Field %s expecting a data shape of a [ydim, xdim], [zdim, ydim, xdim], [tdim, ydim, xdim] or [tdim, zdim, ydim, xdim]. Flag transpose=True could help to reorder the data.')
 
         # Hack around the fact that NaN and ridiculously large values
         # propagate in SciPy's interpolators

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -222,9 +222,15 @@ class Field(object):
             if len(self.data.shape) == 4:
                 self.data = self.data.reshape(sum(((self.data.shape[0],), self.data.shape[2:]), ()))
         if len(self.data.shape) == 4:
-            assert self.data.shape == (self.grid.tdim, self.grid.zdim, self.grid.ydim, self.grid.xdim)
+            assert self.data.shape == (self.grid.tdim, self.grid.zdim, self.grid.ydim, self.grid.xdim), \
+                                      ('Field %s expect a data shape of a [tdim, zdim, ydim, xdim] = [%d %d %d %d], but data is [%d %d %d %d]' %
+                                       (self.name, self.grid.tdim, self.grid.zdim, self.grid.ydim, self.grid.xdim,
+                                        self.data.shape[0], self.data.shape[1], self.data.shape[2], self.data.shape[3]))
         else:
-            assert self.data.shape == (self.grid.tdim, self.grid.ydim, self.grid.xdim)
+            assert self.data.shape == (self.grid.tdim, self.grid.ydim, self.grid.xdim), \
+                                      ('Field %s expect a data shape of a [tdim, ydim, xdim] = [%d %d %d], but data is [%d %d %d]' %
+                                       (self.name, self.grid.tdim, self.grid.ydim, self.grid.xdim,
+                                        self.data.shape[0], self.data.shape[1], self.data.shape[2]))
 
         # Hack around the fact that NaN and ridiculously large values
         # propagate in SciPy's interpolators

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -145,8 +145,7 @@ class Field(object):
     :param name: Name of the field
     :param data: 2D, 3D or 4D numpy array of field data.
            1. If data shape is [xdim, ydim], [xdim, ydim, zdim], [xdim, ydim, tdim] or [xdim, ydim, zdim, tdim],
-              whichever is relevant for the dataset,
-              use the flag transpose=True
+              whichever is relevant for the dataset, use the flag transpose=True
            2. If data shape is [ydim, xdim], [zdim, ydim, xdim], [tdim, ydim, xdim] or [tdim, zdim, ydim, xdim],
               use the flag transpose=False
            3. If data has any other shape, you first need to reorder it

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -40,6 +40,11 @@ class FieldSet(object):
 
         :param data: Dictionary mapping field names to numpy arrays.
                Note that at least a 'U' and 'V' numpy array need to be given
+               1. If data shape is [xdim, ydim], [xdim, ydim, zdim], [xdim, ydim, tdim] or [xdim, ydim, zdim, tdim],
+                  Use the flag transpose=True (default value)
+               2. If data shape is [ydim, xdim], [zdim, ydim, xdim], [tdim, ydim, xdim] or [tdim, zdim, ydim, xdim],
+                  Use the flat transpose=False
+               3. If data has any other shape, you first need to reorder it
         :param dimensions: Dictionary mapping field dimensions (lon,
                lat, depth, time) to numpy arrays.
                Note that dimensions can also be a dictionary of dictionaries if

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -34,16 +34,17 @@ class FieldSet(object):
             self.add_field(field)
 
     @classmethod
-    def from_data(cls, data, dimensions, transpose=True, mesh='spherical',
+    def from_data(cls, data, dimensions, transpose=False, mesh='spherical',
                   allow_time_extrapolation=True, time_periodic=False, **kwargs):
         """Initialise FieldSet object from raw data
 
         :param data: Dictionary mapping field names to numpy arrays.
                Note that at least a 'U' and 'V' numpy array need to be given
                1. If data shape is [xdim, ydim], [xdim, ydim, zdim], [xdim, ydim, tdim] or [xdim, ydim, zdim, tdim],
-                  Use the flag transpose=True (default value)
+                  whichever is relevant for the dataset,
+                  use the flag transpose=True
                2. If data shape is [ydim, xdim], [zdim, ydim, xdim], [tdim, ydim, xdim] or [tdim, zdim, ydim, xdim],
-                  Use the flat transpose=False
+                  use the flag transpose=False (default value)
                3. If data has any other shape, you first need to reorder it
         :param dimensions: Dictionary mapping field dimensions (lon,
                lat, depth, time) to numpy arrays.

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -41,8 +41,7 @@ class FieldSet(object):
         :param data: Dictionary mapping field names to numpy arrays.
                Note that at least a 'U' and 'V' numpy array need to be given
                1. If data shape is [xdim, ydim], [xdim, ydim, zdim], [xdim, ydim, tdim] or [xdim, ydim, zdim, tdim],
-                  whichever is relevant for the dataset,
-                  use the flag transpose=True
+                  whichever is relevant for the dataset, use the flag transpose=True
                2. If data shape is [ydim, xdim], [zdim, ydim, xdim], [tdim, ydim, xdim] or [tdim, zdim, ydim, xdim],
                   use the flag transpose=False (default value)
                3. If data has any other shape, you first need to reorder it

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -43,7 +43,7 @@ def test_advection_zonal(lon, lat, depth, mode, npart=10):
     data3D = {'U': np.ones((lon.size, lat.size, depth.size), dtype=np.float32),
               'V': np.zeros((lon.size, lat.size, depth.size), dtype=np.float32)}
     dimensions = {'lon': lon, 'lat': lat}
-    fieldset2D = FieldSet.from_data(data2D, dimensions, mesh='spherical')
+    fieldset2D = FieldSet.from_data(data2D, dimensions, mesh='spherical', transpose=True)
 
     pset2D = ParticleSet(fieldset2D, pclass=ptype[mode],
                          lon=np.zeros(npart, dtype=np.float32) + 20.,
@@ -52,7 +52,7 @@ def test_advection_zonal(lon, lat, depth, mode, npart=10):
     assert (np.diff(np.array([p.lon for p in pset2D])) > 1.e-4).all()
 
     dimensions['depth'] = depth
-    fieldset3D = FieldSet.from_data(data3D, dimensions, mesh='spherical')
+    fieldset3D = FieldSet.from_data(data3D, dimensions, mesh='spherical', transpose=True)
     pset3D = ParticleSet(fieldset3D, pclass=ptype[mode],
                          lon=np.zeros(npart, dtype=np.float32) + 20.,
                          lat=np.linspace(0, 80, npart, dtype=np.float32),
@@ -69,7 +69,7 @@ def test_advection_meridional(lon, lat, mode, npart=10):
     data = {'U': np.zeros((lon.size, lat.size), dtype=np.float32),
             'V': np.ones((lon.size, lat.size), dtype=np.float32)}
     dimensions = {'lon': lon, 'lat': lat}
-    fieldset = FieldSet.from_data(data, dimensions, mesh='spherical')
+    fieldset = FieldSet.from_data(data, dimensions, mesh='spherical', transpose=True)
 
     pset = ParticleSet(fieldset, pclass=ptype[mode],
                        lon=np.linspace(-60, 60, npart, dtype=np.float32),
@@ -90,7 +90,7 @@ def test_advection_3D(mode, npart=11):
     data = {'U': np.ones((xdim, ydim, zdim), dtype=np.float32),
             'V': np.zeros((xdim, ydim, zdim), dtype=np.float32)}
     data['U'][:, :, 0] = 0.
-    fieldset = FieldSet.from_data(data, dimensions, mesh='flat')
+    fieldset = FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
 
     pset = ParticleSet(fieldset, pclass=ptype[mode],
                        lon=np.zeros(npart, dtype=np.float32),
@@ -107,7 +107,7 @@ def periodicfields(xdim, ydim, uvel, vvel):
 
     data = {'U': uvel * np.ones((xdim, ydim), dtype=np.float32),
             'V': vvel * np.ones((xdim, ydim), dtype=np.float32)}
-    return FieldSet.from_data(data, dimensions, mesh='spherical')
+    return FieldSet.from_data(data, dimensions, mesh='spherical', transpose=True)
 
 
 def periodicBC(particle, fieldset, time, dt):
@@ -171,7 +171,7 @@ def fieldset_stationary(xdim=100, ydim=100, maxtime=delta(hours=6)):
                   'time': time}
     data = {'U': np.ones((xdim, ydim, 1), dtype=np.float32) * u_0 * np.cos(f * time),
             'V': np.ones((xdim, ydim, 1), dtype=np.float32) * -u_0 * np.sin(f * time)}
-    return FieldSet.from_data(data, dimensions, mesh='flat')
+    return FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
@@ -209,7 +209,7 @@ def test_stationary_eddy_vertical(mode, npart=1):
 
     dimensions = {'lon': lon_data, 'lat': lat_data, 'time': time_data}
     data = {'U': fld1, 'V': fldzero, 'W': fld2}
-    fieldset = FieldSet.from_data(data, dimensions, mesh='flat')
+    fieldset = FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
 
     pset = ParticleSet(fieldset, pclass=ptype[mode], lon=lon,
                        lat=lat, depth=depth)
@@ -221,7 +221,7 @@ def test_stationary_eddy_vertical(mode, npart=1):
     assert np.allclose(np.array([p.depth for p in pset]), exp_depth, rtol=1e-5)
 
     data = {'U': fldzero, 'V': fld2, 'W': fld1}
-    fieldset = FieldSet.from_data(data, dimensions, mesh='flat')
+    fieldset = FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
 
     pset = ParticleSet(fieldset, pclass=ptype[mode], lon=lon,
                        lat=lat, depth=depth)
@@ -252,7 +252,7 @@ def fieldset_moving(xdim=100, ydim=100, maxtime=delta(hours=6)):
                   'time': time}
     data = {'U': np.ones((xdim, ydim, 1), dtype=np.float32) * u_g + (u_0 - u_g) * np.cos(f * time),
             'V': np.ones((xdim, ydim, 1), dtype=np.float32) * -(u_0 - u_g) * np.sin(f * time)}
-    return FieldSet.from_data(data, dimensions, mesh='flat')
+    return FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
@@ -296,7 +296,7 @@ def fieldset_decaying(xdim=100, ydim=100, maxtime=delta(hours=6)):
                   'time': time}
     data = {'U': np.ones((xdim, ydim, 1), dtype=np.float32) * u_g * np.exp(-gamma_g * time) + (u_0 - u_g) * np.exp(-gamma * time) * np.cos(f * time),
             'V': np.ones((xdim, ydim, 1), dtype=np.float32) * -(u_0 - u_g) * np.exp(-gamma * time) * np.sin(f * time)}
-    return FieldSet.from_data(data, dimensions, mesh='flat')
+    return FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -14,8 +14,8 @@ def zeros_fieldset(mesh='spherical', xdim=200, ydim=100, mesh_conversion=1):
     lat = np.linspace(-1e5*mesh_conversion, 1e5*mesh_conversion, ydim, dtype=np.float32)
 
     dimensions = {'lon': lon, 'lat': lat}
-    data = {'U': np.zeros((xdim, ydim), dtype=np.float32),
-            'V': np.zeros((xdim, ydim), dtype=np.float32)}
+    data = {'U': np.zeros((ydim, xdim), dtype=np.float32),
+            'V': np.zeros((ydim, xdim), dtype=np.float32)}
     return FieldSet.from_data(data, dimensions, mesh=mesh)
 
 

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -42,7 +42,7 @@ def fieldset(xdim=200, ydim=100):
     data = {'U': U, 'V': V}
     dimensions = {'lon': lon, 'lat': lat}
 
-    return FieldSet.from_data(data, dimensions, mesh='flat')
+    return FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
 
 
 @pytest.fixture
@@ -55,7 +55,7 @@ def fieldset_geometric(xdim=200, ydim=100):
     V *= 1000. * 1.852 * 60.
     data = {'U': U, 'V': V}
     dimensions = {'lon': lon, 'lat': lat}
-    fieldset = FieldSet.from_data(data, dimensions)
+    fieldset = FieldSet.from_data(data, dimensions, transpose=True)
     fieldset.U.units = Geographic()
     fieldset.V.units = Geographic()
     return fieldset
@@ -76,7 +76,7 @@ def fieldset_geometric_polar(xdim=200, ydim=100):
     V *= 1000. * 1.852 * 60.
     data = {'U': U, 'V': V}
     dimensions = {'lon': lon, 'lat': lat}
-    return FieldSet.from_data(data, dimensions, mesh='spherical')
+    return FieldSet.from_data(data, dimensions, mesh='spherical', transpose=True)
 
 
 def test_fieldset_sample(fieldset, xdim=120, ydim=80):
@@ -108,7 +108,7 @@ def test_variable_init_from_field(mode, npart=9):
             'V': np.zeros(dims, dtype=np.float32),
             'P': np.zeros(dims, dtype=np.float32)}
     data['P'][0, 0] = 1.
-    fieldset = FieldSet.from_data(data, dimensions, mesh='flat')
+    fieldset = FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
     xv, yv = np.meshgrid(np.linspace(0, 1, np.sqrt(npart)), np.linspace(0, 1, np.sqrt(npart)))
 
     class VarParticle(pclass(mode)):
@@ -130,7 +130,7 @@ def test_pset_from_field(mode, xdim=10, ydim=20, npart=10000):
     data = {'U': np.zeros((xdim, ydim), dtype=np.float32),
             'V': np.zeros((xdim, ydim), dtype=np.float32),
             'start': startfield}
-    fieldset = FieldSet.from_data(data, dimensions, mesh='flat')
+    fieldset = FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
 
     pset = ParticleSet.from_field(fieldset, size=npart, pclass=pclass(mode),
                                   start_field=fieldset.start)
@@ -150,7 +150,7 @@ def test_nearest_neighbour_interpolation2D(mode, k_sample_p, npart=81):
             'V': np.zeros(dims, dtype=np.float32),
             'P': np.zeros(dims, dtype=np.float32)}
     data['P'][0, 1] = 1.
-    fieldset = FieldSet.from_data(data, dimensions, mesh='flat')
+    fieldset = FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
     fieldset.P.interp_method = 'nearest'
     xv, yv = np.meshgrid(np.linspace(0., 1.0, np.sqrt(npart)), np.linspace(0., 1.0, np.sqrt(npart)))
     pset = ParticleSet(fieldset, pclass=pclass(mode),
@@ -170,7 +170,7 @@ def test_nearest_neighbour_interpolation3D(mode, k_sample_p, npart=81):
             'V': np.zeros(dims, dtype=np.float32),
             'P': np.zeros(dims, dtype=np.float32)}
     data['P'][0, 1, 1] = 1.
-    fieldset = FieldSet.from_data(data, dimensions, mesh='flat')
+    fieldset = FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
     fieldset.P.interp_method = 'nearest'
     xv, yv = np.meshgrid(np.linspace(0, 1.0, np.sqrt(npart)), np.linspace(0, 1.0, np.sqrt(npart)))
     # combine a pset at 0m with pset at 1m, as meshgrid does not do 3D
@@ -250,7 +250,7 @@ def test_meridionalflow_spherical(mode, xdim=100, ydim=200):
     data = {'U': np.zeros([xdim, ydim]),
             'V': maxvel * np.ones([xdim, ydim])}
 
-    fieldset = FieldSet.from_data(data, dimensions, mesh='spherical')
+    fieldset = FieldSet.from_data(data, dimensions, mesh='spherical', transpose=True)
 
     lonstart = [0, 45]
     latstart = [0, 45]
@@ -279,7 +279,7 @@ def test_zonalflow_spherical(mode, k_sample_p, xdim=100, ydim=200):
             'V': np.zeros([xdim, ydim]),
             'P': p_fld * np.ones([xdim, ydim])}
 
-    fieldset = FieldSet.from_data(data, dimensions, mesh='spherical')
+    fieldset = FieldSet.from_data(data, dimensions, mesh='spherical', transpose=True)
 
     lonstart = [0, 45]
     latstart = [0, 45]
@@ -311,7 +311,7 @@ def test_random_field(mode, k_sample_p, xdim=20, ydim=20, npart=100):
             'P': np.random.uniform(0, 1., size=(xdim, ydim)),
             'start': np.ones((xdim, ydim), dtype=np.float32)}
 
-    fieldset = FieldSet.from_data(data, dimensions, mesh='flat')
+    fieldset = FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
     pset = ParticleSet.from_field(fieldset, size=npart, pclass=pclass(mode),
                                   start_field=fieldset.start)
     pset.execute(k_sample_p, endtime=1., dt=1.0)
@@ -331,7 +331,7 @@ def test_sampling_out_of_bounds_time(mode, allow_time_extrapolation, k_sample_p,
             'P': np.ones((xdim, ydim, 1), dtype=np.float32) * dimensions['time']}
 
     fieldset = FieldSet.from_data(data, dimensions, mesh='flat',
-                                  allow_time_extrapolation=allow_time_extrapolation)
+                                  allow_time_extrapolation=allow_time_extrapolation, transpose=True)
     pset = ParticleSet(fieldset, pclass=pclass(mode), lon=[0.5], lat=[0.5], time=-1.0)
     if allow_time_extrapolation:
         pset.execute(k_sample_p, endtime=-0.9, dt=0.1)

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -25,7 +25,7 @@ def fieldset(xdim=20, ydim=20):
     U, V = np.meshgrid(lat, lon)
     data = {'U': np.array(U, dtype=np.float32), 'V': np.array(V, dtype=np.float32)}
     dimensions = {'lat': lat, 'lon': lon}
-    return FieldSet.from_data(data, dimensions, mesh='flat')
+    return FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -9,8 +9,8 @@ ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 
 @pytest.fixture
 def fieldset(xdim=40, ydim=100):
-    U = np.zeros((xdim, ydim), dtype=np.float32)
-    V = np.zeros((xdim, ydim), dtype=np.float32)
+    U = np.zeros((ydim, xdim), dtype=np.float32)
+    V = np.zeros((ydim, xdim), dtype=np.float32)
     lon = np.linspace(0, 1, xdim, dtype=np.float32)
     lat = np.linspace(-60, 60, ydim, dtype=np.float32)
     depth = np.zeros(1, dtype=np.float32)

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -9,8 +9,8 @@ ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 
 @pytest.fixture
 def fieldset(xdim=100, ydim=100):
-    data = {'U': np.zeros((xdim, ydim), dtype=np.float32),
-            'V': np.zeros((xdim, ydim), dtype=np.float32)}
+    data = {'U': np.zeros((ydim, xdim), dtype=np.float32),
+            'V': np.zeros((ydim, xdim), dtype=np.float32)}
     dimensions = {'lon': np.linspace(0, 1, xdim, dtype=np.float32),
                   'lat': np.linspace(0, 1, ydim, dtype=np.float32)}
     return FieldSet.from_data(data, dimensions, mesh='flat')


### PR DESCRIPTION

Error message looks like:

WARNING: Casting field data to np.float32
Traceback (most recent call last):
  File "test.py", line 37, in <module>
    field_set = FieldSet.from_data(data, dimensions,mesh='spherical', allow_time_extrapolation=True)#, transpose=False)
  File "/Users/delandmeter/sources/parcels/parcels/fieldset.py", line 73, in from_data
    allow_time_extrapolation=allow_time_extrapolation, time_periodic=time_periodic, **kwargs)
  File "/Users/delandmeter/sources/parcels/parcels/field.py", line 233, in __init__
    self.data.shape[0], self.data.shape[1], self.data.shape[2]))
AssertionError: Field U expect a data shape of a [tdim, ydim, xdim] = [1 81 131], but data is [1 131 81]

@erikvansebille , do you think we should even improve it? The message is perfect for someone using tdim > 1. But if original array has shape (131 81), it will have the following message, since we add the t dimension to the original data, the final message looks like above.

