### PR TITLE
Field write extension to CurvilinearGrids

### DIFF
--- a/parcels/examples/example_globcurrent.py
+++ b/parcels/examples/example_globcurrent.py
@@ -13,10 +13,9 @@ def set_globcurrent_fieldset(filename=None, indices=None, full_load=False):
     if filename is None:
         filename = path.join(path.dirname(__file__), 'GlobCurrent_example_data',
                              '20*-GLOBCURRENT-L4-CUReul_hs-ALT_SUM-v02.0-fv01.0.nc')
-    filenames = {'U': filename, 'V': filename}
     variables = {'U': 'eastward_eulerian_current_velocity', 'V': 'northward_eulerian_current_velocity'}
     dimensions = {'lat': 'lat', 'lon': 'lon', 'time': 'time'}
-    return FieldSet.from_netcdf(filenames, variables, dimensions, indices, full_load=full_load)
+    return FieldSet.from_netcdf(filename, variables, dimensions, indices, full_load=full_load)
 
 
 def test_globcurrent_fieldset():

--- a/parcels/examples/tutorial_Agulhasparticles.ipynb
+++ b/parcels/examples/tutorial_Agulhasparticles.ipynb
@@ -52,7 +52,7 @@
     "editable": true
    },
    "source": [
-    "Now load the Globcurrent fields from the `GlobCurrent_example_data` directory"
+    "Now load the Globcurrent fields from the `GlobCurrent_example_data` directory (note that unlike in the main Parcels tutorial we don't use a dictionary for the filenames here; as they are the same for all variables, we don't need to)"
    ]
   },
   {
@@ -75,8 +75,7 @@
     }
    ],
    "source": [
-    "filenames = {'U': \"GlobCurrent_example_data/20*.nc\",\n",
-    "             'V': \"GlobCurrent_example_data/20*.nc\"}\n",
+    "filenames = \"GlobCurrent_example_data/20*.nc\"\n",
     "variables = {'U': 'eastward_eulerian_current_velocity',\n",
     "             'V': 'northward_eulerian_current_velocity'}\n",
     "dimensions = {'lat': 'lat',\n",

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -935,17 +935,16 @@ class Field(object):
         vname_depth = 'depth%s' % self.name.lower()
 
         # Create DataArray objects for file I/O
-        t, d = (self.grid.time.size, self.grid.depth.size)
         if type(self.grid) is RectilinearZGrid:
-            x, y = (self.grid.lon.size, self.grid.lat.size)
-            nav_lon = xr.DataArray(self.grid.lon + np.zeros((y, x), dtype=np.float32),
+            nav_lon = xr.DataArray(self.grid.lon + np.zeros((self.grid.ydim, self.grid.xdim), dtype=np.float32),
                                    coords=[('y', self.grid.lat), ('x', self.grid.lon)])
-            nav_lat = xr.DataArray(self.grid.lat.reshape(y, 1) + np.zeros(x, dtype=np.float32),
+            nav_lat = xr.DataArray(self.grid.lat.reshape(self.grid.ydim, 1) + np.zeros(self.grid.xdim, dtype=np.float32),
                                    coords=[('y', self.grid.lat), ('x', self.grid.lon)])
         elif type(self.grid) is CurvilinearZGrid:
-            y, x = self.grid.lat.shape
-            nav_lon = xr.DataArray(self.grid.lon, coords=[('y', range(y)), ('x', range(x))])
-            nav_lat = xr.DataArray(self.grid.lat, coords=[('y', range(y)), ('x', range(x))])
+            nav_lon = xr.DataArray(self.grid.lon, coords=[('y', range(self.grid.ydim)),
+                                                          ('x', range(self.grid.xdim))])
+            nav_lat = xr.DataArray(self.grid.lat, coords=[('y', range(self.grid.ydim)),
+                                                          ('x', range(self.grid.xdim))])
         else:
             raise NotImplementedError('Field.write only implemented for RectilinearZGrid and CurvilinearZGrid')
 
@@ -953,7 +952,7 @@ class Field(object):
         time_counter = xr.DataArray(self.grid.time,
                                     dims=['time_counter'],
                                     attrs=attrs)
-        vardata = xr.DataArray(self.data.reshape((t, d, y, x)),
+        vardata = xr.DataArray(self.data.reshape((self.grid.tdim, self.grid.zdim, self.grid.ydim, self.grid.xdim)),
                                dims=['time_counter', vname_depth, 'y', 'x'])
         # Create xarray Dataset and output to netCDF format
         dset = xr.Dataset({varname: vardata}, coords={'nav_lon': nav_lon,

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -174,10 +174,9 @@ class FieldSet(object):
         fields = {}
         for var, name in variables.items():
             # Resolve all matching paths for the current variable
-            if isinstance(filenames[var], list):
-                paths = filenames[var]
-            else:
-                paths = sorted(glob(str(filenames[var])))
+            paths = filenames[var] if type(filenames) is dict else filenames
+            if not isinstance(paths, list):
+                paths = sorted(glob(str(paths)))
             if len(paths) == 0:
                 raise IOError("FieldSet files not found: %s" % str(filenames[var]))
             for fp in paths:

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -326,8 +326,10 @@ class FieldSet(object):
         :param filename: Basename of the output fileset"""
         logger.info("Generating NEMO FieldSet output with basename: %s" % filename)
 
-        self.U.write(filename, varname='vozocrtx')
-        self.V.write(filename, varname='vomecrty')
+        if hasattr(self, 'U'):
+            self.U.write(filename, varname='vozocrtx')
+        if hasattr(self, 'V'):
+            self.V.write(filename, varname='vomecrty')
 
         for v in self.fields:
             if (v.name is not 'U') and (v.name is not 'V'):

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -148,6 +148,22 @@ def test_fieldset_celledgesizes_curvilinear(dx, dy):
     assert np.allclose(A, fieldset.dx.data * fieldset.dy.data)
 
 
+def test_fieldset_write_curvilinear(tmpdir):
+    fname = path.join(path.dirname(__file__), 'test_data', 'mask_nemo_cross_180lon.nc')
+    filenames = {'dx': fname, 'mesh_mask': fname}
+    variables = {'dx': 'e1u'}
+    dimensions = {'lon': 'glamu', 'lat': 'gphiu'}
+    fieldset = FieldSet.from_nemo(filenames, variables, dimensions)
+
+    newfile = tmpdir.join('curv_field')
+    fieldset.write(newfile)
+
+    fieldset2 = FieldSet.from_netcdf(filenames={'dx': newfile+'dx.nc'}, variables={'dx': 'dx'}, dimensions={'lon': 'nav_lon', 'lat': 'nav_lat'})
+
+    for var in ['lon', 'lat', 'data']:
+        assert np.allclose(getattr(fieldset2.dx, var), getattr(fieldset.dx, var))
+
+
 @pytest.mark.parametrize('mesh', ['flat', 'spherical'])
 def test_fieldset_cellareas(mesh):
     data, dimensions = generate_fieldset(10, 7)

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -158,7 +158,7 @@ def test_fieldset_write_curvilinear(tmpdir):
     newfile = tmpdir.join('curv_field')
     fieldset.write(newfile)
 
-    fieldset2 = FieldSet.from_netcdf(filenames={'dx': newfile+'dx.nc'}, variables={'dx': 'dx'}, dimensions={'lon': 'nav_lon', 'lat': 'nav_lat'})
+    fieldset2 = FieldSet.from_netcdf(filenames=newfile+'dx.nc', variables={'dx': 'dx'}, dimensions={'lon': 'nav_lon', 'lat': 'nav_lat'})
 
     for var in ['lon', 'lat', 'data']:
         assert np.allclose(getattr(fieldset2.dx, var), getattr(fieldset.dx, var))


### PR DESCRIPTION
This PR implements `Field.write()` for `CurvilinearZGrids` (so fixes #378) 

It also adds support for non-dictionary filenames, if the filenames for all variables are the same (i.e. if all variables are in one file, then no need to specify a dictionary entry of filenames for for each variable).