### PR TITLE
Updating example meshes

### DIFF
--- a/parcels/examples/example_moving_eddies.py
+++ b/parcels/examples/example_moving_eddies.py
@@ -12,29 +12,40 @@ ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 method = {'RK4': AdvectionRK4, 'EE': AdvectionEE, 'RK45': AdvectionRK45}
 
 
-def moving_eddies_fieldset(xdim=200, ydim=350):
+def moving_eddies_fieldset(xdim=200, ydim=350, mesh='flat'):
     """Generate a fieldset encapsulating the flow field consisting of two
     moving eddies, one moving westward and the other moving northwestward.
+
+    :param xdim: Horizontal dimension of the generated fieldset
+    :param xdim: Vertical dimension of the generated fieldset
+    :param mesh: String indicating the type of mesh coordinates and
+               units used during velocity interpolation:
+
+               1. spherical: Lat and lon in degree, with a
+                  correction for zonal velocity U near the poles.
+               2. flat  (default): No conversion, lat/lon are assumed to be in m.
 
     Note that this is not a proper geophysical flow. Rather, a Gaussian eddy is moved
     artificially with uniform velocities. Velocities are calculated from geostrophy.
     """
     # Set Parcels FieldSet variables
-    depth = np.zeros(1, dtype=np.float32)
     time = np.arange(0., 8. * 86400., 86400., dtype=np.float64)
 
-    # Coordinates of the test fieldset (on A-grid in deg)
-    lon = np.linspace(0, 4, xdim, dtype=np.float32)
-    lat = np.linspace(45, 52, ydim, dtype=np.float32)
+    # Coordinates of the test fieldset (on A-grid in m)
+    if mesh is 'spherical':
+        lon = np.linspace(0, 4, xdim, dtype=np.float32)
+        lat = np.linspace(45, 52, ydim, dtype=np.float32)
+    else:
+        lon = np.linspace(0, 4.e5, xdim, dtype=np.float32)
+        lat = np.linspace(0, 7.e5, ydim, dtype=np.float32)
 
     # Grid spacing in m
     def cosd(x):
         return math.cos(math.radians(float(x)))
-    dx = (lon[1] - lon[0]) * 1852 * 60 * cosd(lat.mean())
-    dy = (lat[1] - lat[0]) * 1852 * 60
+    dx = (lon[1] - lon[0]) * 1852 * 60 * cosd(lat.mean()) if mesh is 'spherical' else lon[1] - lon[0]
+    dy = (lat[1] - lat[0]) * 1852 * 60 if mesh is 'spherical' else lat[1] - lat[0]
 
-    # Define arrays U (zonal), V (meridional), W (vertical) and P (sea
-    # surface height) all on A-grid
+    # Define arrays U (zonal), V (meridional), and P (sea surface height) on A-grid
     U = np.zeros((lon.size, lat.size, time.size), dtype=np.float32)
     V = np.zeros((lon.size, lat.size, time.size), dtype=np.float32)
     P = np.zeros((lon.size, lat.size, time.size), dtype=np.float32)
@@ -65,8 +76,8 @@ def moving_eddies_fieldset(xdim=200, ydim=350):
         U[:, -1, t] = U[:, -2, t]  # Fill in the last row
 
     data = {'U': U, 'V': V, 'P': P}
