### PR TITLE
Changing FieldLists to SummedFields

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -1,5 +1,4 @@
-from parcels.field import Field, VectorField
-from parcels.fieldset import FieldList, VectorFieldList
+from parcels.field import Field, VectorField, SummedField, SummedVectorField
 from parcels.loggers import logger
 import ast
 import cgen as c
@@ -20,12 +19,12 @@ class FieldSetNode(IntrinsicNode):
         if isinstance(getattr(self.obj, attr), Field):
             return FieldNode(getattr(self.obj, attr),
                              ccode="%s->%s" % (self.ccode, attr))
-        elif isinstance(getattr(self.obj, attr), VectorFieldList):
-            return VectorFieldListNode(getattr(self.obj, attr),
-                                       ccode="%s->%s" % (self.ccode, attr))
-        elif isinstance(getattr(self.obj, attr), FieldList) or isinstance(getattr(self.obj, attr), list):
-            return FieldListNode(getattr(self.obj, attr),
-                                 ccode="%s->%s" % (self.ccode, attr))
+        elif isinstance(getattr(self.obj, attr), SummedVectorField):
+            return SummedVectorFieldNode(getattr(self.obj, attr),
+                                         ccode="%s->%s" % (self.ccode, attr))
+        elif isinstance(getattr(self.obj, attr), SummedField) or isinstance(getattr(self.obj, attr), list):
+            return SummedFieldNode(getattr(self.obj, attr),
+                                   ccode="%s->%s" % (self.ccode, attr))
         elif isinstance(getattr(self.obj, attr), VectorField):
             return VectorFieldNode(getattr(self.obj, attr),
                                    ccode="%s->%s" % (self.ccode, attr))
@@ -60,24 +59,24 @@ class VectorFieldEvalNode(IntrinsicNode):
         self.var3 = var3  # third variable for UVW interpolation
 
 
-class FieldListNode(IntrinsicNode):
+class SummedFieldNode(IntrinsicNode):
     def __getitem__(self, attr):
-        return FieldListEvalNode(self.obj, attr)
+        return SummedFieldEvalNode(self.obj, attr)
 
 
-class FieldListEvalNode(IntrinsicNode):
+class SummedFieldEvalNode(IntrinsicNode):
     def __init__(self, fields, args, var):
         self.fields = fields
         self.args = args
         self.var = var  # the variable in which the interpolated field is written
 
 
-class VectorFieldListNode(IntrinsicNode):
+class SummedVectorFieldNode(IntrinsicNode):
     def __getitem__(self, attr):
-        return VectorFieldListEvalNode(self.obj, attr)
+        return SummedVectorFieldEvalNode(self.obj, attr)
 
 
-class VectorFieldListEvalNode(IntrinsicNode):
+class SummedVectorFieldEvalNode(IntrinsicNode):
     def __init__(self, field, args, var, var2, var3):
         self.field = field
         self.args = args
@@ -210,18 +209,18 @@ class IntrinsicTransformer(ast.NodeTransformer):
 
         # If we encounter field evaluation we replace it with a
         # temporary variable and put the evaluation call on the stack.
-        if isinstance(node.value, FieldListNode):
+        if isinstance(node.value, SummedFieldNode):
             tmp = [self.get_tmp() for _ in node.value.obj]
             # Insert placeholder node for field eval ...
-            self.stmt_stack += [FieldListEvalNode(node.value, node.slice, tmp)]
+            self.stmt_stack += [SummedFieldEvalNode(node.value, node.slice, tmp)]
             # .. and return the name of the temporary that will be populated
             return ast.Name(id='+'.join(tmp))
-        elif isinstance(node.value, VectorFieldListNode):
+        elif isinstance(node.value, SummedVectorFieldNode):
             tmp = [self.get_tmp() for _ in node.value.obj.U]
             tmp2 = [self.get_tmp() for _ in node.value.obj.U]
             tmp3 = [self.get_tmp() if node.value.obj.W else None for _ in node.value.obj.U]
             # Insert placeholder node for field eval ...
