### PR TITLE
Also test with xcode 9.3 but allow failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,15 @@ matrix:
     - os: osx
       language: generic
       env: PY_VERSION=3 MINICONDA_NAME=Miniconda3-latest-MacOSX-x86_64.sh
+    - os: osx
+      osx_image: xcode9.3
+      language: generic
+      env: PY_VERSION=3 MINICONDA_NAME=Miniconda3-latest-MacOSX-x86_64.sh
+  allow_failures:
+    - os: osx
+      osx_image: xcode9.3
+      language: generic
+      env: PY_VERSION=3 MINICONDA_NAME=Miniconda3-latest-MacOSX-x86_64.sh
 
 install:
     - wget http://repo.continuum.io/miniconda/${MINICONDA_NAME} -O miniconda.sh;


### PR DESCRIPTION
This adds a test env which is currently failing because of #332.  But let's include it to see when the Anaconda compilers work with xcode again.

(Supercedes #341.)