### PR TITLE
Better support of parallel runs when spawning multiple .executes

### DIFF
--- a/parcels/compiler.py
+++ b/parcels/compiler.py
@@ -1,7 +1,11 @@
 import subprocess
-from os import path, getenv, makedirs
+from os import path, getenv
 from tempfile import gettempdir
 from struct import calcsize
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path  # python 2 backport
 try:
     from os import getuid
 except:
@@ -16,8 +20,7 @@ def get_package_dir():
 
 def get_cache_dir():
     directory = path.join(gettempdir(), "parcels-%s" % getuid())
-    if not path.exists(directory):
-        makedirs(directory)
+    Path(directory).mkdir(exist_ok=True)
     return directory
 
 


### PR DESCRIPTION
Until parallel execution is properly implemented in Parcels (see #17), one way that users can run multiple processes on a core is to simply spawn a number of `.execute()` statements, for example in a bash script.

However, the creation of the temporary directory in compiler.py can then go wrong, as all `.execute()` will create the same directory. While before this PR we used to check whether this temporary directory already existed, the slight lag time it takes to call `makedirs(directory)` sometimes meant that the directory was created while another process was creating it too. This caused an error.

To fix this, this PR uses the `exist_ok` argument to directory creation. Since that isn't default on python2, we use a solution suggested at
https://stackoverflow.com/questions/45283093/how-to-walk-around-exist-ok-missing-on-python-2-7