-            self.stmt_stack += [VectorFieldListEvalNode(node.value, node.slice, tmp, tmp2, tmp3)]
+            self.stmt_stack += [SummedVectorFieldEvalNode(node.value, node.slice, tmp, tmp2, tmp3)]
             # .. and return the name of the temporary that will be populated
             if all(tmp3):
                 return ast.Tuple([ast.Name(id='+'.join(tmp)), ast.Name(id='+'.join(tmp2)), ast.Name(id='+'.join(tmp3))], ast.Load())
@@ -621,7 +620,7 @@ class KernelGenerator(ast.NodeVisitor):
         """Record intrinsic fields used in kernel"""
         self.field_args[node.obj.name] = node.obj
 
-    def visit_FieldListNode(self, node):
+    def visit_SummedFieldNode(self, node):
         """Record intrinsic fields used in kernel"""
         for fld in node.obj:
             self.field_args[fld.name] = fld
@@ -630,7 +629,7 @@ class KernelGenerator(ast.NodeVisitor):
         """Record intrinsic fields used in kernel"""
         self.vector_field_args[node.obj.name] = node.obj
 
-    def visit_VectorFieldListNode(self, node):
+    def visit_SummedVectorFieldNode(self, node):
         """Record intrinsic fields used in kernel"""
         for fld in node.obj.U:
             self.field_args[fld.name] = fld
@@ -672,7 +671,7 @@ class KernelGenerator(ast.NodeVisitor):
         node.ccode = c.Block([c.Assign("err", ccode_eval),
                               conv_stat, c.Statement("CHECKERROR(err)")])
 
-    def visit_FieldListEvalNode(self, node):
+    def visit_SummedFieldEvalNode(self, node):
         self.visit(node.fields)
         self.visit(node.args)
         cstat = []
@@ -683,7 +682,7 @@ class KernelGenerator(ast.NodeVisitor):
             cstat += [c.Assign("err", ccode_eval), conv_stat, c.Statement("CHECKERROR(err)")]
         node.ccode = c.Block(cstat)
 
-    def visit_VectorFieldListEvalNode(self, node):
+    def visit_SummedVectorFieldEvalNode(self, node):
         self.visit(node.field)
         self.visit(node.args)
         cstat = []

