### PR TITLE
Python3 multiplying with np.infty warning fix

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -363,7 +363,7 @@ class FieldSet(object):
 
     def computeTimeChunk(self, time, dt):
         signdt = np.sign(dt)
-        nextTime = np.infty * signdt
+        nextTime = np.infty if dt > 0 else -np.infty
 
         for g in self.gridset.grids:
             g.update_status = 'not_updated'

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -317,9 +317,9 @@ class ParticleSet(object):
         if self.repeatdt:
             next_prelease = self.repeat_starttime + (abs(time - self.repeat_starttime) // self.repeatdt + 1) * self.repeatdt * np.sign(dt)
         else:
-            next_prelease = np.infty * np.sign(dt)
-        next_output = time + outputdt * np.sign(dt)
-        next_movie = time + moviedt * np.sign(dt)
+            next_prelease = np.infty if dt > 0 else - np.infty
+        next_output = time + outputdt if dt > 0 else time - outputdt
+        next_movie = time + moviedt if dt > 0 else time - moviedt
         next_input = self.fieldset.computeTimeChunk(time, np.sign(dt))
 
         tol = 1e-12


### PR DESCRIPTION
Multiplying with `np.infty` throws a warning in Python3
```
particleset.py:320: RuntimeWarning: invalid value encountered in
multiply
    next_prelease = np.infty * np.sign(dt)
```
So this PR explicitly removes statements like ` np.infty * np.sign(dt)` throughout, reducing clutter in the log messages