### PR TITLE
Allow time extrapolation default

### DIFF
--- a/parcels/examples/example_decaying_moving_eddy.py
+++ b/parcels/examples/example_decaying_moving_eddy.py
@@ -27,7 +27,7 @@ def decaying_moving_eddy_fieldset(xdim=2, ydim=2):  # Define 2D flat, square fie
     http://amsdottorato.unibo.it/1733/1/Fabbroni_Nicoletta_Tesi.pdf
     """
     depth = np.zeros(1, dtype=np.float32)
-    time = np.arange(0., 2. * 86400., 60.*5., dtype=np.float64)
+    time = np.arange(0., 2. * 86400.+1e-5, 60.*5., dtype=np.float64)
     lon = np.linspace(0, 20000, xdim, dtype=np.float32)
     lat = np.linspace(5000, 12000, ydim, dtype=np.float32)
 
@@ -54,7 +54,7 @@ def decaying_moving_example(fieldset, mode='scipy', method=AdvectionRK4):
     pset = ParticleSet(fieldset, pclass=ptype[mode], lon=start_lon, lat=start_lat)
 
     dt = delta(minutes=5)
-    runtime = delta(days=2) - dt  # stop before end of time dimension
+    runtime = delta(days=2)
     outputdt = delta(hours=1)
 
     pset.execute(method, runtime=runtime, dt=dt, moviedt=None,

--- a/parcels/examples/example_decaying_moving_eddy.py
+++ b/parcels/examples/example_decaying_moving_eddy.py
@@ -53,8 +53,8 @@ def true_values(t, x_0, y_0):  # Calculate the expected values for particles at 
 def decaying_moving_example(fieldset, mode='scipy', method=AdvectionRK4):
     pset = ParticleSet(fieldset, pclass=ptype[mode], lon=start_lon, lat=start_lat)
 
-    runtime = delta(days=2)
     dt = delta(minutes=5)
+    runtime = delta(days=2) - dt  # stop before end of time dimension
     outputdt = delta(hours=1)
 
     pset.execute(method, runtime=runtime, dt=dt, moviedt=None,

--- a/parcels/examples/example_nemo_curvilinear.py
+++ b/parcels/examples/example_nemo_curvilinear.py
@@ -18,7 +18,7 @@ def run_nemo_curvilinear(mode, outfile):
     variables = {'U': 'U', 'V': 'V'}
     dimensions = {'U': {'lon': 'nav_lon_u', 'lat': 'nav_lat_u'},
                   'V': {'lon': 'nav_lon_v', 'lat': 'nav_lat_v'}}
-    field_set = FieldSet.from_nemo(filenames, variables, dimensions, allow_time_extrapolation=True)
+    field_set = FieldSet.from_nemo(filenames, variables, dimensions)
 
     # Now run particles as normal
     npart = 20

--- a/parcels/examples/example_peninsula.py
+++ b/parcels/examples/example_peninsula.py
@@ -35,8 +35,6 @@ def peninsula_fieldset(xdim, ydim, mesh):
     to C-grid, we return NetCDF files that are on an A-grid.
     """
     # Set Parcels FieldSet variables
-    depth = np.zeros(1, dtype=np.float32)
-    time = np.zeros(1, dtype=np.float64)
 
     # Generate the original test setup on A-grid in km
     dx = 100. / xdim / 2.
@@ -79,7 +77,7 @@ def peninsula_fieldset(xdim, ydim, mesh):
         raise RuntimeError('Mesh %s is not a valid option' % mesh)
 
     data = {'U': U, 'V': V, 'P': P}
