### PR TITLE
Bug for time_periodic FieldSets in deferred_load mode

### DIFF
--- a/parcels/examples/example_globcurrent.py
+++ b/parcels/examples/example_globcurrent.py
@@ -79,7 +79,7 @@ def test_globcurrent_particles(mode, use_xarray):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
-@pytest.mark.parametrize('rundays', [300, 3000])
+@pytest.mark.parametrize('rundays', [300, 900])
 def test_globcurrent_time_periodic(mode, rundays):
     sample_var = []
     for full_load in [True, False]:

--- a/parcels/examples/example_globcurrent.py
+++ b/parcels/examples/example_globcurrent.py
@@ -10,7 +10,7 @@ import xarray as xr
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 
 
-def set_globcurrent_fieldset(filename=None, indices=None, full_load=False, use_xarray=False):
+def set_globcurrent_fieldset(filename=None, indices=None, full_load=False, use_xarray=False, time_periodic=False):
     if filename is None:
         filename = path.join(path.dirname(__file__), 'GlobCurrent_example_data',
                              '20*-GLOBCURRENT-L4-CUReul_hs-ALT_SUM-v02.0-fv01.0.nc')
@@ -18,9 +18,9 @@ def set_globcurrent_fieldset(filename=None, indices=None, full_load=False, use_x
     dimensions = {'lat': 'lat', 'lon': 'lon', 'time': 'time'}
     if use_xarray:
         ds = xr.open_mfdataset(filename)
-        return FieldSet.from_xarray_dataset(ds, variables, dimensions, indices, full_load=full_load)
+        return FieldSet.from_xarray_dataset(ds, variables, dimensions, indices, full_load=full_load, time_periodic=time_periodic)
     else:
-        return FieldSet.from_netcdf(filename, variables, dimensions, indices, full_load=full_load)
+        return FieldSet.from_netcdf(filename, variables, dimensions, indices, full_load=full_load, time_periodic=time_periodic)
 
 
 @pytest.mark.parametrize('use_xarray', [True, False])
@@ -76,6 +76,27 @@ def test_globcurrent_particles(mode, use_xarray):
 
     assert(abs(pset[0].lon - 23.8) < 1)
     assert(abs(pset[0].lat - -35.3) < 1)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+@pytest.mark.parametrize('rundays', [300, 3000])
+def test_globcurrent_time_periodic(mode, rundays):
+    sample_var = []
+    for full_load in [True, False]:
+        fieldset = set_globcurrent_fieldset(time_periodic=True, full_load=full_load)
+
+        class MyParticle(ptype[mode]):
+            sample_var = Variable('sample_var', initial=fieldset.U)
+
+        pset = ParticleSet(fieldset, pclass=MyParticle, lon=25, lat=-35, time=fieldset.U.grid.time[0])
+
+        def SampleU(particle, fieldset, time):
+            particle.sample_var += fieldset.U[time, particle.depth, particle.lat, particle.lon]
+
+        pset.execute(SampleU, runtime=delta(days=rundays), dt=delta(days=1))
+        sample_var.append(pset[0].sample_var)
+
+    assert np.allclose(sample_var[0], sample_var[1])
 
 
 @pytest.mark.parametrize('dt', [-300, 300])

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -695,8 +695,9 @@ class Field(object):
         time_index = self.grid.time <= time
         if self.time_periodic:
             if time_index.all() or np.logical_not(time_index).all():
-                periods = math.floor((time-self.grid.time[0])/(self.grid.time[-1]-self.grid.time[0]))
-                time -= periods*(self.grid.time[-1]-self.grid.time[0])
+                periods = math.floor((time-self.grid.time_full[0])/(self.grid.time_full[-1]-self.grid.time_full[0]))
+                self.grid.periods = periods
+                time -= periods*(self.grid.time_full[-1]-self.grid.time_full[0])
                 time_index = self.grid.time <= time
                 ti = time_index.argmin() - 1 if time_index.any() else 0
                 return (ti, periods)
@@ -728,7 +729,7 @@ class Field(object):
         scipy.interpolate to perform spatial interpolation.
         """
         (ti, periods) = self.time_index(time)
-        time -= periods*(self.grid.time[-1]-self.grid.time[0])
+        time -= periods*(self.grid.time_full[-1]-self.grid.time_full[0])
         if ti < self.grid.tdim-1 and time > self.grid.time[ti]:
             f0 = self.spatial_interpolation(ti, z, y, x, time)
             f1 = self.spatial_interpolation(ti + 1, z, y, x, time)
@@ -1165,7 +1166,7 @@ class VectorField(object):
         else:
             grid = self.U.grid
             (ti, periods) = self.U.time_index(time)
-            time -= periods*(grid.time[-1]-grid.time[0])
+            time -= periods*(grid.time_full[-1]-grid.time_full[0])
             if ti < grid.tdim-1 and time > grid.time[ti]:
                 t0 = grid.time[ti]
                 t1 = grid.time[ti + 1]

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -695,8 +695,11 @@ class Field(object):
         time_index = self.grid.time <= time
         if self.time_periodic:
             if time_index.all() or np.logical_not(time_index).all():
-                periods = math.floor((time-self.grid.time_full[0])/(self.grid.time_full[-1]-self.grid.time_full[0]))
-                self.grid.periods = periods
+                periods = int(math.floor((time-self.grid.time_full[0])/(self.grid.time_full[-1]-self.grid.time_full[0])))
+                if isinstance(self.grid.periods, c_int):
+                    self.grid.periods.value = periods
+                else:
+                    self.grid.periods = periods
                 time -= periods*(self.grid.time_full[-1]-self.grid.time_full[0])
                 time_index = self.grid.time <= time
                 ti = time_index.argmin() - 1 if time_index.any() else 0

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -147,7 +147,7 @@ class Grid(object):
             if self.ti >= 0:
                 if (time - periods*(self.time_full[-1]-self.time_full[0]) < self.time[0] or time - periods*(self.time_full[-1]-self.time_full[0]) > self.time[2]):
                     self.ti = -1  # reset
-                elif (time - periods*(self.time_full[-1]-self.time_full[0]) <= self.time_full[0] or time - periods*(self.time_full[-1]-self.time_full[0]) >= self.time_full[-1]):
+                elif (time - periods*(self.time_full[-1]-self.time_full[0]) < self.time_full[0] or time - periods*(self.time_full[-1]-self.time_full[0]) >= self.time_full[-1]):
                     self.ti = -1  # reset
                 elif signdt >= 0 and time - periods*(self.time_full[-1]-self.time_full[0]) >= self.time[1] and self.ti < len(self.time_full)-3:
                     self.ti += 1

--- a/parcels/include/index_search.h
+++ b/parcels/include/index_search.h
@@ -384,7 +384,7 @@ static inline ErrorCode search_time_index(double *t, int size, double *tvals, in
       *t -= *periods * (tfull_max-tfull_min);
       search_time_index(t, size, tvals, ti, time_periodic, tfull_min, tfull_max, periods);
     }  
-    else if (*t > tvals[size-1]){
+    else if (*t >= tvals[size-1]){
       *ti = 0;
       *periods = (int) floor( (*t-tfull_min)/(tfull_max-tfull_min));
       *t -= *periods * (tfull_max-tfull_min);

--- a/parcels/include/index_search.h
+++ b/parcels/include/index_search.h
@@ -20,6 +20,8 @@ typedef struct
 {
   int xdim, ydim, zdim, tdim, z4d;
   int sphere_mesh, zonal_periodic;
+  double tfull_min, tfull_max;
+  int* periods;
   float *lonlat_minmax;
   float *lon, *lat, *depth;
   double *time;
@@ -371,22 +373,22 @@ static inline ErrorCode search_indices(float x, float y, float z, CStructuredGri
 }
 
 /* Local linear search to update time index */
-static inline ErrorCode search_time_index(double *t, int size, double *tvals, int *ti, int time_periodic)
+static inline ErrorCode search_time_index(double *t, int size, double *tvals, int *ti, int time_periodic, double tfull_min, double tfull_max, int *periods)
 {
   if (*ti < 0)
     *ti = 0;
   if (time_periodic == 1){
     if (*t < tvals[0]){
       *ti = size-1;
-      int periods = floor( (*t-tvals[0])/(tvals[size-1]-tvals[0]));
-      *t -= periods * (tvals[size-1]-tvals[0]);
-      search_time_index(t, size, tvals, ti, time_periodic);
+      *periods = (int) floor( (*t-tfull_min)/(tfull_max-tfull_min));
+      *t -= *periods * (tfull_max-tfull_min);
+      search_time_index(t, size, tvals, ti, time_periodic, tfull_min, tfull_max, periods);
     }  
     else if (*t > tvals[size-1]){
       *ti = 0;
-      int periods = floor( (*t-tvals[0])/(tvals[size-1]-tvals[0]));
-      *t -= periods * (tvals[size-1]-tvals[0]);
-      search_time_index(t, size, tvals, ti, time_periodic);
+      *periods = (int) floor( (*t-tfull_min)/(tfull_max-tfull_min));
+      *t -= *periods * (tfull_max-tfull_min);
+      search_time_index(t, size, tvals, ti, time_periodic, tfull_min, tfull_max, periods);
     }  
   }          
   while (*ti < size-1 && *t >= tvals[*ti+1]) ++(*ti);

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -113,7 +113,7 @@ static inline ErrorCode temporal_interpolation_structured_grid(float x, float y,
   if (f->time_periodic == 0 && f->allow_time_extrapolation == 0 && (time < grid->time[0] || time > grid->time[grid->tdim-1])){
     return ERROR_TIME_EXTRAPOLATION;
   }
-  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], f->time_periodic); CHECKERROR(err);
+  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], f->time_periodic, grid->tfull_min, grid->tfull_max, grid->periods); CHECKERROR(err);
 
   /* Cast data array intp data[time][depth][lat][lon] as per NEMO convention */
   float (*data)[f->zdim][f->ydim][f->xdim] = (float (*)[f->zdim][f->ydim][f->xdim]) f->data;
@@ -315,7 +315,7 @@ static inline ErrorCode temporal_interpolationUV_c_grid(float x, float y, float 
   if (U->time_periodic == 0 && U->allow_time_extrapolation == 0 && (time < grid->time[0] || time > grid->time[grid->tdim-1])){
     return ERROR_TIME_EXTRAPOLATION;
   }
-  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic); CHECKERROR(err);
+  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic, grid->tfull_min, grid->tfull_max, grid->periods); CHECKERROR(err);
 
   /* Cast data array intp data[time][depth][lat][lon] as per NEMO convention */
   float (*dataU)[U->zdim][U->ydim][U->xdim] = (float (*)[U->zdim][U->ydim][U->xdim]) U->data;
@@ -502,7 +502,7 @@ static inline ErrorCode temporal_interpolationUVW_c_grid(float x, float y, float
   if (U->time_periodic == 0 && U->allow_time_extrapolation == 0 && (time < grid->time[0] || time > grid->time[grid->tdim-1])){
     return ERROR_TIME_EXTRAPOLATION;
   }
-  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic); CHECKERROR(err);
+  err = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic, grid->tfull_min, grid->tfull_max, grid->periods); CHECKERROR(err);
 
   /* Cast data array intp data[time][depth][lat][lon] as per NEMO convention */
   float (*dataU)[U->zdim][U->ydim][U->xdim] = (float (*)[U->zdim][U->ydim][U->xdim]) U->data;

--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -131,7 +131,7 @@ def plotfield(field, show_time=None, domain=None, depth_level=0, projection=None
         if fld.grid.defer_load:
             fld.fieldset.computeTimeChunk(show_time, 1)
         (idx, periods) = fld.time_index(show_time)
-        show_time -= periods * (fld.grid.time[-1] - fld.grid.time[0])
+        show_time -= periods * (fld.grid.time_full[-1] - fld.grid.time_full[0])
         if show_time > fld.grid.time[-1] or show_time < fld.grid.time[0]:
             raise TimeExtrapolationError(show_time, field=fld, msg='show_time')
 


### PR DESCRIPTION
There is a bug in using `time_periodic=True` for `FieldSets` when they are in deferred_load (`full_load=True`) mode.

An example for this is in example_globcurrent.py, which has a unit test that shows that `time_periodic=True` doesn't work in combination with `full_load=True`. The expected result of this unit test is that `pset.sample_var` is the same for full_load and defered_load mode. This is true for `runtime = 300 days` (less than available data) but not true for `runtime = 3000 days`. This clearly is a bug, which needs to be fixed for v2.0.0 release.