### PR TITLE
[in parcels-repo] New C-grid tracer interpolation method

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -721,7 +721,7 @@ class KernelGenerator(ast.NodeVisitor):
         ccode_eval = node.field.obj.ccode_eval(node.var, node.var2, node.var3,
                                                node.field.obj.U, node.field.obj.V, node.field.obj.W,
                                                *node.args.ccode)
-        if node.field.obj.U.interp_method != 'cgrid_linear':
+        if node.field.obj.U.interp_method != 'cgrid_velocity':
             ccode_conv1 = node.field.obj.U.ccode_convert(*node.args.ccode)
             ccode_conv2 = node.field.obj.V.ccode_convert(*node.args.ccode)
             statements = [c.Statement("%s *= %s" % (node.var, ccode_conv1)),
@@ -790,7 +790,7 @@ class KernelGenerator(ast.NodeVisitor):
             ccode_eval = fld.ccode_eval(node.var, node.var2, node.var3,
                                         fld.U, fld.V, fld.W,
                                         *node.args.ccode)
-            if fld.U.interp_method != 'cgrid_linear':
+            if fld.U.interp_method != 'cgrid_velocity':
                 ccode_conv1 = fld.U.ccode_convert(*node.args.ccode)
                 ccode_conv2 = fld.V.ccode_convert(*node.args.ccode)
                 statements = [c.Statement("%s *= %s" % (node.var, ccode_conv1)),

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -622,7 +622,7 @@ class Field(object):
                 xsi*eta * self.data[ti, yi+1, xi+1] + \
                 (1-xsi)*eta * self.data[ti, yi+1, xi]
             return val
-        elif self.interp_method is  'uniform_value':
+        elif self.interp_method is 'cgrid_tracer':
             xii = xi+1
             yii = yi+1
             return self.data[ti, yii, xii]
@@ -655,7 +655,7 @@ class Field(object):
                 xsi*eta * data[yi+1, xi+1] + \
                 (1-xsi)*eta * data[yi+1, xi]
             return (1-zeta) * f0 + zeta * f1
-        elif self.interp_method is 'uniform_value':
+        elif self.interp_method is 'cgrid_tracer':
             xii = xi+1
             yii = yi+1
             zii = zi+1

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -622,10 +622,8 @@ class Field(object):
                 xsi*eta * self.data[ti, yi+1, xi+1] + \
                 (1-xsi)*eta * self.data[ti, yi+1, xi]
             return val
-        elif self.interp_method is 'cgrid_tracer':
-            xii = xi+1
-            yii = yi+1
-            return self.data[ti, yii, xii]
+        elif self.interp_method is 'cgrid_velocity':
+            return self.data[ti, yi+1, xi+1]
         else:
             raise RuntimeError(self.interp_method+" is not implemented for 2D grids")
 
@@ -638,7 +636,7 @@ class Field(object):
             yii = yi if eta <= .5 else yi+1
             zii = zi if zeta <= .5 else zi+1
             return self.data[ti, zii, yii, xii]
-        elif self.interp_method is 'cgrid_linear':
+        elif self.interp_method is 'cgrid_velocity':
             # evaluating W velocity in c_grid
             f0 = self.data[ti, zi, yi, xi]
             f1 = self.data[ti, zi+1, yi, xi]
@@ -656,10 +654,7 @@ class Field(object):
                 (1-xsi)*eta * data[yi+1, xi]
             return (1-zeta) * f0 + zeta * f1
         elif self.interp_method is 'cgrid_tracer':
-            xii = xi+1
-            yii = yi+1
-            zii = zi+1
-            return self.data[ti, zii, yii, xii]
+            return self.data[ti, zi+1, yi+1, xi+1]
         else:
             raise RuntimeError(self.interp_method+" is not implemented for 3D grids")
 
@@ -964,11 +959,11 @@ class VectorField(object):
         self.U = U
         self.V = V
         self.W = W
-        if self.U.interp_method == 'cgrid_linear':
-            assert self.V.interp_method == 'cgrid_linear'
+        if self.U.interp_method == 'cgrid_velocity':
+            assert self.V.interp_method == 'cgrid_velocity'
             assert self.U.grid is self.V.grid
             if W:
-                assert self.W.interp_method == 'cgrid_linear'
+                assert self.W.interp_method == 'cgrid_velocity'
 
     def dist(self, lon1, lon2, lat1, lat2, mesh):
         if mesh == 'spherical':
@@ -1065,7 +1060,7 @@ class VectorField(object):
         return (u, v, w)
 
     def eval(self, time, x, y, z):
-        if self.U.interp_method != 'cgrid_linear':
+        if self.U.interp_method != 'cgrid_velocity':
             u = self.U.eval(time, x, y, z, False)
             v = self.V.eval(time, x, y, z, False)
             u = self.U.units.to_target(u, x, y, z)

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -622,7 +622,7 @@ class Field(object):
                 xsi*eta * self.data[ti, yi+1, xi+1] + \
                 (1-xsi)*eta * self.data[ti, yi+1, xi]
             return val
-        elif self.interp_method is 'cgrid_velocity':
+        elif self.interp_method is 'cgrid_tracer':
             return self.data[ti, yi+1, xi+1]
         else:
             raise RuntimeError(self.interp_method+" is not implemented for 2D grids")

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -623,9 +623,9 @@ class Field(object):
                 (1-xsi)*eta * self.data[ti, yi+1, xi]
             return val
         elif self.interp_method is  'uniform_value':
-			xii = xi+1
-			yii = yi+1
-			return self.data[ti, yii, xii]
+            xii = xi+1
+            yii = yi+1
+            return self.data[ti, yii, xii]
         else:
             raise RuntimeError(self.interp_method+" is not implemented for 2D grids")
 
@@ -656,10 +656,10 @@ class Field(object):
                 (1-xsi)*eta * data[yi+1, xi]
             return (1-zeta) * f0 + zeta * f1
         elif self.interp_method is 'uniform_value':
-			xii = xi+1
-			yii = yi+1
-			zii = zi+1
-			return self.data[ti, zii, yii, xii]
+            xii = xi+1
+            yii = yi+1
+            zii = zi+1
+            return self.data[ti, zii, yii, xii]
         else:
             raise RuntimeError(self.interp_method+" is not implemented for 3D grids")
 

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -291,8 +291,8 @@ class FieldSet(object):
                Default is False if dimensions includes time, else True
         :param time_periodic: boolean whether to loop periodically over the time component of the FieldSet
                This flag overrides the allow_time_interpolation and sets it to False
-        :param tracer_interp_method: Method for interpolation of tracer fields. Either 'linear' or 'nearest'
-               Note that in the case of from_nemo(), the velocity fields are default to 'cgrid_linear'
+        :param tracer_interp_method: Method for interpolation of tracer fields. It is recommended to use 'cgrid_tracer' (default)
+               Note that in the case of from_nemo(), the velocity fields are default to 'cgrid_velocity'
 
         """
 
@@ -302,7 +302,7 @@ class FieldSet(object):
         interp_method = {}
         for v in variables:
             if v in ['U', 'V', 'W']:
-                interp_method[v] = 'cgrid_linear'
+                interp_method[v] = 'cgrid_velocity'
             else:
                 interp_method[v] = tracer_interp_method
 

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -251,7 +251,7 @@ class FieldSet(object):
     @classmethod
     def from_nemo(cls, filenames, variables, dimensions, indices=None, mesh='spherical',
                   allow_time_extrapolation=None, time_periodic=False,
-                  tracer_interp_method='uniform_value', **kwargs):
+                  tracer_interp_method='cgrid_tracer', **kwargs):
         """Initialises FieldSet object from NetCDF files of Curvilinear NEMO fields.
 
         :param filenames: Dictionary mapping variables to file(s). The

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -15,7 +15,7 @@ extern "C" {
 
 typedef enum
   {
-    LINEAR=0, NEAREST=1, CGRID_LINEAR=2
+    LINEAR=0, NEAREST=1, CGRID_LINEAR=2, UNIFORM_VALUE=3,
   } InterpCode;
 
 typedef struct
@@ -55,6 +55,19 @@ static inline ErrorCode spatial_interpolation_trilinear(double xsi, double eta, 
   return SUCCESS;
 }
 
+/* uniform_value interpolation routine for 2D grid */
+static inline ErrorCode spatial_interpolation_uniformvalue2D(int xi, int yi, int xdim, 
+                                                        float **f_data, float *value)
+{
+  /* Cast data array into data[lat][lon] as per NEMO convention */
+  float (*data)[xdim] = (float (*)[xdim]) f_data;
+  int ii, jj;
+  ii = xi+1; 
+  jj = yi+1;
+  *value = data[jj][ii];
+  return SUCCESS;
+}
+
 /* Nearest neighbour interpolation routine for 2D grid */
 static inline ErrorCode spatial_interpolation_nearest2D(double xsi, double eta, int xi, int yi, int xdim,
                                                         float **f_data, float *value)
@@ -81,6 +94,19 @@ static inline ErrorCode spatial_interpolation_nearest3D(double xsi, double eta, 
   return SUCCESS;
 }
 
+/* uniform_value interpolation routine for 3D grid */
+static inline ErrorCode spatial_interpolation_uniformvalue3D(int xi, int yi, int zi,
+                                                        int xdim, int ydim, float **f_data, float *value)
+{
+  float (*data)[ydim][xdim] = (float (*)[ydim][xdim]) f_data;
+  int ii, jj, kk;
+  ii = xi+1;
+  jj = yi+1;
+  kk = zi+1;
+  *value = data[kk][jj][ii];
+  return SUCCESS;
+}
+
 /* Linear interpolation along the time axis */
 static inline ErrorCode temporal_interpolation_structured_grid(float x, float y, float z, double time, CField *f, 
                                                                GridCode gcode, int *xi, int *yi, int *zi, int *ti,
@@ -94,7 +120,7 @@ static inline ErrorCode temporal_interpolation_structured_grid(float x, float y,
   if (f->time_periodic == 0 && f->allow_time_extrapolation == 0 && (time < grid->time[0] || time > grid->time[grid->tdim-1])){
     return ERROR_TIME_EXTRAPOLATION;
   }
-  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], f->time_periodic);
+  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], f->time_periodic); CHECKERROR(err);
 
   /* Cast data array intp data[time][depth][lat][lon] as per NEMO convention */
   float (*data)[f->zdim][f->ydim][f->xdim] = (float (*)[f->zdim][f->ydim][f->xdim]) f->data;
@@ -113,21 +139,35 @@ static inline ErrorCode temporal_interpolation_structured_grid(float x, float y,
     }
     if (interp_method == LINEAR){
       if (grid->zdim==1){
-        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0);
-        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1);
+        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
+        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
       } else {
-        err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]]), &f0);
-        err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]+1]), &f1);
+        err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
+        err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
       }
     }
     else if  (interp_method == NEAREST){
       if (grid->zdim==1){
-        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0);
-        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1);
+        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
+        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
       } else {
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
-                                              (float**)(data[ti[igrid]]), &f0);
+                                              (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
+                                              (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
+      }
+    }
+	else if  (interp_method == UNIFORM_VALUE){
+      if (grid->zdim==1){
+        err = spatial_interpolation_uniformvalue2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0);
+        err = spatial_interpolation_uniformvalue2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1);
+      } else {
+		    int main() {
+				return 0;
+			}
+        err = spatial_interpolation_uniformvalue3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
+                                              (float**)(data[ti[igrid]]), &f0);
+        err = spatial_interpolation_uniformvalue3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                               (float**)(data[ti[igrid]+1]), &f1);
       }
     }