-    dimensions = {'lon': lon, 'lat': lat, 'depth': depth, 'time': time}
+    dimensions = {'lon': lon, 'lat': lat}
     return FieldSet.from_data(data, dimensions, mesh=mesh)
 
 

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -236,7 +236,7 @@ class Field(object):
 
     @classmethod
     def from_netcdf(cls, name, dimensions, filenames, indices={},
-                    allow_time_extrapolation=False, mesh='flat', full_load=False, **kwargs):
+                    allow_time_extrapolation=None, mesh='flat', full_load=False, **kwargs):
         """Create field from netCDF file
 
         :param name: Name of the field to create
@@ -246,7 +246,8 @@ class Field(object):
         :param indices: dictionary mapping indices for each dimension to read from file.
                This can be used for reading in only a subregion of the NetCDF file
         :param allow_time_extrapolation: boolean whether to allow for extrapolation in time
-               (i.e. beyond the last available time snapshot
+               (i.e. beyond the last available time snapshot)
+               Default is False if dimensions includes time, else True
         :param mesh: String indicating the type of mesh coordinates and
                units used during velocity interpolation:
 
@@ -335,6 +336,9 @@ class Field(object):
             grid.time_full = grid.time
             grid.ti = -1
             data = None
+
+        if allow_time_extrapolation is None:
+            allow_time_extrapolation = False if 'time' in dimensions else True
 
         if name in ['cosU', 'sinU', 'cosV', 'sinV']:
             allow_time_extrapolation = True

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -35,7 +35,7 @@ class FieldSet(object):
 
     @classmethod
     def from_data(cls, data, dimensions, transpose=False, mesh='spherical',
-                  allow_time_extrapolation=True, time_periodic=False, **kwargs):
+                  allow_time_extrapolation=None, time_periodic=False, **kwargs):
         """Initialise FieldSet object from raw data
 
         :param data: Dictionary mapping field names to numpy arrays.
@@ -59,6 +59,7 @@ class FieldSet(object):
                2. flat: No conversion, lat/lon are assumed to be in m.
         :param allow_time_extrapolation: boolean whether to allow for extrapolation
                (i.e. beyond the last available time snapshot)
+               Default is False if dimensions includes time, else True
         :param time_periodic: boolean whether to loop periodically over the time component of the FieldSet
                This flag overrides the allow_time_interpolation and sets it to False
         """
@@ -67,6 +68,9 @@ class FieldSet(object):
         for name, datafld in data.items():
             # Use dimensions[name] if dimensions is a dict of dicts
             dims = dimensions[name] if name in dimensions else dimensions
+
+            if allow_time_extrapolation is None:
+                allow_time_extrapolation = False if 'time' in dims else True
 
             lon = dims['lon']
             lat = dims['lat']
@@ -106,7 +110,7 @@ class FieldSet(object):
 
     @classmethod
     def from_netcdf(cls, filenames, variables, dimensions, indices={},
-                    mesh='spherical', allow_time_extrapolation=False, time_periodic=False, full_load=False, **kwargs):
+                    mesh='spherical', allow_time_extrapolation=None, time_periodic=False, full_load=False, **kwargs):
         """Initialises FieldSet object from NetCDF files
 
         :param filenames: Dictionary mapping variables to file(s). The
@@ -130,6 +134,7 @@ class FieldSet(object):
                2. flat: No conversion, lat/lon are assumed to be in m.
         :param allow_time_extrapolation: boolean whether to allow for extrapolation
                (i.e. beyond the last available time snapshot)
+               Default is False if dimensions includes time, else True
         :param time_periodic: boolean whether to loop periodically over the time component of the FieldSet
                This flag overrides the allow_time_interpolation and sets it to False
         :param full_load: boolean whether to fully load the data or only pre-load them. (default: False)
@@ -165,7 +170,7 @@ class FieldSet(object):
 
     @classmethod
     def from_nemo(cls, filenames, variables, dimensions, indices={}, mesh='spherical',
-                  allow_time_extrapolation=False, time_periodic=False, **kwargs):
+                  allow_time_extrapolation=None, time_periodic=False, **kwargs):
         """Initialises FieldSet object from NetCDF files of Curvilinear NEMO fields.
         Note that this assumes the following default values for the mesh_mask:
         variables['mesh_mask'] = {'cosU': 'cosU',
@@ -197,6 +202,7 @@ class FieldSet(object):
                2. flat: No conversion, lat/lon are assumed to be in m.
         :param allow_time_extrapolation: boolean whether to allow for extrapolation
                (i.e. beyond the last available time snapshot)
+               Default is False if dimensions includes time, else True
         :param time_periodic: boolean whether to loop periodically over the time component of the FieldSet
                This flag overrides the allow_time_interpolation and sets it to False
         """
