### PR TITLE
Bug-fix for erroneous behaviour when 'tmp' used in custom kernels

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -209,7 +209,7 @@ class IntrinsicTransformer(ast.NodeTransformer):
 
     def get_tmp(self):
         """Create a new temporary veriable name"""
-        tmp = "tmp%d" % self._tmp_counter
+        tmp = "parcels_tmpvar%d" % self._tmp_counter
         self._tmp_counter += 1
         self.tmp_vars += [tmp]
         return tmp
@@ -228,8 +228,8 @@ class IntrinsicTransformer(ast.NodeTransformer):
             node = RandomNode(math, ccode='')
         elif node.id == 'print':
             node = PrintNode()
-        elif 'tmp' in node.id:
-            raise NotImplementedError("Custom Kernels cannot contain string 'tmp'; please change your kernel")
+        elif 'parcels_tmpvar' in node.id:
+            raise NotImplementedError("Custom Kernels cannot contain string 'parcels_tmpvar'; please change your kernel")
         return node
 
     def visit_Attribute(self, node):
@@ -544,7 +544,7 @@ class KernelGenerator(ast.NodeVisitor):
             self.visit(b)
         # field evals are replaced by a tmp variable is added to the stack.
         # Here it means field evals passes from node.test to node.body. We take it out manually
-        fieldInTestCount = node.test.ccode.count('tmp')
+        fieldInTestCount = node.test.ccode.count('parcels_tmpvar')
         body0 = c.Block([b.ccode for b in node.body[:fieldInTestCount]])
         body = c.Block([b.ccode for b in node.body[fieldInTestCount:]])
         orelse = c.Block([b.ccode for b in node.orelse]) if len(node.orelse) > 0 else None

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -228,6 +228,8 @@ class IntrinsicTransformer(ast.NodeTransformer):
             node = RandomNode(math, ccode='')
         elif node.id == 'print':
             node = PrintNode()
+        elif 'tmp' in node.id:
+            raise NotImplementedError("Custom Kernels cannot contain string 'tmp'; please change your kernel")
         return node
 
     def visit_Attribute(self, node):

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -128,13 +128,13 @@ def test_nested_if(fieldset, mode):
     assert np.allclose([pset[0].p0, pset[0].p1], [0, 1])
 
 
-def test_tmp_in_kernel(fieldset):
+def test_parcels_tmpvar_in_kernel(fieldset):
     """Tests for error thrown if vartiable with 'tmp' defined in custom kernel"""
     error_thrown = False
     pset = ParticleSet(fieldset, pclass=JITParticle, lon=0, lat=0)
 
     def kernel_tmpvar(particle, fieldset, time):
-        tmpvar = 0  # noqa
+        parcels_tmpvar0 = 0  # noqa
 
     try:
         pset.execute(kernel_tmpvar, endtime=1, dt=1.)

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -114,18 +114,33 @@ def test_while_if_break(fieldset, mode):
 def test_nested_if(fieldset, mode):
     """Test nested if commands"""
     class TestParticle(ptype[mode]):
+        p0 = Variable('p0', dtype=np.int32, initial=0)
         p1 = Variable('p1', dtype=np.int32, initial=1)
-        p2 = Variable('p2', dtype=np.int32, initial=0)
     pset = ParticleSet(fieldset, pclass=TestParticle, lon=0, lat=0)
 
     def kernel(particle, fieldset, time):
-        if particle.p1 >= particle.p2:
-            particle.p2 = 1
-            if particle.p2 == particle.p1:
-                particle.p1 = 5
+        if particle.p1 >= particle.p0:
+            var = particle.p0
+            if var + 1 < particle.p1:
+                particle.p1 = -1
 
     pset.execute(kernel, endtime=10, dt=1.)
-    assert np.allclose([pset[0].p1, pset[0].p2], [5, 1])
+    assert np.allclose([pset[0].p0, pset[0].p1], [0, 1])
+
+
+def test_tmp_in_kernel(fieldset):
+    """Tests for error thrown if vartiable with 'tmp' defined in custom kernel"""
+    error_thrown = False
+    pset = ParticleSet(fieldset, pclass=JITParticle, lon=0, lat=0)
+
+    def kernel_tmpvar(particle, fieldset, time):
+        tmpvar = 0  # noqa
+
+    try:
+        pset.execute(kernel_tmpvar, endtime=1, dt=1.)
+    except NotImplementedError:
+        error_thrown = True
+    assert error_thrown
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -111,6 +111,24 @@ def test_while_if_break(fieldset, mode):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_nested_if(fieldset, mode):
+    """Test nested if commands"""
+    class TestParticle(ptype[mode]):
+        p1 = Variable('p1', dtype=np.int32, initial=1)
+        p2 = Variable('p2', dtype=np.int32, initial=0)
+    pset = ParticleSet(fieldset, pclass=TestParticle, lon=0, lat=0)
+
+    def kernel(particle, fieldset, time):
+        if particle.p1 >= particle.p2:
+            particle.p2 = 1
+            if particle.p2 == particle.p1:
+                particle.p1 = 5
+
+    pset.execute(kernel, endtime=10, dt=1.)
+    assert np.allclose([pset[0].p1, pset[0].p2], [5, 1])
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_if_withfield(fieldset, mode):
     """Test combination of if and Field sampling commands"""
     class TestParticle(ptype[mode]):


### PR DESCRIPTION
This PR fixes #538, which was caused by a user variable with the string `tmp` in the name. These are also used in the codegenerator for Field interpolation, creating erroneous behaviour.

Now, this is fixed by
- changing the special`tmp` to `parcels_tmpvar` in the code generator, which users are far less likely to use themselves
- throwing an error if users do use `parcels_tmpvar` in a custom kernel
