### PR TITLE
Mom model fixes

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1190,7 +1190,7 @@ class NetcdfFileBuffer(object):
         elif len(lon.shape) == 4:  # some lon, lat have a time and depth dimension 1
             lon_subset = np.array(lon[0, 0, self.indices['lat'], self.indices['lon']])
             lat_subset = np.array(lat[0, 0, self.indices['lat'], self.indices['lon']])
-         if len(lon.shape) > 1:  # Tests if lon, lat are rectilinear but were stored in arrays
+        if len(lon.shape) > 1:  # Tests if lon, lat are rectilinear but were stored in arrays
             rectilinear = True
             # test if all columns and rows are the same for lon and lat (in which case grid is rectilinear)
             for xi in range(1, lon_subset.shape[0]):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1191,9 +1191,18 @@ class NetcdfFileBuffer(object):
             lon_subset = np.array(lon[0, 0, self.indices['lat'], self.indices['lon']])
             lat_subset = np.array(lat[0, 0, self.indices['lat'], self.indices['lon']])
         if len(lon.shape) > 1:  # if lon, lat are rectilinear but were stored in arrays
-            xdim = lon_subset.shape[0]
-            ydim = lat_subset.shape[1]
-            if np.allclose(lon_subset[0, :], lon_subset[xdim-1, :]) and np.allclose(lat_subset[:, 0], lat_subset[:, ydim-1]):
+            rectilinear = True
+            # test if all columns and rows are the same for lon and lat (in which case grid is rectilinear)
+            for x in range(1, lon_subset.shape[0]):
+                if not np.allclose(lon_subset[0, :], lon_subset[x, :]):
+                    rectilinear = False
+                    break
+            if rectilinear:
+                for y in range(1, lat_subset.shape[1]):
+                    if not np.allclose(lat_subset[:, 0], lat_subset[:, y]):
+                        rectilinear = False
+                        break
+            if rectilinear:
                 lon_subset = lon_subset[0, :]
                 lat_subset = lat_subset[:, 0]
         return lon_subset, lat_subset

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1199,7 +1199,7 @@ class NetcdfFileBuffer(object):
                     break
             if rectilinear:
                 for yi in range(1, lat_subset.shape[1]):
-                    if not np.allclose(lat_subset[:, 0], lat_subset[:, y]):
+                    if not np.allclose(lat_subset[:, 0], lat_subset[:, yi]):
                         rectilinear = False
                         break
             if rectilinear:

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1198,7 +1198,7 @@ class NetcdfFileBuffer(object):
                     rectilinear = False
                     break
             if rectilinear:
-                for y in range(1, lat_subset.shape[1]):
+                for yi in range(1, lat_subset.shape[1]):
                     if not np.allclose(lat_subset[:, 0], lat_subset[:, y]):
                         rectilinear = False
                         break

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1194,7 +1194,7 @@ class NetcdfFileBuffer(object):
             rectilinear = True
             # test if all columns and rows are the same for lon and lat (in which case grid is rectilinear)
             for xi in range(1, lon_subset.shape[0]):
-                if not np.allclose(lon_subset[0, :], lon_subset[x, :]):
+                if not np.allclose(lon_subset[0, :], lon_subset[xi, :]):
                     rectilinear = False
                     break
             if rectilinear:

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1193,7 +1193,7 @@ class NetcdfFileBuffer(object):
          if len(lon.shape) > 1:  # Tests if lon, lat are rectilinear but were stored in arrays
             rectilinear = True
             # test if all columns and rows are the same for lon and lat (in which case grid is rectilinear)
-            for x in range(1, lon_subset.shape[0]):
+            for xi in range(1, lon_subset.shape[0]):
                 if not np.allclose(lon_subset[0, :], lon_subset[x, :]):
                     rectilinear = False
                     break

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1190,7 +1190,7 @@ class NetcdfFileBuffer(object):
         elif len(lon.shape) == 4:  # some lon, lat have a time and depth dimension 1
             lon_subset = np.array(lon[0, 0, self.indices['lat'], self.indices['lon']])
             lat_subset = np.array(lat[0, 0, self.indices['lat'], self.indices['lon']])
-        if len(lon.shape) > 1:  # if lon, lat are rectilinear but were stored in arrays
+         if len(lon.shape) > 1:  # Tests if lon, lat are rectilinear but were stored in arrays
             rectilinear = True
             # test if all columns and rows are the same for lon and lat (in which case grid is rectilinear)
             for x in range(1, lon_subset.shape[0]):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1193,7 +1193,7 @@ class NetcdfFileBuffer(object):
         if len(lon.shape) > 1:  # if lon, lat are rectilinear but were stored in arrays
             xdim = lon_subset.shape[0]
             ydim = lat_subset.shape[1]
-            if np.allclose(lon_subset[0, :], lon_subset[int(xdim/2), :]) and np.allclose(lat_subset[:, 0], lat_subset[:, int(ydim/2)]):
+            if np.allclose(lon_subset[0, :], lon_subset[xdim-1, :]) and np.allclose(lat_subset[:, 0], lat_subset[:, ydim-1]):
                 lon_subset = lon_subset[0, :]
                 lat_subset = lat_subset[:, 0]
         return lon_subset, lat_subset

--- a/parcels/scripts/plottrajectoriesfile.py
+++ b/parcels/scripts/plottrajectoriesfile.py
@@ -93,7 +93,10 @@ def plotTrajectoriesFile(filename, mode='2d', tracerfile=None, tracerfield='P',
         if isinstance(plottimes[0], (np.datetime64, np.timedelta64)):
             plottimes = plottimes[~np.isnat(plottimes)]
         else:
-            plottimes = plottimes[~np.isnan(plottimes)]
+            try:
+                plottimes = plottimes[~np.isnan(plottimes)]
+            except:
+                pass
         b = time == plottimes[0]
         if cartopy:
             scat = ax.scatter(lon[b], lat[b], s=20, color='k', transform=cartopy.crs.Geodetic())


### PR DESCRIPTION
Fixing two bugs in running on MOM6 with NOLEAP calendar (see also #456).
1) Since the curvilinear grid in MOM starts quite far northward, the test 
```if np.allclose(lon_subset[0, :], lon_subset[int(xdim/2), :]) and np.allclose(lat_subset[:, 0], lat_subset[:, int(ydim/2)])```
did not catch the grid as curvilinear. So changed this to 
```if np.allclose(lon_subset[0, :], lon_subset[xdim-1, :]) and np.allclose(lat_subset[:, 0], lat_subset[:, ydim-1])```
2) If ParticleFile is written as `NOLEAP` calendar, then creating an animation was not possible. 