@@ -238,7 +244,7 @@ class FieldSet(object):
 
     @classmethod
     def from_parcels(cls, basename, uvar='vozocrtx', vvar='vomecrty', indices={}, extra_fields={},
-                     allow_time_extrapolation=False, time_periodic=False, full_load=False, **kwargs):
+                     allow_time_extrapolation=None, time_periodic=False, full_load=False, **kwargs):
         """Initialises FieldSet data from NetCDF files using the Parcels FieldSet.write() conventions.
 
         :param basename: Base name of the file(s); may contain
@@ -249,6 +255,7 @@ class FieldSet(object):
         :param extra_fields: Extra fields to read beyond U and V
         :param allow_time_extrapolation: boolean whether to allow for extrapolation
                (i.e. beyond the last available time snapshot)
+               Default is False if dimensions includes time, else True
         :param time_periodic: boolean whether to loop periodically over the time component of the FieldSet
                This flag overrides the allow_time_interpolation and sets it to False
         :param full_load: boolean whether to fully load the data or only pre-load them. (default: False)

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -159,13 +159,13 @@ def truth_stationary(x_0, y_0, t):
 
 
 @pytest.fixture
-def fieldset_stationary(xdim=100, ydim=100, maxtime=delta(hours=7)):
+def fieldset_stationary(xdim=100, ydim=100, maxtime=delta(hours=6)):
     """Generate a FieldSet encapsulating the flow field of a stationary eddy.
 
     Reference: N. Fabbroni, 2009, "Numerical simulations of passive
     tracers dispersion in the sea"
     """
-    time = np.arange(0., maxtime.total_seconds(), 60., dtype=np.float64)
+    time = np.arange(0., maxtime.total_seconds()+1e-5, 60., dtype=np.float64)
     dimensions = {'lon': np.linspace(0, 25000, xdim, dtype=np.float32),
                   'lat': np.linspace(0, 25000, ydim, dtype=np.float32),
                   'time': time}
@@ -202,7 +202,7 @@ def test_stationary_eddy_vertical(mode, npart=1):
     xdim = ydim = 100
     lon_data = np.linspace(0, 25000, xdim, dtype=np.float32)
     lat_data = np.linspace(0, 25000, ydim, dtype=np.float32)
-    time_data = np.arange(0., 7*3600, 60., dtype=np.float64)
+    time_data = np.arange(0., 6*3600+1e-5, 60., dtype=np.float64)
     fld1 = np.ones((xdim, ydim, 1), dtype=np.float32) * u_0 * np.cos(f * time_data)
     fld2 = np.ones((xdim, ydim, 1), dtype=np.float32) * -u_0 * np.sin(f * time_data)
     fldzero = np.zeros((xdim, ydim, 1), dtype=np.float32) * time_data
@@ -240,13 +240,13 @@ def truth_moving(x_0, y_0, t):
 
 
 @pytest.fixture
-def fieldset_moving(xdim=100, ydim=100, maxtime=delta(hours=7)):
+def fieldset_moving(xdim=100, ydim=100, maxtime=delta(hours=6)):
     """Generate a FieldSet encapsulating the flow field of a moving eddy.
 
     Reference: N. Fabbroni, 2009, "Numerical simulations of passive
     tracers dispersion in the sea"
     """
-    time = np.arange(0., maxtime.total_seconds(), 60., dtype=np.float64)
+    time = np.arange(0., maxtime.total_seconds()+1e-5, 60., dtype=np.float64)
     dimensions = {'lon': np.linspace(0, 25000, xdim, dtype=np.float32),
                   'lat': np.linspace(0, 25000, ydim, dtype=np.float32),
                   'time': time}

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -159,7 +159,7 @@ def truth_stationary(x_0, y_0, t):
 
 
 @pytest.fixture
-def fieldset_stationary(xdim=100, ydim=100, maxtime=delta(hours=6)):
+def fieldset_stationary(xdim=100, ydim=100, maxtime=delta(hours=7)):
     """Generate a FieldSet encapsulating the flow field of a stationary eddy.
 
     Reference: N. Fabbroni, 2009, "Numerical simulations of passive
@@ -202,7 +202,7 @@ def test_stationary_eddy_vertical(mode, npart=1):
     xdim = ydim = 100
     lon_data = np.linspace(0, 25000, xdim, dtype=np.float32)
     lat_data = np.linspace(0, 25000, ydim, dtype=np.float32)
-    time_data = np.arange(0., 6*3600, 60., dtype=np.float64)
+    time_data = np.arange(0., 7*3600, 60., dtype=np.float64)
     fld1 = np.ones((xdim, ydim, 1), dtype=np.float32) * u_0 * np.cos(f * time_data)
     fld2 = np.ones((xdim, ydim, 1), dtype=np.float32) * -u_0 * np.sin(f * time_data)
     fldzero = np.zeros((xdim, ydim, 1), dtype=np.float32) * time_data
@@ -240,7 +240,7 @@ def truth_moving(x_0, y_0, t):
 
 
 @pytest.fixture
