### PR TITLE
Fix bug initialising Variable with field when particle.time is None

### DIFF
--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -123,11 +123,10 @@ class _Particle(object):
                 lat = self.getInitialValue(ptype, name='lat')
                 depth = self.getInitialValue(ptype, name='depth')
                 time = self.getInitialValue(ptype, name='time')
-                v.initial.fieldset.computeTimeChunk(time, 1)
                 if time is None:
-                    logger.error('Cannot initialise a Variable with a Field if no time provided. '
-                                 'Add a "time=" to ParticleSet construction')
-                    exit(-1)
+                    raise RuntimeError('Cannot initialise a Variable with a Field if no time provided. '
+                                       'Add a "time=" to ParticleSet construction')
+                v.initial.fieldset.computeTimeChunk(time, 1)
                 initial = v.initial[time, depth, lat, lon]
             else:
                 initial = v.initial

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -1,6 +1,5 @@
 from parcels.tools.error import ErrorCode
 from parcels.field import Field
-from parcels.tools.loggers import logger
 from operator import attrgetter
 import numpy as np
 from ctypes import c_void_p


### PR DESCRIPTION
Fixing a bug in the error message when `particle.time` is `None` and `Variable` is initialised with `Field`. Previously, checking if time is None was done _after_ `computeTimeChunk()`, resulting in an error in `computeTimeChunk()`. This is now reversed

Also changing the error from `logger.error` to `RuntimeError`