### PR TITLE
summedfields cgrid unitconversion bugfix

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -761,10 +761,11 @@ class KernelGenerator(ast.NodeVisitor):
         for U, V, W, var, var2, var3 in zip(node.field.obj.U, node.field.obj.V, Wlist, node.var, node.var2, node.var3):
             vfld = VectorField(node.field.obj.name, U, V, W)
             ccode_eval = vfld.ccode_eval(var, var2, var3, U, V, W, *node.args.ccode)
-            ccode_conv1 = U.ccode_convert(*node.args.ccode)
-            ccode_conv2 = V.ccode_convert(*node.args.ccode)
-            statements = [c.Statement("%s *= %s" % (var, ccode_conv1)),
-                          c.Statement("%s *= %s" % (var2, ccode_conv2))]
+            if node.field.obj.U.interp_method != 'cgrid_velocity':
+                ccode_conv1 = U.ccode_convert(*node.args.ccode)
+                ccode_conv2 = V.ccode_convert(*node.args.ccode)
+                statements = [c.Statement("%s *= %s" % (var, ccode_conv1)),
+                              c.Statement("%s *= %s" % (var2, ccode_conv2))]
             if var3:
                 ccode_conv3 = W.ccode_convert(*node.args.ccode)
                 statements.append(c.Statement("%s *= %s" % (var3, ccode_conv3)))

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -766,6 +766,8 @@ class KernelGenerator(ast.NodeVisitor):
                 ccode_conv2 = V.ccode_convert(*node.args.ccode)
                 statements = [c.Statement("%s *= %s" % (var, ccode_conv1)),
                               c.Statement("%s *= %s" % (var2, ccode_conv2))]
+            else:
+                statements = []
             if var3:
                 ccode_conv3 = W.ccode_convert(*node.args.ccode)
                 statements.append(c.Statement("%s *= %s" % (var3, ccode_conv3)))

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -761,7 +761,7 @@ class KernelGenerator(ast.NodeVisitor):
         for U, V, W, var, var2, var3 in zip(node.field.obj.U, node.field.obj.V, Wlist, node.var, node.var2, node.var3):
             vfld = VectorField(node.field.obj.name, U, V, W)
             ccode_eval = vfld.ccode_eval(var, var2, var3, U, V, W, *node.args.ccode)
-            if node.field.obj.U.interp_method != 'cgrid_velocity':
+            if U.interp_method != 'cgrid_velocity':
                 ccode_conv1 = U.ccode_convert(*node.args.ccode)
                 ccode_conv2 = V.ccode_convert(*node.args.ccode)
                 statements = [c.Statement("%s *= %s" % (var, ccode_conv1)),


### PR DESCRIPTION
Fixing a bug where unit converters were still applied to `cgrid_velocity` in summed fields, even though that is not necessary. 

While this was correctly implemented for normal VectorFields and NestedVectorFields, it was not yet implemented for SummedVectorFields