### PR TITLE
Fix plotting domain

### DIFF
--- a/parcels/examples/tutorial_nemo_3D.ipynb
+++ b/parcels/examples/tutorial_nemo_3D.ipynb
@@ -118,7 +118,7 @@
     "depth_level = 8\n",
     "print(\"Level[%d] depth is: [%g %g]\" % (depth_level, fieldset.W.grid.depth[depth_level], fieldset.W.grid.depth[depth_level+1]))\n",
     "\n",
-    "pset.show(field=fieldset.W, domain=[60,49,15,0], depth_level=depth_level)"
+    "pset.show(field=fieldset.W, domain={'N':60, 'S':49, 'E':15 ,'W':0}, depth_level=depth_level)"
    ]
   }
  ],

--- a/parcels/examples/tutorial_plotting.ipynb
+++ b/parcels/examples/tutorial_plotting.ipynb
@@ -180,7 +180,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To set the domain of the plot, we specify the domain argument. The format `domain` expects is `[max lat, min lat, max lon, min lon]`. Note that the plotted domain is found by interpolating the user-specified domain onto the velocity grid. For instance,"
+    "To set the domain of the plot, we specify the domain argument. The format `domain` expects a dictionary with entries `{'S', 'N', 'E', 'W'}` for South, North, East and West extent, respectively. Note that the plotted domain is found by interpolating the user-specified domain onto the velocity grid. For instance,"
    ]
   },
   {
@@ -200,7 +200,7 @@
     }
    ],
    "source": [
-    "pset.show(domain=[-31, -35, 33, 26])"
+    "pset.show(domain={'N':-31, 'S':-35, 'E':33, 'W':26})"
    ]
   },
   {
@@ -345,7 +345,7 @@
     }
    ],
    "source": [
-    "pset.show(field='vector', vmax=3.0, domain=[-31, -39, 33, 18])"
+    "pset.show(field='vector', vmax=3.0, domain={'N':-31, 'S':-39, 'E':33, 'W':18})"
    ]
   },
   {
@@ -374,7 +374,7 @@
    "source": [
     "try:  # Within a try/pass for unit testing on machines without cartopy installed\n",
     "    import cartopy\n",
-    "    pset.show(field='vector', vmax=3.0, domain=[-31, -39, 33, 18], projection=cartopy.crs.Robinson())\n",
+    "    pset.show(field='vector', vmax=3.0, domain={'N':-31, 'S':-39, 'E':33, 'W':18}, projection=cartopy.crs.Robinson())\n",
     "except:\n",
     "    pass"
    ]
@@ -400,7 +400,7 @@
     }
    ],
    "source": [
-    "pset.show(field='vector', vmax=3.0, domain=[-31, -39, 33, 18], land=True, savefile='particles')"
+    "pset.show(field='vector', vmax=3.0, domain={'N':-31, 'S':-39, 'E':33, 'W':18}, land=True, savefile='particles')"
    ]
   }
  ],

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -788,7 +788,7 @@ class Field(object):
 
         :param animation: Boolean whether result is a single plot, or an animation
         :param show_time: Time at which to show the Field (only in single-plot mode)
-        :param domain: Four-vector (latN, latS, lonE, lonW) defining domain to show
+        :param domain: dictionary (with keys 'N', 'S', 'E', 'W') defining domain to show
         :param depth_level: depth level to be plotted (default 0)
         :param projection: type of cartopy projection to use (default PlateCarree)
         :param land: Boolean whether to show land. This is ignored for flat meshes

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -413,7 +413,7 @@ class ParticleSet(object):
         :param with_particles: Boolean whether to show particles
         :param show_time: Time at which to show the ParticleSet
         :param field: Field to plot under particles (either None, a Field object, or 'vector')
-        :param domain: Four-vector (latN, latS, lonE, lonW) defining domain to show
+        :param domain: dictionary (with keys 'N', 'S', 'E', 'W') defining domain to show
         :param projection: type of cartopy projection to use (default PlateCarree)
         :param land: Boolean whether to show land. This is ignored for flat meshes
         :param vmin: minimum colour scale (only in single-plot mode)

