### PR TITLE
Clearer error message when paths not found

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -182,7 +182,8 @@ class FieldSet(object):
             if not isinstance(paths, list):
                 paths = sorted(glob(str(paths)))
             if len(paths) == 0:
-                raise IOError("FieldSet files not found: %s" % str(paths))
+                notfound_paths = filenames[var] if type(filenames) is dict else filenames
+                raise IOError("FieldSet files not found: %s" % str(notfound_paths))
             for fp in paths:
                 if not path.exists(fp):
                     raise IOError("FieldSet file not found: %s" % str(fp))


### PR DESCRIPTION
This PR improves the error message when paths are not found in FieldSet.from_netcdf

Since the error is only thrown after `glob()` and when `len(paths) == 0`, this was always an empty list; so error did not say _which_ files weren’t found. Now, that is made explicit