### PR TITLE
Use xfail rather than skip

### DIFF
--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -112,7 +112,7 @@ def test_while_if_break(fieldset, mode):
 @pytest.mark.parametrize(
     'mode',
     ['scipy',
-     pytest.mark.skipif(
+     pytest.mark.xfail(
          (sys.version_info >= (3, 0)) or (sys.platform == 'win32'),
          reason="py.test FD capturing does not work for jit on python3 or Win"
      )(


### PR DESCRIPTION
This will run the tests that we know (or expect) to fail under the given circumstances rather than skipping them right away.  Acutally running the tests and allowing them to fail has the advantage that if the reason for the failure disappears in the future, we'll notice that the tests pass.