### PR TITLE
Fixing a bug where animations don't include the first snapshot of a particleFile

### DIFF
--- a/parcels/scripts/plottrajectoriesfile.py
+++ b/parcels/scripts/plottrajectoriesfile.py
@@ -100,7 +100,7 @@ def plotTrajectoriesFile(filename, mode='2d', tracerfile=None, tracerfield='P',
         else:
             scat = ax.scatter(lon[b], lat[b], s=20, color='k')
         ttl = ax.set_title('Particles' + titlestr + ' at time ' + str(plottimes[0]))
-        frames = np.arange(1, len(plottimes))
+        frames = np.arange(0, len(plottimes))
 
         def animate(t):
             b = time == plottimes[t]


### PR DESCRIPTION
Fixing a bug where the first frame of an animation is not included in the animation.

This may also be why sometimes it appears that particles are not written at initial time (#458); they are written but simply not added to animation.