### PR TITLE
Allowing variable names to be a list

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1180,6 +1180,9 @@ class NetcdfFileBuffer(object):
             for nm in name:
                 if hasattr(self.dataset, nm):
                     name = nm
+                    break
+        if isinstance(name, list):
+            raise IOError('None of variables in list found in file')
         return name
 
     @property

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -178,7 +178,7 @@ class FieldSet(object):
             if not isinstance(paths, list):
                 paths = sorted(glob(str(paths)))
             if len(paths) == 0:
-                raise IOError("FieldSet files not found: %s" % str(filenames[var]))
+                raise IOError("FieldSet files not found: %s" % str(paths))
             for fp in paths:
                 if not path.exists(fp):
                     raise IOError("FieldSet file not found: %s" % str(fp))


### PR DESCRIPTION
In the GlobCurrent v3.0 data set, the variable names change halfway (between delay-time and near-real-time mode) from `eastward_eulerian_current_velocity` to `u`. 

Here, we allow that the `variable` names can be a `list`, e.g.:
```
variables = {'U': ['eastward_eulerian_current_velocity', 'u'], 'V': ['northward_eulerian_current_velocity', 'v']}
```
Parcels will then work with either of these two names, whichever is in the file