### PR TITLE
Pinning netcdf4 version to max 1.4.1

### DIFF
--- a/environment_py2_linux.yml
+++ b/environment_py2_linux.yml
@@ -14,7 +14,7 @@ dependencies:
   - git
   - jupyter
   - matplotlib>=2.0.2
-  - netcdf4>=1.1.9
+  - netcdf4>=1.1.9,<=1.4.1
   - numpy>=1.9.1
   - progressbar2
   - py>=1.4.27

--- a/environment_py2_osx.yml
+++ b/environment_py2_osx.yml
@@ -14,7 +14,7 @@ dependencies:
   - git
   - jupyter
   - matplotlib>=2.0.2
-  - netcdf4>=1.1.9
+  - netcdf4>=1.1.9,<=1.4.1
   - numpy>=1.9.1
   - progressbar2
   - py>=1.4.27

--- a/environment_py2_win.yml
+++ b/environment_py2_win.yml
@@ -13,7 +13,7 @@ dependencies:
   - jupyter
   - m2w64-toolchain
   - matplotlib>=2.0.2
-  - netcdf4>=1.1.9
+  - netcdf4>=1.1.9,<=1.4.1
   - numpy>=1.9.1
   - progressbar2
   - py>=1.4.27

--- a/environment_py3_linux.yml
+++ b/environment_py3_linux.yml
@@ -13,7 +13,7 @@ dependencies:
   - git
   - jupyter
   - matplotlib>=2.0.2
-  - netcdf4>=1.1.9
+  - netcdf4>=1.1.9,<=1.4.1
   - numpy>=1.9.1
   - progressbar2
   - py>=1.4.27

--- a/environment_py3_osx.yml
+++ b/environment_py3_osx.yml
@@ -13,7 +13,7 @@ dependencies:
   - git
   - jupyter
   - matplotlib>=2.0.2
-  - netcdf4>=1.1.9
+  - netcdf4>=1.1.9,<=1.4.1
   - numpy>=1.9.1
   - progressbar2
   - py>=1.4.27

--- a/environment_py3_win.yml
+++ b/environment_py3_win.yml
@@ -12,7 +12,7 @@ dependencies:
   - jupyter
   - m2w64-toolchain
   - matplotlib>=2.0.2
-  - netcdf4>=1.1.9
+  - netcdf4>=1.1.9,<=1.4.1
   - numpy>=1.9.1
   - progressbar2
   - py>=1.4.27


### PR DESCRIPTION
This PR pins `netCDF4` to version 1.4.1, since parcels seems very slow for netcdf4 version 1.4.2 (only in python3, though). See also #504 