### PR TITLE
New C-grid tracer interpolation method

### DIFF
--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -15,7 +15,7 @@ extern "C" {
 
 typedef enum
   {
-    LINEAR=0, NEAREST=1, CGRID_LINEAR=2
+    LINEAR=0, NEAREST=1, CGRID_LINEAR=2, UNIFORM_VALUE=3,
   } InterpCode;
 
 typedef struct
@@ -55,6 +55,19 @@ static inline ErrorCode spatial_interpolation_trilinear(double xsi, double eta, 
   return SUCCESS;
 }
 
+/* uniform_value interpolation routine for 2D grid */
+static inline ErrorCode spatial_interpolation_uniformvalue2D(int xi, int yi, int xdim, 
+                                                        float **f_data, float *value)
+{
+  /* Cast data array into data[lat][lon] as per NEMO convention */
+  float (*data)[xdim] = (float (*)[xdim]) f_data;
+  int ii, jj;
+  ii = xi+1; 
+  jj = yi+1;
+  *value = data[jj][ii];
+  return SUCCESS;
+}
+
 /* Nearest neighbour interpolation routine for 2D grid */
 static inline ErrorCode spatial_interpolation_nearest2D(double xsi, double eta, int xi, int yi, int xdim,
                                                         float **f_data, float *value)
@@ -81,6 +94,19 @@ static inline ErrorCode spatial_interpolation_nearest3D(double xsi, double eta, 
   return SUCCESS;
 }
 
+/* uniform_value interpolation routine for 3D grid */
+static inline ErrorCode spatial_interpolation_uniformvalue3D(int xi, int yi, int zi,
+                                                        int xdim, int ydim, float **f_data, float *value)
+{
+  float (*data)[ydim][xdim] = (float (*)[ydim][xdim]) f_data;
+  int ii, jj, kk;
+  ii = xi+1;
+  jj = yi+1;
+  kk = zi+1;
+  *value = data[kk][jj][ii];
+  return SUCCESS;
+}
+
 /* Linear interpolation along the time axis */
 static inline ErrorCode temporal_interpolation_structured_grid(float x, float y, float z, double time, CField *f, 
                                                                GridCode gcode, int *xi, int *yi, int *zi, int *ti,
@@ -94,7 +120,7 @@ static inline ErrorCode temporal_interpolation_structured_grid(float x, float y,
   if (f->time_periodic == 0 && f->allow_time_extrapolation == 0 && (time < grid->time[0] || time > grid->time[grid->tdim-1])){
     return ERROR_TIME_EXTRAPOLATION;
   }
-  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], f->time_periodic);
+  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], f->time_periodic); CHECKERROR(err);
 
   /* Cast data array intp data[time][depth][lat][lon] as per NEMO convention */
   float (*data)[f->zdim][f->ydim][f->xdim] = (float (*)[f->zdim][f->ydim][f->xdim]) f->data;
@@ -113,21 +139,35 @@ static inline ErrorCode temporal_interpolation_structured_grid(float x, float y,
     }
     if (interp_method == LINEAR){
       if (grid->zdim==1){
-        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0);
-        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1);
+        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
+        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
       } else {
-        err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]]), &f0);
-        err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]+1]), &f1);
+        err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
+        err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
       }
     }
     else if  (interp_method == NEAREST){
       if (grid->zdim==1){
-        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0);
-        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1);
+        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
+        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
       } else {
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
-                                              (float**)(data[ti[igrid]]), &f0);
+                                              (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
+                                              (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
+      }
+    }
+	else if  (interp_method == UNIFORM_VALUE){
+      if (grid->zdim==1){
+        err = spatial_interpolation_uniformvalue2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0);
+        err = spatial_interpolation_uniformvalue2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1);
+      } else {
+		    int main() {
+				return 0;
+			}
+        err = spatial_interpolation_uniformvalue3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
+                                              (float**)(data[ti[igrid]]), &f0);
+        err = spatial_interpolation_uniformvalue3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                               (float**)(data[ti[igrid]+1]), &f1);
       }
     }
