### PR TITLE
Clearer codegenerator error messages

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -543,7 +543,8 @@ class KernelGenerator(ast.NodeVisitor):
         self.visit(node.op)
         self.visit(node.right)
         if isinstance(node.op, ast.BitXor):
-            raise RuntimeError('JIT kernels do not support ^ operator. Please use ** for power operator')
+            raise RuntimeError("JIT kernels do not support the '^' operator.\n"
+                               "Did you intend to use the exponential/power operator? In that case, please use '**'")
         elif node.op.ccode == 'pow':  # catching '**' pow statements
             node.ccode = "pow(%s, %s)" % (node.left.ccode, node.right.ccode)
         else:


### PR DESCRIPTION
This PR ensures better error messages when the codegenerator fails on `numpy` or `^` statements.

For all other cases, it now also adds name of the variable on which codegenerator fails to the error message, which will help in debugging

This PR fixes #448