### PR TITLE
Raising an error for Variable.name='z'

### DIFF
--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -21,6 +21,8 @@ class Variable(object):
     :param to_write: Boolean to control whether Variable is written to NetCDF file
     """
     def __init__(self, name, dtype=np.float32, initial=0, to_write=True):
+        if name == 'z':
+            raise NotImplementedError("Custom Variable name 'z' is not allowed, as it is used for depth in ParticleFile")
         self.name = name
         self.dtype = dtype
         self.initial = initial

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -52,6 +52,19 @@ def test_variable_unsupported_dtypes(fieldset, mode, type):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_variable_special_names(fieldset, mode):
+    """Test that checks errors thrown for special names"""
+    class TestParticle(ptype[mode]):
+        error_thrown = False
+        try:
+            z = Variable('z', dtype=np.float32, initial=10.)
+        except RuntimeError:
+            error_thrown = True
+        assert error_thrown
+    ParticleSet(fieldset, pclass=TestParticle, lon=[0], lat=[0])
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_variable_init_relative(fieldset, mode, npart=10):
     """Test that checks relative initialisation of custom variables"""
     class TestParticle(ptype[mode]):


### PR DESCRIPTION
As ‘z’ is used in ParticleFile for particle.depth (from CF-convention), it shouldn’t also be used for a custom Variable. This PR raises an error when user specifies a custom Variable with name 'z'