--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -210,11 +210,11 @@ def plotfield(field, show_time=None, domain=None, depth_level=0, projection=None
         else:
             cs = ax.pcolormesh(plotlon[0], plotlat[0], d)
 
-    if cartopy is None or projection is None:
+    if cartopy is None:
         ax.set_xlim(np.nanmin(plotlon[0]), np.nanmax(plotlon[0]))
         ax.set_ylim(np.nanmin(plotlat[0]), np.nanmax(plotlat[0]))
     elif domain is not None:
-        ax.set_extent([np.nanmin(plotlon[0]), np.nanmax(plotlon[0]), np.nanmin(plotlat[0]), np.nanmax(plotlat[0])])
+        ax.set_extent([np.nanmin(plotlon[0]), np.nanmax(plotlon[0]), np.nanmin(plotlat[0]), np.nanmax(plotlat[0])], crs=cartopy.crs.PlateCarree())
     cs.cmap.set_over('k')
     cs.cmap.set_under('w')
     cs.set_clim(vmin, vmax)

--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -14,7 +14,7 @@ def plotparticles(particles, with_particles=True, show_time=None, field=None, do
     :param show_time: Time at which to show the ParticleSet
     :param with_particles: Boolean whether particles are also plotted on Field
     :param field: Field to plot under particles (either None, a Field object, or 'vector')
-    :param domain: Four-vector (latN, latS, lonE, lonW) defining domain to show
+    :param domain: dictionary (with keys 'N', 'S', 'E', 'W') defining domain to show
     :param projection: type of cartopy projection to use (default PlateCarree)
     :param land: Boolean whether to show land. This is ignored for flat meshes
     :param vmin: minimum colour scale (only in single-plot mode)
@@ -99,7 +99,7 @@ def plotfield(field, show_time=None, domain=None, depth_level=0, projection=None
     """Function to plot a Parcels Field
 
     :param show_time: Time at which to show the Field
-    :param domain: Four-vector (latN, latS, lonE, lonW) defining domain to show
+    :param domain: dictionary (with keys 'N', 'S', 'E', 'W') defining domain to show
     :param depth_level: depth level to be plotted (default 0)
     :param projection: type of cartopy projection to use (default PlateCarree)
     :param land: Boolean whether to show land. This is ignored for flat meshes
@@ -291,8 +291,10 @@ def create_parcelsfig_axis(spherical, land=True, projection=None, central_longit
 def parsedomain(domain, field):
     field.grid.check_zonal_periodic()
     if domain is not None:
-        _, _, _, lonW, latS, _ = field.search_indices(domain[3], domain[1], 0, 0, 0, search2D=True)
-        _, _, _, lonE, latN, _ = field.search_indices(domain[2], domain[0], 0, 0, 0, search2D=True)
+        if not isinstance(domain, dict) and len(domain)  == 4:
+            domain = {'N': domain[0], 'S': domain[1], 'E': domain[2],'W': domain[3]}
+        _, _, _, lonW, latS, _ = field.search_indices(domain['W'], domain['S'], 0, 0, 0, search2D=True)
+        _, _, _, lonE, latN, _ = field.search_indices(domain['E'], domain['N'], 0, 0, 0, search2D=True)
         return latN+1, latS, lonE+1, lonW
     else:
         if field.grid.gtype in [GridCode.RectilinearSGrid, GridCode.CurvilinearSGrid]:

--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -291,7 +291,7 @@ def create_parcelsfig_axis(spherical, land=True, projection=None, central_longit
 def parsedomain(domain, field):
     field.grid.check_zonal_periodic()
     if domain is not None:
-        if not isinstance(domain, dict) and len(domain)  == 4:
+        if not isinstance(domain, dict) and len(domain) == 4:  # for backward compatibility with <v2.0.0
             domain = {'N': domain[0], 'S': domain[1], 'E': domain[2],'W': domain[3]}
         _, _, _, lonW, latS, _ = field.search_indices(domain['W'], domain['S'], 0, 0, 0, search2D=True)
         _, _, _, lonE, latN, _ = field.search_indices(domain['E'], domain['N'], 0, 0, 0, search2D=True)


### PR DESCRIPTION
Changing the call to the `domain` option in plotting from a vector `[max lat, min lat, max lon, min lon]` to a dictionary with entries `{'S', 'N', 'E', 'W'}` for South, North, East and West extent, respectively. Note that the vectors notation is still backward-compatible

This PR also fixes the Issue with the hycom plotting #537 