### PR TITLE
Compiler cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,6 @@ matrix:
       osx_image: xcode9.3
       language: generic
       env: PY_VERSION=3 MINICONDA_NAME=Miniconda3-latest-MacOSX-x86_64.sh
-  allow_failures:
-    - os: osx
-      osx_image: xcode9.3
-      language: generic
-      env: PY_VERSION=3 MINICONDA_NAME=Miniconda3-latest-MacOSX-x86_64.sh
 
 install:
     - wget http://repo.continuum.io/miniconda/${MINICONDA_NAME} -O miniconda.sh;

--- a/parcels/compiler.py
+++ b/parcels/compiler.py
@@ -24,11 +24,7 @@ def get_cache_dir():
 class Compiler(object):
     """A compiler object for creating and loading shared libraries.
 
-    :arg cc: C compiler executable (can be overriden by exporting the
-        environment variable ``CC``).
-    :arg ld: Linker executable (optional, if ``None``, we assume the compiler
-        can build object files and link in a single invocation, can be
-        overridden by exporting the environment variable ``LDSHARED``).
+    :arg cc: C compiler executable (uses environment variable ``CC`` if not provided).
     :arg cppargs: A list of arguments to the C compiler (optional).
     :arg ldargs: A list of arguments to the linker (optional)."""
 

--- a/parcels/compiler.py
+++ b/parcels/compiler.py
@@ -1,5 +1,5 @@
 import subprocess
-from os import path, environ, makedirs
+from os import path, getenv, makedirs
 from tempfile import gettempdir
 from struct import calcsize
 try:
@@ -32,13 +32,13 @@ class Compiler(object):
     :arg cppargs: A list of arguments to the C compiler (optional).
     :arg ldargs: A list of arguments to the linker (optional)."""
 
-    def __init__(self, cc, cppargs=None, ldargs=None):
+    def __init__(self, cc=None, cppargs=None, ldargs=None):
         if cppargs is None:
             cppargs = []
         if ldargs is None:
             ldargs = []
 
-        self._cc = environ.get('CC', cc)
+        self._cc = getenv('CC') if cc is None else cc
         self._cppargs = cppargs
         self._ldargs = ldargs
 

--- a/parcels/compiler.py
+++ b/parcels/compiler.py
@@ -32,14 +32,13 @@ class Compiler(object):
     :arg cppargs: A list of arguments to the C compiler (optional).
     :arg ldargs: A list of arguments to the linker (optional)."""
 
-    def __init__(self, cc, ld=None, cppargs=None, ldargs=None):
+    def __init__(self, cc, cppargs=None, ldargs=None):
         if cppargs is None:
             cppargs = []
         if ldargs is None:
             ldargs = []
 
         self._cc = environ.get('CC', cc)
-        self._ld = environ.get('LDSHARED', ld)
         self._cppargs = cppargs
         self._ldargs = ldargs
 


### PR DESCRIPTION
Cleaning up the Compiler class, as suggestion by @willirath in #284 

Note that this also fixes an old issue (#332) where users had to explicitly set `export CC=gcc`. That is not necessary anymore with this change, and therefore also works now with xcode 9.3 (#343).