### PR TITLE
Limiting pytest to versions < 4.0

### DIFF
--- a/environment_py2_linux.yml
+++ b/environment_py2_linux.yml
@@ -26,5 +26,5 @@ dependencies:
   - dask
   - cftime
   - pip:
-      - pytest>=2.7.0
+      - pytest<4.0
       - nbval

--- a/environment_py2_osx.yml
+++ b/environment_py2_osx.yml
@@ -26,5 +26,5 @@ dependencies:
   - dask
   - cftime
   - pip:
-      - pytest>=2.7.0
+      - pytest<4.0
       - nbval

--- a/environment_py2_win.yml
+++ b/environment_py2_win.yml
@@ -25,5 +25,5 @@ dependencies:
   - dask
   - cftime
   - pip:
-      - pytest>=2.7.0
+      - pytest<4.0
       - nbval

--- a/environment_py3_linux.yml
+++ b/environment_py3_linux.yml
@@ -25,5 +25,5 @@ dependencies:
   - cftime
   - dask
   - pip:
-      - pytest>=2.7.0
+      - pytest<4.0
       - nbval

--- a/environment_py3_osx.yml
+++ b/environment_py3_osx.yml
@@ -25,5 +25,5 @@ dependencies:
   - dask
   - cftime
   - pip:
-      - pytest>=2.7.0
+      - pytest<4.0
       - nbval

--- a/environment_py3_win.yml
+++ b/environment_py3_win.yml
@@ -25,5 +25,5 @@ dependencies:
   - cftime
   - ipykernel<5.0
   - pip:
-      - pytest>=2.7.0
+      - pytest<4.0
       - nbval


### PR DESCRIPTION
With pytest v4, we would need to rewrite our entire test suite, as fixtures can’t be function anymore. See also e.g. https://github.com/pytest-dev/pytest/issues/3950

For now therefore limiting pytest versions to <4.0