### PR TITLE
Ignoring single-snapshot Grids in calculating of dimrange(`time`)

### DIFF
--- a/parcels/gridset.py
+++ b/parcels/gridset.py
@@ -40,14 +40,15 @@ class GridSet(object):
            in a gridset. Useful for finding e.g. longitude range that
            overlaps on all grids in a gridset"""
 
-        maxleft, minright = (0, np.inf)
+        maxleft, minright = (-np.inf, np.inf)
         for g in self.grids:
-            if dim == 'time_full' and len(getattr(g, dim)) == 1:
-                continue  # not including grids where only one time_full entry, as with allow_time_extrapolation=True
+            if len(getattr(g, dim)) == 1:
+                continue  # not including grids where only one entry
             else:
                 maxleft = max(maxleft, getattr(g, dim)[0])
                 minright = min(minright, getattr(g, dim)[-1])
-        minright = 0 if minright == np.inf else minright  # if all len(time_full) == 1
+        maxleft = 0 if maxleft == -np.inf else maxleft  # if all len(dim) == 1
+        minright = 0 if minright == np.inf else minright  # if all len(dim) == 1
         return maxleft, minright
 
     @property

--- a/parcels/gridset.py
+++ b/parcels/gridset.py
@@ -42,8 +42,11 @@ class GridSet(object):
 
         maxleft, minright = (0, np.infty)
         for g in self.grids:
-            maxleft = max(maxleft, getattr(g, dim)[0])
-            minright = min(minright, getattr(g, dim)[-1])
+            if dim == 'time_full' and len(getattr(g, dim)) == 1:
+                continue  # not including grids where only one time_full entry, as with allow_time_extrapolation=True
+            else:
+                maxleft = max(maxleft, getattr(g, dim)[0])
+                minright = min(minright, getattr(g, dim)[-1])
         return maxleft, minright
 
     @property

--- a/parcels/gridset.py
+++ b/parcels/gridset.py
@@ -40,13 +40,14 @@ class GridSet(object):
            in a gridset. Useful for finding e.g. longitude range that
            overlaps on all grids in a gridset"""
 
-        maxleft, minright = (0, np.infty)
+        maxleft, minright = (0, np.inf)
         for g in self.grids:
             if dim == 'time_full' and len(getattr(g, dim)) == 1:
                 continue  # not including grids where only one time_full entry, as with allow_time_extrapolation=True
             else:
                 maxleft = max(maxleft, getattr(g, dim)[0])
                 minright = min(minright, getattr(g, dim)[-1])
+        minright = 0 if minright == np.inf else minright  # if all len(time_full) == 1
         return maxleft, minright
 
     @property


### PR DESCRIPTION
Fixing a bug where `dimrange('time_full')` was wrong when `FieldSet` included a `Field` with one snapshot