### PR TITLE
Fixing bug in advancetime due to new TimeConverter class

### DIFF
--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -114,7 +114,7 @@ class Grid(object):
     def advancetime(self, grid_new):
         assert isinstance(grid_new.time_origin, type(self.time_origin)), 'time_origin of new and old grids must be either both None or both a date'
         if self.time_origin:
-            grid_new.time = grid_new.time + (grid_new.time_origin - self.time_origin) / np.timedelta64(1, 's')
+            grid_new.time = grid_new.time + self.time_origin.reltime(grid_new.time_origin)
         if len(grid_new.time) is not 1:
             raise RuntimeError('New FieldSet needs to have only one snapshot')
         if grid_new.time > self.time[-1]:  # forward in time, so appending at end


### PR DESCRIPTION
Although the `advancetime()` method is depreciated, it is still part of Parcels and hence needs to at least work as expected. This PR fixes a bug that was introduced when we started using the `TimeConverter` class (#456) 