@@ -145,17 +185,30 @@ static inline ErrorCode temporal_interpolation_structured_grid(float x, float y,
       interp_method = LINEAR;
     }
     if (interp_method == LINEAR){
-      if (grid->zdim==1)
-        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value);
-      else
+      if (grid->zdim==1){
+        err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value); CHECKERROR(err);
+      }
+      else{
         err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
-                                             (float**)(data[ti[igrid]]), value);
+                                             (float**)(data[ti[igrid]]), value); CHECKERROR(err);
+      }
     }
     else if (interp_method == NEAREST){
-      if (grid->zdim==1)
-        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value);
+      if (grid->zdim==1){
+        err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value); CHECKERROR(err);
+      }
       else {
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
+                                             (float**)(data[ti[igrid]]), value); CHECKERROR(err);
+      }
+    }
+	else if (interp_method == UNIFORM_VALUE){
+		
+      if (grid->zdim==1){
+        err = spatial_interpolation_uniformvalue2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value);
+	  }
+	  else {
+        err = spatial_interpolation_uniformvalue3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                              (float**)(data[ti[igrid]]), value);
       }
     }
@@ -275,7 +328,7 @@ static inline ErrorCode temporal_interpolation_UV_c_grid(float x, float y, float
   if (U->time_periodic == 0 && U->allow_time_extrapolation == 0 && (time < grid->time[0] || time > grid->time[grid->tdim-1])){
     return ERROR_TIME_EXTRAPOLATION;
   }
-  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic);
+  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic); CHECKERROR(err);
 
   /* Cast data array intp data[time][depth][lat][lon] as per NEMO convention */
   float (*dataU)[U->zdim][U->ydim][U->xdim] = (float (*)[U->zdim][U->ydim][U->xdim]) U->data;
