### PR TITLE
Field arithmetic operators

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -6,7 +6,6 @@ import numpy as np
 from ctypes import Structure, c_int, c_float, POINTER, pointer
 import xarray as xr
 from math import cos, pi
-from copy import deepcopy
 import datetime
 import math
 from .grid import (RectilinearZGrid, RectilinearSGrid, CurvilinearZGrid,
@@ -1029,16 +1028,14 @@ class Field(object):
     def __add__(self, fld2):
         if self.grid is not fld2.grid:
             raise RuntimeError('Fields to be added need to be on the same grid')
-        newfld = deepcopy(self)
-        newfld.data = self.data + fld2.data
-        return newfld
+        return Field('(%s+%s)' % (self.name, fld2.name), self.data + fld2.data,
+                     grid=self.grid)
 
     def __sub__(self, fld2):
         if self.grid is not fld2.grid:
             raise RuntimeError('Fields to be subtracted need to be on the same grid')
-        newfld = deepcopy(self)
-        newfld.data = self.data - fld2.data
-        return newfld
+        return Field('(%s-%s)' % (self.name, fld2.name), self.data - fld2.data,
+                     grid=self.grid)
 
 
 class NetcdfFileBuffer(object):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1027,6 +1027,8 @@ class Field(object):
         return data
 
     def __add__(self, fld2):
+        if self.grid is not fld2.grid:
+            raise RuntimeError('Fields to be added need to be on the same grid')
         newfld = deepcopy(self)
         newfld.data = self.data + fld2.data
         return newfld

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1033,6 +1033,13 @@ class Field(object):
         newfld.data = self.data + fld2.data
         return newfld
 
+    def __sub__(self, fld2):
+        if self.grid is not fld2.grid:
+            raise RuntimeError('Fields to be subtracted need to be on the same grid')
+        newfld = deepcopy(self)
+        newfld.data = self.data - fld2.data
+        return newfld
+
 
 class NetcdfFileBuffer(object):
     """ Class that encapsulates and manages deferred access to file data. """

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -6,6 +6,7 @@ import numpy as np
 from ctypes import Structure, c_int, c_float, POINTER, pointer
 import xarray as xr
 from math import cos, pi
+from copy import deepcopy
 import datetime
 import math
 from .grid import (RectilinearZGrid, RectilinearSGrid, CurvilinearZGrid,
@@ -1024,6 +1025,11 @@ class Field(object):
             data[data > self.vmax] = 0.
 
         return data
+
+    def __add__(self, fld2):
+        newfld = deepcopy(self)
+        newfld.data = self.data + fld2.data
+        return newfld
 
 
 class NetcdfFileBuffer(object):

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -124,6 +124,16 @@ def test_add_fields(xdim, ydim):
     assert np.allclose(fieldset.new.data, fieldset.U.data+fieldset.V.data)
 
 
+@pytest.mark.xfail(strict=True)
+def test_add_fields_different_grid():
+    data, dimensions = generate_fieldset(20, 10)
+    fieldset = FieldSet.from_data(data, dimensions)
+    data, dimensions = generate_fieldset(10, 20)
+    fieldset2 = FieldSet.from_data(data, dimensions)
+    fieldset.new = fieldset.U + fieldset2.V
+    assert np.allclose(fieldset.new.data, fieldset.U.data+fieldset.V.data)
+
+
 @pytest.mark.parametrize('mesh', ['flat', 'spherical'])
 def test_fieldset_celledgesizes(mesh):
     data, dimensions = generate_fieldset(10, 7)

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -115,6 +115,15 @@ def test_add_field(xdim, ydim, tmpdir, filename='test_add'):
     fieldset.write(filepath)
 
 
+@pytest.mark.parametrize('xdim', [100, 200])
+@pytest.mark.parametrize('ydim', [100, 200])
+def test_add_fields(xdim, ydim):
+    data, dimensions = generate_fieldset(xdim, ydim)
+    fieldset = FieldSet.from_data(data, dimensions)
+    fieldset.new = fieldset.U + fieldset.V
+    assert np.allclose(fieldset.new.data, fieldset.U.data+fieldset.V.data)
+
+
 @pytest.mark.parametrize('mesh', ['flat', 'spherical'])
 def test_fieldset_celledgesizes(mesh):
     data, dimensions = generate_fieldset(10, 7)

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -134,6 +134,15 @@ def test_add_fields_different_grid():
     assert np.allclose(fieldset.new.data, fieldset.U.data+fieldset.V.data)
 
 
+@pytest.mark.parametrize('xdim', [100, 200])
+@pytest.mark.parametrize('ydim', [100, 200])
+def test_subtract_fields(xdim, ydim):
+    data, dimensions = generate_fieldset(xdim, ydim)
+    fieldset = FieldSet.from_data(data, dimensions)
+    fieldset.new = fieldset.U - fieldset.V
+    assert np.allclose(fieldset.new.data, fieldset.U.data-fieldset.V.data)
+
+
 @pytest.mark.parametrize('mesh', ['flat', 'spherical'])
 def test_fieldset_celledgesizes(mesh):
     data, dimensions = generate_fieldset(10, 7)


### PR DESCRIPTION
This PR introduces support for the `+` and `-` arithmetic operators on `Field` objects. An error is thrown if the `Fields` do not have the same `Grid`

This implements #384 