-def fieldset_moving(xdim=100, ydim=100, maxtime=delta(hours=6)):
+def fieldset_moving(xdim=100, ydim=100, maxtime=delta(hours=7)):
     """Generate a FieldSet encapsulating the flow field of a moving eddy.
 
     Reference: N. Fabbroni, 2009, "Numerical simulations of passive
@@ -284,7 +284,7 @@ def truth_decaying(x_0, y_0, t):
 
 
 @pytest.fixture
-def fieldset_decaying(xdim=100, ydim=100, maxtime=delta(hours=6)):
+def fieldset_decaying(xdim=100, ydim=100, maxtime=delta(hours=7)):
     """Generate a FieldSet encapsulating the flow field of a decaying eddy.
 
     Reference: N. Fabbroni, 2009, "Numerical simulations of passive

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -284,13 +284,13 @@ def truth_decaying(x_0, y_0, t):
 
 
 @pytest.fixture
-def fieldset_decaying(xdim=100, ydim=100, maxtime=delta(hours=7)):
+def fieldset_decaying(xdim=100, ydim=100, maxtime=delta(hours=6)):
     """Generate a FieldSet encapsulating the flow field of a decaying eddy.
 
     Reference: N. Fabbroni, 2009, "Numerical simulations of passive
     tracers dispersion in the sea"
     """
-    time = np.arange(0., maxtime.total_seconds(), 60., dtype=np.float64)
+    time = np.arange(0., maxtime.total_seconds()+1e-5, 60., dtype=np.float64)
     dimensions = {'lon': np.linspace(0, 25000, xdim, dtype=np.float32),
                   'lat': np.linspace(0, 25000, ydim, dtype=np.float32),
                   'time': time}

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -18,11 +18,13 @@ def generate_fieldset(xdim, ydim, zdim=1, tdim=1):
     time = np.zeros(tdim, dtype=np.float64)
     if zdim == 1 and tdim == 1:
         U, V = np.meshgrid(lon, lat)
+        dimensions = {'lat': lat, 'lon': lon}
     else:
         U = np.ones((tdim, zdim, ydim, xdim))
         V = np.ones((tdim, zdim, ydim, xdim))
+        dimensions = {'lat': lat, 'lon': lon, 'depth': depth, 'time': time}
     data = {'U': np.array(U, dtype=np.float32), 'V': np.array(V, dtype=np.float32)}
-    dimensions = {'lat': lat, 'lon': lon, 'depth': depth, 'time': time}
+
     return (data, dimensions)
 
 
@@ -222,7 +224,7 @@ def test_periodic(mode, time_periodic, dt_sign):
 
     data = {'U': U, 'V': V, 'W': W, 'temp': temp}
     dimensions = {'lon': lon, 'lat': lat, 'depth': depth, 'time': time}
-    fieldset = FieldSet.from_data(data, dimensions, mesh='flat', time_periodic=time_periodic, transpose=True)
+    fieldset = FieldSet.from_data(data, dimensions, mesh='flat', time_periodic=time_periodic, transpose=True, allow_time_extrapolation=True)
 
     def sampleTemp(particle, fieldset, time, dt):
         # Note that fieldset.temp is interpolated at time=time+dt.

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -14,9 +14,8 @@ def fieldset(xdim=40, ydim=100):
     lon = np.linspace(0, 1, xdim, dtype=np.float32)
     lat = np.linspace(-60, 60, ydim, dtype=np.float32)
     depth = np.zeros(1, dtype=np.float32)
-    time = np.zeros(1, dtype=np.float64)
     data = {'U': np.array(U, dtype=np.float32), 'V': np.array(V, dtype=np.float32)}
-    dimensions = {'lat': lat, 'lon': lon, 'depth': depth, 'time': time}
+    dimensions = {'lat': lat, 'lon': lon, 'depth': depth}
     return FieldSet.from_data(data, dimensions)
 
 


### PR DESCRIPTION
Setting default `allow_time_extrapolation` to `False` if `dimensions` includes `time`, else `True`.

Note that a few of the examples used time extrapolation when the `runtime` is exactly the same length as the length of the `FieldSet` time. Now, this is fixed by either shortening the `runtime` (by `1*dt`) or lengthening the `FieldSet` time.

However, a more elegant solution would be to somehow allow execution all the ay until the absolute end of a `FieldSet` time. I tried running with #359, but that didn't solve the issue 

-> problem of last two paragraphs solved in last commit. np.arange was not used properly, such that the fieldset time span was shorter than thought.

This fixes #361 