### PR TITLE
Setting a better, more explicit error for time extrapolation errors in field.show()

### DIFF
--- a/parcels/examples/parcels_tutorial.ipynb
+++ b/parcels/examples/parcels_tutorial.ipynb
@@ -1669,7 +1669,7 @@
     "pset.execute(AdvectionRK4 + k_sample,    # Add kernels using the + operator.\n",
     "             runtime=timedelta(hours=20),\n",
     "             dt=timedelta(minutes=5))\n",
-    "pset.show(field=fieldset.P)\n",
+    "pset.show(field=fieldset.P, show_time=0)\n",
     "print('p values after execution:', [p.p for p in pset])"
    ]
   },

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -610,10 +610,15 @@ class Field(object):
 
         :rtype: Linearly interpolated field"""
         t0 = self.grid.time[ti]
-        t1 = self.grid.time[ti+1]
-        f0 = self.data[ti, :]
-        f1 = self.data[ti+1, :]
-        return f0 + (f1 - f0) * ((time - t0) / (t1 - t0))
+        if time == t0:
+            return self.data[ti, :]
+        elif ti+1 >= len(self.grid.time):
+            raise TimeExtrapolationError(time, field=self, msg='show_time')
+        else:
+            t1 = self.grid.time[ti+1]
+            f0 = self.data[ti, :]
+            f1 = self.data[ti+1, :]
+            return f0 + (f1 - f0) * ((time - t0) / (t1 - t0))
 
     def spatial_interpolation(self, ti, z, y, x, time):
         """Interpolate horizontal field values using a SciPy interpolator"""

--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -1,6 +1,7 @@
 from parcels.field import Field, VectorField
 from parcels.grid import CurvilinearGrid, GridCode
 from parcels.tools.loggers import logger
+from parcels.tools.error import TimeExtrapolationError
 import numpy as np
 from datetime import timedelta as delta
 from datetime import datetime
@@ -130,6 +131,8 @@ def plotfield(field, show_time=None, domain=None, projection=None, land=True,
             fld.fieldset.computeTimeChunk(show_time, 1)
         (idx, periods) = fld.time_index(show_time)
         show_time -= periods * (fld.grid.time[-1] - fld.grid.time[0])
+        if show_time > fld.grid.time[-1] or show_time < fld.grid.time[0]:
+            raise TimeExtrapolationError(show_time, field=fld, msg='show_time')
 
         latN, latS, lonE, lonW = parsedomain(domain, fld)
         if isinstance(fld.grid, CurvilinearGrid):

--- a/parcels/tools/error.py
+++ b/parcels/tools/error.py
@@ -33,12 +33,15 @@ class FieldSamplingError(RuntimeError):
 class TimeExtrapolationError(RuntimeError):
     """Utility error class to propagate erroneous time extrapolation sampling in Scipy mode"""
 
-    def __init__(self, time, field=None):
+    def __init__(self, time, field=None, msg='allow_time_extrapoltion'):
         if field is not None and field.grid.time_origin and time is not None:
             time = field.grid.time_origin + np.timedelta64(int(time), 's')
         message = "%s sampled outside time domain at time %s." % (
             field.name if field else "Field", time)
-        message += " Try setting allow_time_extrapolation to True"
+        if msg == 'allow_time_extrapoltion':
+            message += " Try setting allow_time_extrapolation to True"
+        elif msg == 'show_time':
+            message += " Try explicitly providing a 'show_time'"
         super(TimeExtrapolationError, self).__init__(message)
 
 


### PR DESCRIPTION
Also improves efficiency of `temporal_interpolate_fullfield()` when `time == ti`

This addresses #446