### PR TITLE
Removing netcdftime module

### DIFF
--- a/environment_py2_linux.yml
+++ b/environment_py2_linux.yml
@@ -23,7 +23,6 @@ dependencies:
   - scipy>=0.16.0
   - six >=1.10.0
   - xarray>=0.10.8
-  - netcdftime
   - cftime
   - pip:
       - pytest>=2.7.0

--- a/environment_py2_osx.yml
+++ b/environment_py2_osx.yml
@@ -23,7 +23,6 @@ dependencies:
   - scipy>=0.16.0
   - six>=1.10.0
   - xarray>=0.10.8
-  - netcdftime
   - cftime
   - pip:
       - pytest>=2.7.0

--- a/environment_py2_win.yml
+++ b/environment_py2_win.yml
@@ -22,7 +22,6 @@ dependencies:
   - scipy>=0.16.0
   - six>=1.10.0
   - xarray>=0.5.1
-  - netcdftime
   - cftime
   - pip:
       - pytest>=2.7.0

--- a/environment_py3_linux.yml
+++ b/environment_py3_linux.yml
@@ -22,7 +22,6 @@ dependencies:
   - scipy>=0.16.0
   - six >=1.10.0
   - xarray>=0.10.8
-  - netcdftime
   - cftime
   - pip:
       - pytest>=2.7.0

--- a/environment_py3_osx.yml
+++ b/environment_py3_osx.yml
@@ -22,7 +22,6 @@ dependencies:
   - scipy>=0.16.0
   - six>=1.10.0
   - xarray>=0.10.8
-  - netcdftime
   - cftime
   - pip:
       - pytest>=2.7.0

--- a/environment_py3_win.yml
+++ b/environment_py3_win.yml
@@ -21,7 +21,6 @@ dependencies:
   - scipy>=0.16.0
   - six>=1.10.0
   - xarray>=0.5.1
-  - netcdftime
   - cftime
   - ipykernel<5.0
   - pip:

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1003,14 +1003,14 @@ class VectorField(object):
         meshJac = (deg2m * deg2m * cos(rad * y)) if grid.mesh == 'spherical' else 1
         jac = self.jacobian(xsi, eta, px, py) * meshJac
 
-        u = ((-(1-eta) * U - (1-xsi) * V) * px[0] +
-             ((1-eta) * U - xsi * V) * px[1] +
-             (eta * U + xsi * V) * px[2] +
-             (-eta * U + (1-xsi) * V) * px[3]) / jac
-        v = ((-(1-eta) * U - (1-xsi) * V) * py[0] +
-             ((1-eta) * U - xsi * V) * py[1] +
-             (eta * U + xsi * V) * py[2] +
-             (-eta * U + (1-xsi) * V) * py[3]) / jac
+        u = ((-(1-eta) * U - (1-xsi) * V) * px[0]
+             + ((1-eta) * U - xsi * V) * px[1]
+             + (eta * U + xsi * V) * px[2]
+             + (-eta * U + (1-xsi) * V) * px[3]) / jac
+        v = ((-(1-eta) * U - (1-xsi) * V) * py[0]
+             + ((1-eta) * U - xsi * V) * py[1]
+             + (eta * U + xsi * V) * py[2]
+             + (-eta * U + (1-xsi) * V) * py[3]) / jac
         return (u, v)
 
     def spatial_c_grid_interpolation3D(self, ti, z, y, x, time):