-    dimensions = {'lon': lon, 'lat': lat, 'depth': depth, 'time': time}
-    return FieldSet.from_data(data, dimensions, transpose=True)
+    dimensions = {'lon': lon, 'lat': lat, 'time': time}
+    return FieldSet.from_data(data, dimensions, transpose=True, mesh=mesh)
 
 
 def moving_eddies_example(fieldset, npart=2, mode='jit', verbose=False,
@@ -77,8 +88,10 @@ def moving_eddies_example(fieldset, npart=2, mode='jit', verbose=False,
     :arg npart: Number of particles to initialise"""
 
     # Determine particle class according to mode
+    start = (3.3, 46.) if fieldset.U.grid.mesh == 'spherical' else (3.3e5, 1e5)
+    finish = (3.3, 47.8) if fieldset.U.grid.mesh == 'spherical' else (3.3e5, 2.8e5)
     pset = ParticleSet.from_line(fieldset=fieldset, size=npart, pclass=ptype[mode],
-                                 start=(3.3, 46.), finish=(3.3, 47.8))
+                                 start=start, finish=finish)
 
     if verbose:
         print("Initial particle positions:\n%s" % pset)
@@ -97,13 +110,15 @@ def moving_eddies_example(fieldset, npart=2, mode='jit', verbose=False,
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
-def test_moving_eddies_fwdbwd(mode, npart=2):
+@pytest.mark.parametrize('mesh', ['flat', 'spherical'])
+def test_moving_eddies_fwdbwd(mode, mesh, npart=2):
     method = AdvectionRK4
-    fieldset = moving_eddies_fieldset()
+    fieldset = moving_eddies_fieldset(mesh=mesh)
 
     # Determine particle class according to mode
-    pset = ParticleSet.from_line(fieldset=fieldset, size=npart, pclass=ptype[mode],
-                                 start=(3.3, 46.), finish=(3.3, 47.8))
+    lons = [3.3, 3.3] if fieldset.U.grid.mesh == 'spherical' else [3.3e5, 3.3e5]
+    lats = [46., 47.8] if fieldset.U.grid.mesh == 'spherical' else [1e5, 2.8e5]
+    pset = ParticleSet(fieldset=fieldset, pclass=ptype[mode], lon=lons, lat=lats)
 
     # Execte for 14 days, with 30sec timesteps and hourly output
     runtime = delta(days=1)
@@ -117,35 +132,44 @@ def test_moving_eddies_fwdbwd(mode, npart=2):
     pset.execute(method, endtime=0, dt=-dt,
                  output_file=pset.ParticleFile(name="EddyParticlebwd", outputdt=outputdt))
 
-    assert(pset[0].lon > 3.2 and 45.9 < pset[0].lat < 46.1)
-    assert(pset[1].lon > 3.2 and 47.7 < pset[1].lat < 47.9)
-
+    assert np.allclose([p.lon for p in pset], lons)
+    assert np.allclose([p.lat for p in pset], lats)
     return pset
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
-def test_moving_eddies_fieldset(mode):
-    fieldset = moving_eddies_fieldset()
+@pytest.mark.parametrize('mesh', ['flat', 'spherical'])
+def test_moving_eddies_fieldset(mode, mesh):
+    fieldset = moving_eddies_fieldset(mesh=mesh)
     pset = moving_eddies_example(fieldset, 2, mode=mode)
-    assert(pset[0].lon < 2.0 and 46.2 < pset[0].lat < 46.25)
-    assert(pset[1].lon < 2.0 and 48.8 < pset[1].lat < 48.85)
+    if mesh is 'flat':
+        assert (pset[0].lon < 2.2e5 and 1.1e5 < pset[0].lat < 1.2e5)
+        assert (pset[1].lon < 2.2e5 and 3.7e5 < pset[1].lat < 3.8e5)
+    else:
+        assert(pset[0].lon < 2.0 and 46.2 < pset[0].lat < 46.25)
+        assert(pset[1].lon < 2.0 and 48.8 < pset[1].lat < 48.85)
 
 
 @pytest.fixture(scope='module')
-def fieldsetfile():
+def fieldsetfile(mesh):
     """Generate fieldset files for moving_eddies test"""
     filename = 'moving_eddies'
-    fieldset = moving_eddies_fieldset(200, 350)
+    fieldset = moving_eddies_fieldset(200, 350, mesh=mesh)
     fieldset.write(filename)
     return filename
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
-def test_moving_eddies_file(fieldsetfile, mode):
-    fieldset = FieldSet.from_parcels(fieldsetfile, extra_fields={'P': 'P'})
+@pytest.mark.parametrize('mesh', ['flat', 'spherical'])
+def test_moving_eddies_file(mode, mesh):
+    fieldset = FieldSet.from_parcels(fieldsetfile(mesh), extra_fields={'P': 'P'})
     pset = moving_eddies_example(fieldset, 2, mode=mode)
-    assert(pset[0].lon < 2.0 and 46.2 < pset[0].lat < 46.25)
-    assert(pset[1].lon < 2.0 and 48.8 < pset[1].lat < 48.85)
+    if mesh is 'flat':
+        assert (pset[0].lon < 2.2e5 and 1.1e5 < pset[0].lat < 1.2e5)
+        assert (pset[1].lon < 2.2e5 and 3.7e5 < pset[1].lat < 3.8e5)
+    else:
+        assert(pset[0].lon < 2.0 and 46.2 < pset[0].lat < 46.25)
+        assert(pset[1].lon < 2.0 and 48.8 < pset[1].lat < 48.85)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
@@ -200,7 +224,7 @@ Example of particle advection around an idealised peninsula""")
 
     # Generate fieldset files according to given dimensions
     if args.fieldset is not None:
-        fieldset = moving_eddies_fieldset(args.fieldset[0], args.fieldset[1])
+        fieldset = moving_eddies_fieldset(args.fieldset[0], args.fieldset[1], mesh='flat')
         fieldset.write(filename)
 
     # Open fieldset files

--- a/parcels/examples/example_peninsula.py
+++ b/parcels/examples/example_peninsula.py
@@ -133,18 +133,19 @@ def test_peninsula_fieldset(mode, mesh):
 
 
 @pytest.fixture(scope='module')
-def fieldsetfile():
+def fieldsetfile(mesh):
     """Generate fieldset files for peninsula test"""
     filename = 'peninsula'
-    fieldset = peninsula_fieldset(100, 50, mesh='spherical')
+    fieldset = peninsula_fieldset(100, 50, mesh=mesh)
     fieldset.write(filename)
     return filename
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
-def test_peninsula_file(fieldsetfile, mode):
+@pytest.mark.parametrize('mesh', ['flat', 'spherical'])
+def test_peninsula_file(mode, mesh):
     """Open fieldset files and execute"""
-    fieldset = FieldSet.from_parcels(fieldsetfile, extra_fields={'P': 'P'}, allow_time_extrapolation=True)
+    fieldset = FieldSet.from_parcels(fieldsetfile(mesh), extra_fields={'P': 'P'}, allow_time_extrapolation=True)
     pset = pensinsula_example(fieldset, 5, mode=mode, degree=1)
     # Test advection accuracy by comparing streamline values
     err_adv = np.array([abs(p.p_start - p.p) for p in pset])

--- a/parcels/examples/example_peninsula.py
+++ b/parcels/examples/example_peninsula.py
@@ -11,7 +11,7 @@ ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 method = {'RK4': AdvectionRK4, 'EE': AdvectionEE, 'RK45': AdvectionRK45}
 
 
-def peninsula_fieldset(xdim, ydim, mesh):
+def peninsula_fieldset(xdim, ydim, mesh='flat'):
     """Construct a fieldset encapsulating the flow field around an
     idealised peninsula.
 
@@ -20,9 +20,9 @@ def peninsula_fieldset(xdim, ydim, mesh):
     :param mesh: String indicating the type of mesh coordinates and
                units used during velocity interpolation:
 
-               1. spherical (default): Lat and lon in degree, with a
+               1. spherical: Lat and lon in degree, with a
                   correction for zonal velocity U near the poles.
-               2. flat: No conversion, lat/lon are assumed to be in m.
+               2. flat  (default): No conversion, lat/lon are assumed to be in m.
 
     The original test description can be found in Fig. 2.2.3 in:
     North, E. W., Gallego, A., Petitgas, P. (Eds). 2009. Manual of
@@ -36,26 +36,19 @@ def peninsula_fieldset(xdim, ydim, mesh):
     """
     # Set Parcels FieldSet variables
 
-    # Generate the original test setup on A-grid in km
-    dx = 100. / xdim / 2.
-    dy = 50. / ydim / 2.
-    La = np.linspace(dx, 100.-dx, xdim, dtype=np.float32)
-    Wa = np.linspace(dy, 50.-dy, ydim, dtype=np.float32)
-
-    # Define arrays U (zonal), V (meridional), W (vertical) and P (sea
-    # surface height) all on A-grid
-    U = np.zeros((ydim, xdim), dtype=np.float32)
-    V = np.zeros((ydim, xdim), dtype=np.float32)
-    W = np.zeros((ydim, xdim), dtype=np.float32)
-    P = np.zeros((ydim, xdim), dtype=np.float32)
+    # Generate the original test setup on A-grid in m
+    domainsizeX, domainsizeY = (1.e5, 5.e4)
+    dx, dy = domainsizeX / xdim, domainsizeY / ydim
+    La = np.linspace(dx, 1.e5-dx, xdim, dtype=np.float32)
+    Wa = np.linspace(dy, 5.e4-dy, ydim, dtype=np.float32)
 
     u0 = 1
-    x0 = 50.
-    R = 0.32 * 50.
+    x0 = domainsizeX / 2
+    R = 0.32 * domainsizeX / 2
 
     # Create the fields
     x, y = np.meshgrid(La, Wa, sparse=True, indexing='xy')
-    P = u0*R**2*y/((x-x0)**2+y**2)-u0*y
+    P = u0*R**2*y/((x-x0)**2+y**2)-u0*y / 1e3
     U = u0-u0*R**2*((x-x0)**2-y**2)/(((x-x0)**2+y**2)**2)
     V = -2*u0*R**2*((x-x0)*y)/(((x-x0)**2+y**2)**2)
 
@@ -63,18 +56,10 @@ def peninsula_fieldset(xdim, ydim, mesh):
     landpoints = P >= 0.
     U[landpoints] = np.nan
     V[landpoints] = np.nan
-    W[landpoints] = np.nan
 
-    if mesh == 'spherical':
-        # Convert from km to lat/lon
-        lon = La / 1.852 / 60.
-        lat = Wa / 1.852 / 60.
-    elif mesh == 'flat':
-        # Convert from km to m
-        lon = La * 1000.
-        lat = Wa * 1000.
-    else:
-        raise RuntimeError('Mesh %s is not a valid option' % mesh)
+    # Convert from m to lat/lon for spherical meshes
+    lon = La / 1852. / 60. if mesh is 'spherical' else La
+    lat = Wa / 1852. / 60. if mesh is 'spherical' else Wa
 
     data = {'U': U, 'V': V, 'P': P}
     dimensions = {'lon': lon, 'lat': lat}
@@ -192,7 +177,7 @@ Example of particle advection around an idealised peninsula""")
 
     if args.fieldset is not None:
         filename = 'peninsula'
-        fieldset = peninsula_fieldset(args.fieldset[0], args.fieldset[1], mesh='spherical')
+        fieldset = peninsula_fieldset(args.fieldset[0], args.fieldset[1], mesh='flat')
         fieldset.write(filename)
 
     # Open fieldset file set


### PR DESCRIPTION
This PR adds `flat` meshes to the `moving_eddies` and `brownian` examples, and updates the FieldSet generation for the `peninsula` example. Furthermore, it adds information on whether the mesh was `flat` or `spherical` to `Field.write`. 

That last feature is important for the plotting of Fields (see also #401) as it will allow us to show the examples in `flat` meshes rather than `spherical` ones