### PR TITLE
Implement way to do computations on Fields that are defer-loaded

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -243,6 +243,7 @@ class Field(object):
         self.dimensions = kwargs.pop('dimensions', None)
         self.indices = kwargs.pop('indices', None)
         self.dataFiles = kwargs.pop('dataFiles', None)
+        self.compute_on_defer = None
 
     @classmethod
     def from_netcdf(cls, filenames, variable, dimensions, indices=None, grid=None,

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -243,7 +243,7 @@ class Field(object):
         self.dimensions = kwargs.pop('dimensions', None)
         self.indices = kwargs.pop('indices', None)
         self.dataFiles = kwargs.pop('dataFiles', None)
-        self._tindex = []
+        self.loaded_time_indices = []
 
     @classmethod
     def from_netcdf(cls, filenames, variable, dimensions, indices=None, grid=None,

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -243,7 +243,7 @@ class Field(object):
         self.dimensions = kwargs.pop('dimensions', None)
         self.indices = kwargs.pop('indices', None)
         self.dataFiles = kwargs.pop('dataFiles', None)
-        self.compute_on_defer = None
+        self._tindex = []
 
     @classmethod
     def from_netcdf(cls, filenames, variable, dimensions, indices=None, grid=None,
@@ -433,22 +433,26 @@ class Field(object):
             self.calc_cell_edge_sizes()
         return self.grid.cell_edge_sizes['x'] * self.grid.cell_edge_sizes['y']
 
-    def gradient(self, update=False):
+    def gradient(self, update=False, tindex=None):
         """Method to calculate horizontal gradients of Field.
                 Returns two Fields: the zonal and meridional gradients,
                 on the same Grid as the original Field, using numpy.gradient() method
                 Names of these grids are dNAME_dx and dNAME_dy, where NAME is the name
                 of the original Field"""
+        tindex = range(self.grid.tdim) if tindex is None else tindex
         if not self.grid.cell_edge_sizes:
             self.calc_cell_edge_sizes()
         if self.grid.defer_load and self.data is None:
             (dFdx, dFdy) = (None, None)
         else:
-            dFdy = np.gradient(self.data, axis=-2) / self.grid.cell_edge_sizes['y']
-            dFdx = np.gradient(self.data, axis=-1) / self.grid.cell_edge_sizes['x']
+            dFdy = np.gradient(self.data[tindex, :], axis=-2) / self.grid.cell_edge_sizes['y']
+            dFdx = np.gradient(self.data[tindex, :], axis=-1) / self.grid.cell_edge_sizes['x']
         if update:
-            self.gradientx.data = dFdx
-            self.gradienty.data = dFdy
+            if self.gradientx.data is None:
+                self.gradientx.data = np.zeros_like(self.data)
+                self.gradienty.data = np.zeros_like(self.data)
+            self.gradientx.data[tindex, :] = dFdx
+            self.gradienty.data[tindex, :] = dFdy
         else:
             dFdx_fld = Field('d%s_dx' % self.name, dFdx, grid=self.grid)
             dFdy_fld = Field('d%s_dy' % self.name, dFdy, grid=self.grid)
@@ -969,11 +973,6 @@ class Field(object):
                     data[tindex, 0, :, :] = filebuffer.data[ti, :, :]
             else:
                 data[tindex, :, :, :] = filebuffer.data[ti, :, :, :]
-        data[np.isnan(data)] = 0.
-        if self.vmin is not None:
-            data[data < self.vmin] = 0.
-        if self.vmax is not None:
-            data[data > self.vmax] = 0.
 
         return data
 

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -407,6 +407,8 @@ class FieldSet(object):
                 data = np.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
                 for tindex in range(3):
                     data = f.computeTimeChunk(data, tindex)
+                if f.compute_on_defer:
+                    data = f.compute_on_defer(data)
                 if f._scaling_factor:
                     data *= f._scaling_factor
                 f.data = f.reshape(data)
@@ -419,6 +421,8 @@ class FieldSet(object):
                     f.data[1:, :] = f.data[:2, :]
                     tindex = 0
                 data = f.computeTimeChunk(data, tindex)
+                if f.compute_on_defer:
+                    data[tindex, :] = f.compute_on_defer(data[tindex, :])
                 if f._scaling_factor:
                     data *= f._scaling_factor
                 f.data[tindex, :] = f.reshape(data)[tindex, :]

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -407,8 +407,8 @@ class FieldSet(object):
                 data = np.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
                 for tindex in range(3):
                     data = f.computeTimeChunk(data, tindex)
-                if f.compute_on_defer:
-                    data = f.compute_on_defer(data)
+                    if f.compute_on_defer:
+                        data[tindex, :] = f.compute_on_defer(data[tindex, :])
                 if f._scaling_factor:
                     data *= f._scaling_factor
                 f.data = f.reshape(data)

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -408,25 +408,25 @@ class FieldSet(object):
             g = f.grid
             if g.update_status == 'first_updated':  # First load of data
                 data = np.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
-                f._tindex = range(3)
-                for tind in f._tindex:
+                f.loaded_time_indices = range(3)
+                for tind in f.loaded_time_indices:
                     data = f.computeTimeChunk(data, tind)
                 f.data = f.reshape(data)
             elif g.update_status == 'updated':
                 data = np.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
                 if signdt >= 0:
                     f.data[:2, :] = f.data[1:, :]
-                    f._tindex = [2]
+                    f.loaded_time_indices = [2]
                 else:
                     f.data[1:, :] = f.data[:2, :]
-                    f._tindex = [0]
-                data = f.computeTimeChunk(data, f._tindex[0])
-                f.data[f._tindex[0], :] = f.reshape(data)[f._tindex[0], :]
+                    f.loaded_time_indices = [0]
+                data = f.computeTimeChunk(data, f.loaded_time_indices[0])
+                f.data[f.loaded_time_indices[0], :] = f.reshape(data)[f.loaded_time_indices[0], :]
             else:
-                f._tindex = []
+                f.loaded_time_indices = []
 
             # do built-in computations on data
-            for tind in f._tindex:
+            for tind in f.loaded_time_indices:
                 if f._scaling_factor:
                     f.data[tind, :] *= f._scaling_factor
                 f.data[tind, :] = np.where(np.isnan(f.data[tind, :]), 0, f.data[tind, :])

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -31,6 +31,8 @@ class FieldSet(object):
             for name, field in fields.items():
                 self.add_field(field, name)
 
+        self.compute_on_defer = None
+
     @classmethod
     def from_data(cls, data, dimensions, transpose=False, mesh='spherical',
                   allow_time_extrapolation=None, time_periodic=False, **kwargs):
@@ -399,35 +401,45 @@ class FieldSet(object):
                 nextTime_loc = f.grid.computeTimeChunk(f, time, signdt)
             nextTime = min(nextTime, nextTime_loc) if signdt >= 0 else max(nextTime, nextTime_loc)
 
+        # load in new data
         for f in self.fields:
             if isinstance(f, VectorField) or not f.grid.defer_load or f.is_gradient:
                 continue
             g = f.grid
             if g.update_status == 'first_updated':  # First load of data
                 data = np.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
-                for tindex in range(3):
-                    data = f.computeTimeChunk(data, tindex)
-                    if f.compute_on_defer:
-                        data[tindex, :] = f.compute_on_defer(data[tindex, :])
-                if f._scaling_factor:
-                    data *= f._scaling_factor
+                f._tindex = range(3)
+                for tind in f._tindex:
+                    data = f.computeTimeChunk(data, tind)
                 f.data = f.reshape(data)
             elif g.update_status == 'updated':
                 data = np.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
                 if signdt >= 0:
                     f.data[:2, :] = f.data[1:, :]
-                    tindex = 2
+                    f._tindex = [2]
                 else:
                     f.data[1:, :] = f.data[:2, :]
-                    tindex = 0
-                data = f.computeTimeChunk(data, tindex)
-                if f.compute_on_defer:
-                    data[tindex, :] = f.compute_on_defer(data[tindex, :])
+                    f._tindex = [0]
+                data = f.computeTimeChunk(data, f._tindex[0])
+                f.data[f._tindex[0], :] = f.reshape(data)[f._tindex[0], :]
+            else:
+                f._tindex = []
+
+            # do built-in computations on data
+            for tind in f._tindex:
                 if f._scaling_factor:
-                    data *= f._scaling_factor
-                f.data[tindex, :] = f.reshape(data)[tindex, :]
-            if f.gradientx is not None and g.update_status in ['first_updated', 'updated']:
-                f.gradient(update=True)
+                    f.data[tind, :] *= f._scaling_factor
+                f.data[tind, :] = np.where(np.isnan(f.data[tind, :]), 0, f.data[tind, :])
+                if f.vmin is not None:
+                    f.data[tind, :] = np.where(f.data[tind, :] < f.vmin, 0, f.data[tind, :])
+                if f.vmax is not None:
+                    f.data[tind, :] = np.where(f.data[tind, :] > f.vmax, 0, f.data[tind, :])
+                if f.gradientx is not None:
+                    f.gradient(update=True, tindex=tind)
+
+        # do user-defined computations on fieldset data
+        if self.compute_on_defer:
+            self.compute_on_defer(self)
 
         if abs(nextTime) == np.infty or np.isnan(nextTime):  # Second happens when dt=0
             return nextTime

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -340,7 +340,7 @@ def test_fieldset_defer_loading_function(zdim, scale_fac, tmpdir, filename='test
     def compute(fieldset):
         # Calculating vertical weighted average
         for f in [fieldset.U, fieldset.V]:
-            for tind in f._tindex:
+            for tind in f.loaded_time_indices:
                 f.data[tind, :] = np.sum(f.data[tind, :] * DZ, axis=0) / sum(dz)
 
     fieldset.compute_on_defer = compute


### PR DESCRIPTION
This PR implements support for a new `fieldset.compute_on_defer` attribute, that can be used to do arbitrary computations on `Fields` in a `FieldSet` during loading. This will also solve #371. A usage example would be

```
def addone(fieldset):
    for tind in fieldset.U.loaded_time_indices:
        fieldset.U.data[tind, :] += 1
fieldset.compute_on_defer = addone
```
Note that `loaded_time_indices` here is a list of the timeslices that have been updated in the `computeTimeChunk` (all three timeslices on initial loading, and either the first or the last on updating, depending on the sign of `dt`)

Furthermore, this PR includes some cleaning-up of the `computeTimeChunk()` methods for `FieldSets` and `Fields`. 