### PR TITLE
Appveyor python3 timeout issue

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,14 @@ environment:
       PYTHON_ARCH: "64"
       ENV_NAME: "environment_py2_win.yml"
 
-    allow_failures:
     - PYTHON: "C:\\Python36-miniconda"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       ENV_NAME: "environment_py3_win.yml"
+
+matrix:
+  allow_failures:
+    - PYTHON_VERSION: "3.6.x"
 
 install:
   - "powershell ./appveyor/install_miniconda.ps1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,12 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
       ENV_NAME: "environment_py2_win.yml"
+
     allow_failures:
-      - PYTHON: "C:\\Python36-miniconda"
-        PYTHON_VERSION: "3.6.x"
-        PYTHON_ARCH: "64"
-        ENV_NAME: "environment_py3_win.yml"
+    - PYTHON: "C:\\Python36-miniconda"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
+      ENV_NAME: "environment_py3_win.yml"
 
 install:
   - "powershell ./appveyor/install_miniconda.ps1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,11 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
       ENV_NAME: "environment_py2_win.yml"
-
-    - PYTHON: "C:\\Python36-miniconda"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_ARCH: "64"
-      ENV_NAME: "environment_py3_win.yml"
+    allow_failures:
+      - PYTHON: "C:\\Python36-miniconda"
+        PYTHON_VERSION: "3.6.x"
+        PYTHON_ARCH: "64"
+        ENV_NAME: "environment_py3_win.yml"
 
 install:
   - "powershell ./appveyor/install_miniconda.ps1"


### PR DESCRIPTION
Python3 on appveyor CI has been very slow for a while now, mostly on the ofam_example (perhaps because of xarray issues?). This PR allows for the python 3 version to fail, meaning that the overall testing passes again