@@ -145,17 +185,30 @@ static inline ErrorCode temporal_interpolation_structured_grid(float x, float y,
       interp_method = LINEAR;
     }
     if (interp_method == LINEAR){
-      if (grid->zdim==1)
-        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value);
-      else
+      if (grid->zdim==1){
+        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value); CHECKERROR(err);
+      }
+      else{
         err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
-                                             (float**)(data[ti[igrid]]), value);
+                                             (float**)(data[ti[igrid]]), value); CHECKERROR(err);
+      }
     }
     else if (interp_method == NEAREST){
-      if (grid->zdim==1)
-        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value);
+      if (grid->zdim==1){
+        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value); CHECKERROR(err);
+      }
       else {
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
+                                             (float**)(data[ti[igrid]]), value); CHECKERROR(err);
+      }
+    }
+	else if (interp_method == UNIFORM_VALUE){
+		
+      if (grid->zdim==1){
+        err = spatial_interpolation_uniformvalue2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value);
+	  }
+	  else {
+        err = spatial_interpolation_uniformvalue3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                              (float**)(data[ti[igrid]]), value);
       }
     }
@@ -275,7 +328,7 @@ static inline ErrorCode temporal_interpolation_UV_c_grid(float x, float y, float
   if (U->time_periodic == 0 && U->allow_time_extrapolation == 0 && (time < grid->time[0] || time > grid->time[grid->tdim-1])){
     return ERROR_TIME_EXTRAPOLATION;
   }
-  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic);
+  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic); CHECKERROR(err);
 
   /* Cast data array intp data[time][depth][lat][lon] as per NEMO convention */
   float (*dataU)[U->zdim][U->ydim][U->xdim] = (float (*)[U->zdim][U->ydim][U->xdim]) U->data;
@@ -289,11 +342,11 @@ static inline ErrorCode temporal_interpolation_UV_c_grid(float x, float y, float
     /* Identify grid cell to sample through local linear search */
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], time, t0, t1); CHECKERROR(err);
     if (grid->zdim==1){
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]])  , (float**)(dataV[ti[igrid]]),   &u0, &v0);
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1]), (float**)(dataV[ti[igrid]+1]), &u1, &v1);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]])  , (float**)(dataV[ti[igrid]]),   &u0, &v0); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1]), (float**)(dataV[ti[igrid]+1]), &u1, &v1); CHECKERROR(err);
     } else {
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]),   &u0, &v0);
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1][zi[igrid]]), (float**)(dataV[ti[igrid]+1][zi[igrid]]), &u1, &v1);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]),   &u0, &v0); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1][zi[igrid]]), (float**)(dataV[ti[igrid]+1][zi[igrid]]), &u1, &v1); CHECKERROR(err);
     }
     *u = u0 + (u1 - u0) * (float)((time - t0) / (t1 - t0));
     *v = v0 + (v1 - v0) * (float)((time - t0) / (t1 - t0));
@@ -302,10 +355,10 @@ static inline ErrorCode temporal_interpolation_UV_c_grid(float x, float y, float
     double t0 = grid->time[ti[igrid]];
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], t0, t0, t0+1); CHECKERROR(err);
     if (grid->zdim==1){
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]]), u, v);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]]), u, v); CHECKERROR(err);
     }
     else{
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]), u, v);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]), u, v); CHECKERROR(err);
     }
     return SUCCESS;
   }


### PR DESCRIPTION
Increasing the accuracy of the C-grid Tracer interpolation. We suggest a new interpolation method called uniform_value, written for both 2D and 3D fields. 

This new interpolation method assigns the tracer value of the gridcell the particle is in to the particle. Everywhere in the cell, the particle will be assigned the same tracer value. This is an improvement for particles located in a C-grid like the NEMO fields, which are currently interpolated with nearest neighbour interpolation.

Written by Anne Kruijt and Isolde Glissenaar