### PR TITLE
Add string argument option to particleset.density()

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -497,7 +497,7 @@ class ParticleSet(object):
         :param field: Optional :mod:`parcels.field.Field` object to calculate the histogram
                       on. Default is `fieldset.U`
         :param particle_val: Optional numpy-array of values to weigh each particle with,
-                             or string name of particle attribute to use weigh particles with.
+                             or string name of particle variable to use weigh particles with.
                              Default is None, resulting in a value of 1 for each particle
         :param relative: Boolean to control whether the density is scaled by the total
                          weight of all particles. Default is False
@@ -506,7 +506,7 @@ class ParticleSet(object):
         """
 
         field = field if field else self.fieldset.U
-        if isinstance(particle_val, basestring):
+        if isinstance(particle_val, str):
             particle_val = [getattr(p, particle_val) for p in self.particles]
         else:
             particle_val = particle_val if particle_val else np.ones(len(self.particles))

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -496,8 +496,9 @@ class ParticleSet(object):
 
         :param field: Optional :mod:`parcels.field.Field` object to calculate the histogram
                       on. Default is `fieldset.U`
-        :param particle_val: Optional numpy-array of values to weigh each particle with.
-                             Default is 1 for each particle
+        :param particle_val: Optional numpy-array of values to weigh each particle with,
+                             or string name of particle attribute to use weigh particles with.
+                             Default is None, resulting in a value of 1 for each particle
         :param relative: Boolean to control whether the density is scaled by the total
                          weight of all particles. Default is False
         :param area_scale: Boolean to control whether the density is scaled by the area
@@ -505,7 +506,10 @@ class ParticleSet(object):
         """
 
         field = field if field else self.fieldset.U
-        particle_val = particle_val if particle_val else np.ones(len(self.particles))
+        if isinstance(particle_val, basestring):
+            particle_val = [getattr(p, particle_val) for p in self.particles]
+        else:
+            particle_val = particle_val if particle_val else np.ones(len(self.particles))
         density = np.zeros((field.grid.lat.size, field.grid.lon.size), dtype=np.float32)
 
         for pi, p in enumerate(self.particles):


### PR DESCRIPTION
Added a check for the option of particle_val being of type basestring (note this won't work for python 3.x), in which case this string is assumed to be the name of a particle attribute used for weighting density calculation. Otherwise, the use of particle_val is as before.