@@ -289,11 +342,11 @@ static inline ErrorCode temporal_interpolation_UV_c_grid(float x, float y, float
     /* Identify grid cell to sample through local linear search */
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], time, t0, t1); CHECKERROR(err);
     if (grid->zdim==1){
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]])  , (float**)(dataV[ti[igrid]]),   &u0, &v0);
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1]), (float**)(dataV[ti[igrid]+1]), &u1, &v1);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]])  , (float**)(dataV[ti[igrid]]),   &u0, &v0); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1]), (float**)(dataV[ti[igrid]+1]), &u1, &v1); CHECKERROR(err);
     } else {
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]),   &u0, &v0);
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1][zi[igrid]]), (float**)(dataV[ti[igrid]+1][zi[igrid]]), &u1, &v1);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]),   &u0, &v0); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1][zi[igrid]]), (float**)(dataV[ti[igrid]+1][zi[igrid]]), &u1, &v1); CHECKERROR(err);
     }
     *u = u0 + (u1 - u0) * (float)((time - t0) / (t1 - t0));
     *v = v0 + (v1 - v0) * (float)((time - t0) / (t1 - t0));
@@ -302,10 +355,10 @@ static inline ErrorCode temporal_interpolation_UV_c_grid(float x, float y, float
     double t0 = grid->time[ti[igrid]];
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], t0, t0, t0+1); CHECKERROR(err);
     if (grid->zdim==1){
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]]), u, v);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]]), u, v); CHECKERROR(err);
     }
     else{
-      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]), u, v);
+      err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]), u, v); CHECKERROR(err);
     }
     return SUCCESS;
   }

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -162,9 +162,6 @@ static inline ErrorCode temporal_interpolation_structured_grid(float x, float y,
         err = spatial_interpolation_uniformvalue2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0);
         err = spatial_interpolation_uniformvalue2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1);
       } else {
-		    int main() {
-				return 0;
-			}
         err = spatial_interpolation_uniformvalue3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                               (float**)(data[ti[igrid]]), &f0);
         err = spatial_interpolation_uniformvalue3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -15,7 +15,7 @@ extern "C" {
 
 typedef enum
   {
-    LINEAR=0, NEAREST=1, CGRID_LINEAR=2, CGRID_TRACER=3,
+    LINEAR=0, NEAREST=1, CGRID_VELOCITY=2, CGRID_TRACER=3,
   } InterpCode;
 
 typedef struct
@@ -369,7 +369,7 @@ static inline ErrorCode temporal_interpolationUV(float x, float y, float z, doub
                                                  float *valueU, float *valueV, int interp_method)
 {
   ErrorCode err;
-  if (interp_method == CGRID_LINEAR){
+  if (interp_method == CGRID_VELOCITY){
     CGrid *_grid = U->grid;
     GridCode gcode = _grid->gtype;
     int *xi = (int *) vxi;
@@ -392,7 +392,7 @@ static inline ErrorCode temporal_interpolationUVW(float x, float y, float z, dou
                                                   float *valueU, float *valueV, float *valueW, int interp_method)
 {
   ErrorCode err;
-  if (interp_method == CGRID_LINEAR){
+  if (interp_method == CGRID_VELOCITY){
     CGrid *_grid = U->grid;
     GridCode gcode = _grid->gtype;
     if (gcode == RECTILINEAR_S_GRID || gcode == CURVILINEAR_S_GRID){


### PR DESCRIPTION
(this is a PR on the parcels repo of the one at #491; text of that PR below)

Increasing the accuracy of the C-grid Tracer interpolation. We suggest a new interpolation method called uniform_value, written for both 2D and 3D fields.

This new interpolation method assigns the tracer value of the gridcell the particle is in to the particle. Everywhere in the cell, the particle will be assigned the same tracer value. This is an improvement for particles located in a C-grid like the NEMO fields, which are currently interpolated with nearest neighbour interpolation.

Written by Anne Kruijt and Isolde Glissenaar