### PR TITLE
Multiple variable declaration warning fix

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -383,7 +383,8 @@ class KernelGenerator(ast.NodeVisitor):
         funcvars_copy = copy(funcvars)  # editing a list while looping over it is dangerous
         for kvar in funcvars:
             if kvar in used_vars:
-                logger.warning(kvar+" declared in multiple Kernels")
+                if kvar not in ['particle', 'fieldset', 'time']:
+                    logger.warning(kvar+" declared in multiple Kernels")
                 funcvars_copy.remove(kvar)
             else:
                 used_vars.append(kvar)


### PR DESCRIPTION
Issue warning that variable declared in multiple kernels only for variables other than `['particle', 'fieldset', 'time']`. Since these variables are always declared for each kernel, it’s obvious that they are multiply-declared so the warning is somewhat pointless for these variables