### PR TITLE
Set python version when copying example notebooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,8 @@ script:
         make linkcheck -C docs;
       fi
     - |
-      # evaluate example scripts and notebooks on linux python2
-      if [[ "${PY_VERSION}" = 2 ]] && [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
+      # evaluate example scripts and notebooks on linux only
+      if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
         py.test -v -s --nbval-lax examples/;
-      fi
-    - |
-      # evaluate example scripts only on linux python2
-      if [[ "${PY_VERSION}" = 3 ]] && [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
         py.test -v -s examples/;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,4 @@ script:
       # evaluate example scripts and notebooks on linux only
       if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
         py.test -v -s --nbval-lax examples/;
-        py.test -v -s examples/;
       fi

--- a/parcels/scripts/get_examples.py
+++ b/parcels/scripts/get_examples.py
@@ -2,6 +2,8 @@
 
 import argparse
 from datetime import datetime, timedelta
+from glob import glob
+import json
 import os
 import pkg_resources
 from progressbar import ProgressBar
@@ -12,6 +14,7 @@ except ImportError:
     # Fall back to Python 2's urllib2
     from urllib2 import urlopen
 import shutil
+import sys
 
 example_data_files = (
     ["MovingEddies_data/" + fn for fn in [
@@ -58,6 +61,25 @@ def copy_data_and_examples_from_package_to(target_path):
         pass
 
 
+def set_jupyter_kernel_to_python_version(path, python_version=2):
+    """Set notebook kernelspec to desired python version.
+
+    This also drops all other meta data from the notebook.
+    """
+    for file_name in glob(os.path.join(path, "*.ipynb")):
+
+        with open(file_name, 'r') as f:
+            notebook_data = json.load(f)
+
+        notebook_data['metadata'] = {"kernelspec": {
+            "display_name": "Python {}".format(python_version),
+            "language": "python",
+            "name": "python{}".format(python_version)}}
+
+        with open(file_name, 'w') as f:
+            json.dump(notebook_data, f, indent=2)
+
+
 def _still_to_download(file_names, target_path):
     """Only return the files that are not yet present on disk."""
     for fn in list(file_names):
@@ -102,6 +124,11 @@ def main(target_path=None):
 
     # copy data and examples
     copy_data_and_examples_from_package_to(target_path)
+
+    # make sure the notebooks use the correct python version
+    set_jupyter_kernel_to_python_version(
+        target_path,
+        python_version=sys.version_info[0])
 
     # try downloading remaining files
     remaining_example_data_files = _still_to_download(


### PR DESCRIPTION
The notebooks included in the examples usually contain metadata specifying the
kernel to use.  For notebooks saved after using a Python 2 kernel, this will
ensure that Jupyter tries to pick the correct kernel when the notebook is
opened again.  For testing with `pytest --nbval*`, however, this means that
nbval will fail if a notebook specifying Python 2 is evaluated from a Python 3
environment.

This commit adds a function to `parcels_get_examples` which reads the current
Python version from `sys` and then writes a corresponding `kernelspec` to the
notebook metadata.