### PR TITLE
[Do not merge!] This shows a way out of the performance issues with netcdf4=1.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
         sh -e /etc/init.d/xvfb start;
         sleep 3;
       fi
-    - py.test -v -s tests/
+    - py.test -v -s --durations=0 tests/
     - |
       # only get examples on linux
       if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
@@ -51,5 +51,5 @@ script:
     - |
       # evaluate example scripts and notebooks on linux only
       if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
-        py.test -v -s --nbval-lax examples/;
+        py.test -v -s --nbval-lax --durations=0 examples/;
       fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,6 @@ install:
 build: false
 
 test_script:
-  - "py.test -v -s tests/"
+  - "py.test -v -s --durations=0 tests/"
   - "parcels_get_examples examples/"
-  - "py.test -v -s --nbval-lax examples/"
+  - "py.test -v -s --nbval-lax --durations=0 examples/"

--- a/environment_py3_linux.yml
+++ b/environment_py3_linux.yml
@@ -13,7 +13,7 @@ dependencies:
   - git
   - jupyter
   - matplotlib>=2.0.2
-  - netcdf4>=1.1.9,<=1.4.1
+  - netcdf4>=1.1.9
   - numpy>=1.9.1
   - progressbar2
   - py>=1.4.27

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1334,10 +1334,10 @@ class NetcdfFileBuffer(object):
         for inds in self.indices.values():
             if type(inds) not in [list, range]:
                 raise RuntimeError('Indices for field subsetting need to be a list')
-        try:
-            self.dataset.set_auto_mask(False)
-        except:
-            pass
+        # try:
+        #     self.dataset.set_auto_mask(False)
+        # except:
+        #     pass
         return self
 
     def __exit__(self, type, value, traceback):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1334,6 +1334,10 @@ class NetcdfFileBuffer(object):
         for inds in self.indices.values():
             if type(inds) not in [list, range]:
                 raise RuntimeError('Indices for field subsetting need to be a list')
+        try:
+            self.dataset.set_auto_mask(False)
+        except:
+            pass
         return self
 
     def __exit__(self, type, value, traceback):


### PR DESCRIPTION
Changes 

- Set automasking of netCDF data to False.
- Unpin netCDF4 max version again
- Measrure timing of pytests (which might help with diagnosing similar issues in the future)

Note that my change in 

https://github.com/OceanParcels/parcels/commit/378c5ee5437a6e0aa71d6b3ee75ec9adbb4332e6#diff-a68ef84b67d3b404f48daf2ccc3ca441R1337

is a relatively dirty hack.  So please don't just merge this. :)