### PR TITLE
Fieldset reuse grid

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -237,6 +237,7 @@ class Field(object):
         self.ccode_data = self.name
         self.dimensions = kwargs.pop('dimensions', None)
         self.indices = kwargs.pop('indices', None)
+        self.timeFiles = kwargs.pop('timeFiles', None)
 
     @classmethod
     def from_netcdf(cls, filenames, variable, dimensions, indices=None, grid=None,
@@ -310,7 +311,7 @@ class Field(object):
                 else:
                     grid = CurvilinearSGrid(lon, lat, depth, time, time_origin=time_origin, mesh=mesh)
             grid.timeslices = timeslices
-            grid.timeFiles = timeFiles
+            kwargs['timeFiles'] = timeFiles
 
         if 'time' in indices:
             logger.warning_once('time dimension in indices is not necessary anymore. It is then ignored.')
@@ -965,7 +966,7 @@ class Field(object):
 
     def computeTimeChunk(self, data, tindex):
         g = self.grid
-        with NetcdfFileBuffer(self.grid.timeFiles[g.ti+tindex], self.dimensions, self.indices) as filebuffer:
+        with NetcdfFileBuffer(self.timeFiles[g.ti+tindex], self.dimensions, self.indices) as filebuffer:
             filebuffer.name = self.dimensions['data'] if 'data' in self.dimensions else self.name
             time_data = filebuffer.time
             if isinstance(time_data[0], np.datetime64):

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -196,7 +196,7 @@ class FieldSet(object):
                 procinds = indices[procvar] if (indices and procvar in indices) else indices
                 if filenames[procvar] == filenames[var] and procdims == dims and procinds == inds:
                     grid = fields[procvar].grid
-                    kwargs['timeFiles'] = fields[procvar].timeFiles
+                    kwargs['dataFiles'] = fields[procvar].dataFiles
                     break
             fields[var] = Field.from_netcdf(paths, var, dims, inds, grid=grid, mesh=mesh,
                                             allow_time_extrapolation=allow_time_extrapolation,

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -189,7 +189,15 @@ class FieldSet(object):
             dims['data'] = name
             inds = indices[var] if (indices and var in indices) else indices
 
-            fields[var] = Field.from_netcdf(paths, var, dims, inds, mesh=mesh,
+            grid = None
+            # check if grid has already been processed (i.e. if other fields have same filenames, dimensions and indices)
+            for procvar, _ in fields.items():
+                procdims = dimensions[procvar] if procvar in dimensions else dimensions
+                procinds = indices[procvar] if (indices and procvar in indices) else indices
+                if filenames[procvar] == filenames[var] and procdims == dims and procinds == inds:
+                    grid = fields[procvar].grid
+                    break
+            fields[var] = Field.from_netcdf(paths, var, dims, inds, grid=grid, mesh=mesh,
                                             allow_time_extrapolation=allow_time_extrapolation,
                                             time_periodic=time_periodic, full_load=full_load, **kwargs)
         u = fields.pop('U', None)

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -193,7 +193,8 @@ class FieldSet(object):
             for procvar, _ in fields.items():
                 procdims = dimensions[procvar] if procvar in dimensions else dimensions
                 procinds = indices[procvar] if (indices and procvar in indices) else indices
-                if filenames[procvar] == filenames[var] and procdims == dims and procinds == inds:
+                if (type(filenames) is not dict or filenames[procvar] == filenames[var]) \
+                        and procdims == dims and procinds == inds:
                     grid = fields[procvar].grid
                     kwargs['dataFiles'] = fields[procvar].dataFiles
                     break

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -196,6 +196,7 @@ class FieldSet(object):
                 procinds = indices[procvar] if (indices and procvar in indices) else indices
                 if filenames[procvar] == filenames[var] and procdims == dims and procinds == inds:
                     grid = fields[procvar].grid
+                    kwargs['timeFiles'] = fields[procvar].timeFiles
                     break
             fields[var] = Field.from_netcdf(paths, var, dims, inds, grid=grid, mesh=mesh,
                                             allow_time_extrapolation=allow_time_extrapolation,


### PR DESCRIPTION
This PR speeds up creation of `FieldSets`, which can be very slow if the hydrodynamic data is spread over many (>100) files. Currently, all these files have to be openend upon creation of the `Field`, even when `defer_load=True`, to check the time dimension in the files.
However, when multiple variables are in the same fileset (and have the same `dimensions` and `indices`) then it doesn't make sense to do open these timeslices for each Field, as we know they will be the same.

In this PR, we check whether the timeslices of a `Field` have already been loaded, in which case the new `Field` inherits its `Grid` and timeslices.

This PR fixes #404