### PR TITLE
convert datetime.date to np.datetime64 in pset creation

### DIFF
--- a/parcels/examples/example_globcurrent.py
+++ b/parcels/examples/example_globcurrent.py
@@ -74,6 +74,22 @@ def test_globcurrent_particles(mode):
     assert(abs(pset[0].lat - -35.3) < 1)
 
 
+def test__particles_init_time():
+    fieldset = set_globcurrent_fieldset()
+
+    lonstart = [25]
+    latstart = [-35]
+
+    # tests the different ways of initialising the time of a particle
+    pset = ParticleSet(fieldset, pclass=JITParticle, lon=lonstart, lat=latstart, time=np.datetime64('2002-01-15'))
+    pset2 = ParticleSet(fieldset, pclass=JITParticle, lon=lonstart, lat=latstart, time=14*86400)
+    pset3 = ParticleSet(fieldset, pclass=JITParticle, lon=lonstart, lat=latstart, time=np.array([np.datetime64('2002-01-15')]))
+    pset4 = ParticleSet(fieldset, pclass=JITParticle, lon=lonstart, lat=latstart, time=[np.datetime64('2002-01-15')])
+    assert pset[0].time - pset2[0].time == 0
+    assert pset[0].time - pset3[0].time == 0
+    assert pset[0].time - pset4[0].time == 0
+
+
 @pytest.mark.xfail(reason="Time extrapolation error expected to be thrown")
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_globcurrent_time_extrapolation_error(mode):

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -10,7 +10,7 @@ import bisect
 import progressbar
 from collections import Iterable
 from datetime import timedelta as delta
-from datetime import datetime
+from datetime import datetime, date
 
 __all__ = ['ParticleSet']
 
@@ -58,6 +58,7 @@ class ParticleSet(object):
         time = time.tolist() if isinstance(time, np.ndarray) else time
         time = [time] * len(lat) if not isinstance(time, list) else time
         time = [np.datetime64(t) if isinstance(t, datetime) else t for t in time]
+        time = [np.datetime64(t) if isinstance(t, date) else t for t in time]
         self.time_origin = fieldset.time_origin
         if len(time) > 0 and isinstance(time[0], np.timedelta64) and not self.time_origin:
             raise NotImplementedError('If fieldset.time_origin is not a date, time of a particle must be a double')


### PR DESCRIPTION
This can be useful in general.
But it is also important because of this python behaviour:

* If you give a list of `np.datetime64` objects, everything goes well
* If you give a np.array of `np.datetime64` objects, pset converts the np.array to a list using function `to_list()`, that automatically converts `np.datetime64` to `datetime.date` (if original date had no hours..)