--- a/parcels/examples/tutorial_SummedFields.ipynb
+++ b/parcels/examples/tutorial_SummedFields.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Tutorial on how to combine different Fields for advection into a `FieldList` object"
+    "## Tutorial on how to combine different Fields for advection into a `SummedField` object"
    ]
   },
   {
@@ -13,9 +13,9 @@
    "source": [
     "In some oceanographic applications, you may want to advect particles using a combination of different velocity data sets. For example, particles at the surface are transported by a combination of geostrophic, Ekman and Stokes flow. And often, these flows are not even on the same grid.\n",
     "\n",
-    "One option would be to write a  `Kernel` that computes the movement of particles due to each of these flows. However, in Parcels it is possible to directly combine different flows (without interpolation) and feed them into the built-in `AdvectionRK4` kernel. For that, we use so-called `FieldList` objects.\n",
+    "One option would be to write a  `Kernel` that computes the movement of particles due to each of these flows. However, in Parcels it is possible to directly combine different flows (without interpolation) and feed them into the built-in `AdvectionRK4` kernel. For that, we use so-called `SummedField` objects.\n",
     "\n",
-    "This tutorial shows how to use these `FieldLists` with a very idealised example. We start by importing the relevant modules."
+    "This tutorial shows how to use these `SummedField` with a very idealised example. We start by importing the relevant modules."
    ]
   },
   {
@@ -123,7 +123,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now comes the trick of the `FieldLists`. We can simply define a new `FieldSet` with a list of different `Fields`, as in `U=[U, Ustokes]`."
+    "Now comes the trick of the `SummedFields`. We can simply define a new `FieldSet` with a summation of different `Fields`, as in `U=U+Ustokes`."
    ]
   },
   {
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fieldset = FieldSet(U=[U, Ustokes], V=[V, Vstokes])"
+    "fieldset = FieldSet(U=U+Ustokes, V=V+Vstokes)"
    ]
   },
   {
@@ -177,9 +177,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What happens under the hood is that each `Field` in the `FieldList` is interpolated separately to the particle location, and that the different velocities are added in each step of the RK4 advection. So `FieldLists` are effortless to users\n",
+    "What happens under the hood is that each `Field` in the `SummedField` is interpolated separately to the particle location, and that the different velocities are added in each step of the RK4 advection. So `SummedFields` are effortless to users\n",
     "\n",
-    "Note that `FieldLists` work for any type of `Field`, not only for velocities. Any call to a `Field` interpolation (`fieldset.fld[time, lon, lat, depth]`) will return the sum of all `Fields` in the list if `fld` is a `FieldList`."
+    "Note that `SummedFields` work for any type of `Field`, not only for velocities. Any call to a `Field` interpolation (`fieldset.fld[time, lon, lat, depth]`) will return the sum of all `Fields` in the list if `fld` is a `SummedField`."
    ]
   },
   {
@@ -206,7 +206,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -981,10 +981,18 @@ class Field(object):
         if isinstance(self, Field) and isinstance(field, Field):
             return SummedField([self, field])
         elif isinstance(field, SummedField):
-            return field.__add__(self)
+            field.insert(0, self)
+            return field
 
 
 class SummedField(list):
+    """Class SummedField is a list of Fields over which Field interpolation
+    is summed. This can e.g. be used when combining multiple flow fields,
+    where the total flow is the sum of all the individual flows.
+    Note that the individual Fields can be on different Grids.
+    Also note that, since SummedFields are lists, the individual Fields can
+    still be queried through their list index (e.g. SummedField[1]).
+    """
     def eval(self, time, x, y, z, applyConversion=True):
         tmp = 0
         for fld in self:

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -978,7 +978,10 @@ class Field(object):
         return data
 
     def __add__(self, field):
-        return SummedField([self, field])
+        if isinstance(self, Field) and isinstance(field, Field):
+            return SummedField([self, field])
+        elif isinstance(field, SummedField):
+            return field.__add__(self)
 
 
 class SummedField(list):
@@ -993,6 +996,14 @@ class SummedField(list):
             return list.__getitem__(self, key)
         else:
             return self.eval(*key)
+
+    def __add__(self, field):
+        if isinstance(field, Field):
+            self.append(field)
+        elif isinstance(field, SummedField):
+            for fld in field:
+                self.append(fld)
+        return self
 
 
 class VectorField(object):

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -97,6 +97,8 @@ class FieldSet(object):
             for fld in field:
                 self.gridset.add_grid(fld)
                 fld.fieldset = self
+        elif isinstance(field, list):
+            raise NotImplementedError('FieldLists have been replaced by SummedFields. Use the + operator instead of []')
         else:
             setattr(self, name, field)
             self.gridset.add_grid(field)

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1,4 +1,4 @@
-from parcels.field import Field, VectorField
+from parcels.field import Field, VectorField, SummedField, SummedVectorField
 from parcels.gridset import GridSet
 from parcels.grid import RectilinearZGrid
 from parcels.loggers import logger
@@ -8,7 +8,7 @@ from glob import glob
 from copy import deepcopy
 
 
-__all__ = ['FieldSet', 'FieldList']
+__all__ = ['FieldSet']
 
 
 class FieldSet(object):
@@ -92,8 +92,8 @@ class FieldSet(object):
         :param name: Name of the :class:`parcels.field.Field` object to be added
         """
         name = field.name if name is None else name
-        if isinstance(field, list):
-            setattr(self, name, FieldList(field))
+        if isinstance(field, SummedField):
+            setattr(self, name, field)
             for fld in field:
                 self.gridset.add_grid(fld)
                 fld.fieldset = self
@@ -128,13 +128,13 @@ class FieldSet(object):
                     g.time_full = g.time_full + (g.time_origin - self.time_origin) / np.timedelta64(1, 's')
                 g.time_origin = self.time_origin
         if not hasattr(self, 'UV'):
-            if isinstance(self.U, FieldList):
-                self.add_vector_field(VectorFieldList('UV', self.U, self.V))
+            if isinstance(self.U, SummedField):
+                self.add_vector_field(SummedVectorField('UV', self.U, self.V))
             else:
                 self.add_vector_field(VectorField('UV', self.U, self.V))
         if not hasattr(self, 'UVW') and hasattr(self, 'W'):
-            if isinstance(self.U, FieldList):
-                self.add_vector_field(VectorFieldList('UVW', self.U, self.V, self.W))
+            if isinstance(self.U, SummedField):
+                self.add_vector_field(SummedVectorField('UVW', self.U, self.V, self.W))
             else:
                 self.add_vector_field(VectorField('UVW', self.U, self.V, self.W))
 
@@ -303,7 +303,7 @@ class FieldSet(object):
         for v in self.__dict__.values():
             if isinstance(v, Field):
                 fields.append(v)
-            elif isinstance(v, FieldList):
+            elif isinstance(v, SummedField):
                 for v2 in v:
                     if v2 not in fields:
                         fields.append(v2)
@@ -449,60 +449,3 @@ class FieldSet(object):
                 return nextTime
             else:
                 return time + nSteps * dt
-
-
-class FieldList(list):
-    def eval(self, time, x, y, z, applyConversion=True):
-        tmp = 0
-        for fld in self:
-            tmp += fld.eval(time, x, y, z, applyConversion)
-        return tmp
-
-    def __getitem__(self, key):
-        if isinstance(key, int):
-            return list.__getitem__(self, key)
-        else:
-            return self.eval(*key)
-
-
-class VectorFieldList(list):
-    """Class VectorFieldList stores 2 or 3 FieldLists which defines together a vector field.
-    This enables to interpolate them as one single vector FieldList in the kernels.
-
-    :param name: Name of the vector field
-    :param U: FieldList defining the zonal component
-    :param V: FieldList defining the meridional component
-    :param W: FieldList defining the vertical component (default: None)
-    """
-
-    def __init__(self, name, U, V, W=None):
-        self.name = name
-        self.U = U
-        self.V = V
-        self.W = W
-
-    def eval(self, time, x, y, z):
-        zonal = meridional = vertical = 0
-        if self.W is not None:
-            for (U, V, W) in zip(self.U, self.V, self.W):
-                vfld = VectorField(self.name, U, V, W)
-                vfld.fieldset = self.fieldset
-                (tmp1, tmp2, tmp3) = vfld.eval(time, x, y, z)
-                zonal += tmp1
-                meridional += tmp2
-                vertical += tmp3
-            return (zonal, meridional, vertical)
-        else:
-            for (U, V) in zip(self.U, self.V):
-                vfld = VectorField(self.name, U, V)
-                vfld.fieldset = self.fieldset
-                (tmp1, tmp2) = vfld.eval(time, x, y, z)
-                zonal += tmp1
-                meridional += tmp2
-            return (zonal, meridional)
-
-    def __getitem__(self, key):
-        if isinstance(key, int):
-            return list.__getitem__(self, key)
-        else:
-            return self.eval(*key)

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -426,7 +426,7 @@ def test_list_of_fields(mode, with_W, k_sample_p, mesh):
                mesh=mesh, fieldtype='U')
     V1 = Field('V1', np.zeros((zdim*gf, ydim*gf, xdim*gf), dtype=np.float32), grid=U1.grid, fieldtype='V')
     V2 = Field('V2', np.zeros((zdim, ydim, xdim), dtype=np.float32), grid=U2.grid, fieldtype='V')
-    fieldset = FieldSet([U1, U2], [V1, V2])
+    fieldset = FieldSet(U1+U2, V1+V2)
 
     conv = 1852*60 if mesh == 'spherical' else 1.
     assert np.allclose(fieldset.U.eval(0, 0, 0, 0)*conv, 0.3)
@@ -434,13 +434,13 @@ def test_list_of_fields(mode, with_W, k_sample_p, mesh):
 
     P1 = Field('P1', 30*np.ones((zdim*gf, ydim*gf, xdim*gf), dtype=np.float32), grid=U1.grid)
     P2 = Field('P2', 20*np.ones((zdim, ydim, xdim), dtype=np.float32), grid=U2.grid)
-    fieldset.add_field([P1, P2], name='P')
+    fieldset.add_field(P1+P2, name='P')
     assert np.allclose(fieldset.P[0, 0, 0, 0], 50)
 
     if with_W:
         W1 = Field('W1', 2*np.ones((zdim * gf, ydim * gf, xdim * gf), dtype=np.float32), grid=U1.grid)
         W2 = Field('W2', np.ones((zdim, ydim, xdim), dtype=np.float32), grid=U2.grid)
-        fieldset.add_field([W1, W2], name='W')
+        fieldset.add_field(W1+W2, name='W')
         pset = ParticleSet(fieldset, pclass=pclass(mode), lon=[0], lat=[0.9])
         pset.execute(AdvectionRK4_3D+pset.Kernel(k_sample_p), runtime=2, dt=1)
         assert np.isclose(pset[0].depth, 6)

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -434,8 +434,10 @@ def test_summedfields(mode, with_W, k_sample_p, mesh):
 
     P1 = Field('P1', 30*np.ones((zdim*gf, ydim*gf, xdim*gf), dtype=np.float32), grid=U1.grid)
     P2 = Field('P2', 20*np.ones((zdim, ydim, xdim), dtype=np.float32), grid=U2.grid)
-    fieldset.add_field(P1+P2, name='P')
-    assert np.allclose(fieldset.P[0, 0, 0, 0], 50)
+    P3 = Field('P3', 10*np.ones((zdim, ydim, xdim), dtype=np.float32), grid=U2.grid)
+    P4 = Field('P4', 0*np.ones((zdim, ydim, xdim), dtype=np.float32), grid=U2.grid)
+    fieldset.add_field((P1+P4)+(P2+P3), name='P')
+    assert np.allclose(fieldset.P[0, 0, 0, 0], 60)
 
     if with_W:
         W1 = Field('W1', 2*np.ones((zdim * gf, ydim * gf, xdim * gf), dtype=np.float32), grid=U1.grid)
@@ -447,6 +449,6 @@ def test_summedfields(mode, with_W, k_sample_p, mesh):
     else:
         pset = ParticleSet(fieldset, pclass=pclass(mode), lon=[0], lat=[0.9])
         pset.execute(AdvectionRK4+pset.Kernel(k_sample_p), runtime=2, dt=1)
-    assert np.isclose(pset[0].p, 50)
+    assert np.isclose(pset[0].p, 60)
     assert np.isclose(pset[0].lon*conv, 0.6, atol=1e-3)
     assert np.isclose(pset[0].lat, 0.9)

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -409,7 +409,7 @@ def test_sampling_multiple_grid_sizes(mode):
 @pytest.mark.parametrize('mode', ['jit', 'scipy'])
 @pytest.mark.parametrize('with_W', [True, False])
 @pytest.mark.parametrize('mesh', ['flat', 'spherical'])
-def test_list_of_fields(mode, with_W, k_sample_p, mesh):
+def test_summedfields(mode, with_W, k_sample_p, mesh):
     xdim = 10
     ydim = 20
     zdim = 4

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -437,6 +437,7 @@ def test_summedfields(mode, with_W, k_sample_p, mesh):
     P3 = Field('P3', 10*np.ones((zdim, ydim, xdim), dtype=np.float32), grid=U2.grid)
     P4 = Field('P4', 0*np.ones((zdim, ydim, xdim), dtype=np.float32), grid=U2.grid)
     fieldset.add_field((P1+P4)+(P2+P3), name='P')
+    assert fieldset.P[0].name == 'P1'
     assert np.allclose(fieldset.P[0, 0, 0, 0], 60)
 
     if with_W:


### PR DESCRIPTION
This PR introduces a change in the API for combining of different `Fields` for interpolation (see also Issue #432). 

Using the `+` operator is much more intuitive if the data in different `Fields` need to be summed at a particle location.

Also, this means that we can use the list operator `[]` for a future feature such as possibly nested `Fields`