--- a/parcels/scripts/get_examples.py
+++ b/parcels/scripts/get_examples.py
@@ -18,19 +18,19 @@ import sys
 
 example_data_files = (
     ["MovingEddies_data/" + fn for fn in [
-        "moving_eddiesP.nc", "moving_eddiesU.nc", "moving_eddiesV.nc"]] +
-    ["OFAM_example_data/" + fn for fn in [
-        "OFAM_simple_U.nc", "OFAM_simple_V.nc"]] +
-    ["Peninsula_data/" + fn for fn in [
-        "peninsulaU.nc", "peninsulaV.nc", "peninsulaP.nc"]] +
-    ["GlobCurrent_example_data/" + fn for fn in [
+        "moving_eddiesP.nc", "moving_eddiesU.nc", "moving_eddiesV.nc"]]
+    + ["OFAM_example_data/" + fn for fn in [
+        "OFAM_simple_U.nc", "OFAM_simple_V.nc"]]
+    + ["Peninsula_data/" + fn for fn in [
+        "peninsulaU.nc", "peninsulaV.nc", "peninsulaP.nc"]]
+    + ["GlobCurrent_example_data/" + fn for fn in [
         "%s000000-GLOBCURRENT-L4-CUReul_hs-ALT_SUM-v02.0-fv01.0.nc" % (
             date.strftime("%Y%m%d"))
         for date in [datetime(2002, 1, 1) + timedelta(days=x)
-                     for x in range(0, 365)]]] +
-    ["DecayingMovingEddy_data/" + fn for fn in [
-        "decaying_moving_eddyU.nc", "decaying_moving_eddyV.nc"]] +
-    ["NemoCurvilinear_data/" + fn for fn in [
+                     for x in range(0, 365)]]]
+    + ["DecayingMovingEddy_data/" + fn for fn in [
+        "decaying_moving_eddyU.nc", "decaying_moving_eddyV.nc"]]
+    + ["NemoCurvilinear_data/" + fn for fn in [
         "U_purely_zonal-ORCA025_grid_U.nc4", "V_purely_zonal-ORCA025_grid_V.nc4",
         "mesh_mask.nc4"]])
 

--- a/parcels/tools/converters.py
+++ b/parcels/tools/converters.py
@@ -19,8 +19,7 @@ class TimeConverter(object):
         self.time_origin = 0 if time_origin is None else time_origin
         if isinstance(time_origin, np.datetime64):
             self.calendar = "standard"
-        elif isinstance(time_origin, (cftime._cftime.DatetimeNoLeap,
-                                      netcdftime._netcdftime.DatetimeNoLeap)):
+        elif isinstance(time_origin, cftime._cftime.DatetimeNoLeap):
             self.calendar = "NOLEAP"
         else:
             self.calendar = None

--- a/parcels/tools/converters.py
+++ b/parcels/tools/converters.py
@@ -1,7 +1,6 @@
 from math import cos, pi
 import numpy as np
 import cftime
-import netcdftime
 from datetime import timedelta as delta
 
 __all__ = ['UnitConverter', 'Geographic', 'GeographicPolar', 'GeographicSquare',

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -274,12 +274,12 @@ def test_moving_eddy(fieldset_moving, mode, method, rtol, npart=1):
 
 
 def truth_decaying(x_0, y_0, t):
-    lat = y_0 - ((u_0 - u_g) * f / (f ** 2 + gamma ** 2) *
-                 (1 - np.exp(-gamma * t) * (np.cos(f * t) + gamma / f * np.sin(f * t))))
-    lon = x_0 + (u_g / gamma_g * (1 - np.exp(-gamma_g * t)) +
-                 (u_0 - u_g) * f / (f ** 2 + gamma ** 2) *
-                 (gamma / f + np.exp(-gamma * t) *
-                  (math.sin(f * t) - gamma / f * math.cos(f * t))))
+    lat = y_0 - ((u_0 - u_g) * f / (f ** 2 + gamma ** 2)
+                 * (1 - np.exp(-gamma * t) * (np.cos(f * t) + gamma / f * np.sin(f * t))))
+    lon = x_0 + (u_g / gamma_g * (1 - np.exp(-gamma_g * t))
+                 + (u_0 - u_g) * f / (f ** 2 + gamma ** 2)
+                 * (gamma / f + np.exp(-gamma * t)
+                    * (math.sin(f * t) - gamma / f * math.cos(f * t))))
     return lon, lat
 
 


### PR DESCRIPTION
Removing `netcdftime` module, which is deprecated and replaced by `cftime`. This fixes #481, as suggested by @aidanheerdegen

Note that we also changed flake8 PEP W504 error, where binary operators on multiple lines should be placed at beginning of line, rather than end (see https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator)