### PR TITLE
Test correct keys in dimensions dictionary

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -56,7 +56,7 @@ class Field(object):
                  fieldtype=None, transpose=False, vmin=None, vmax=None, time_origin=None,
                  interp_method='linear', allow_time_extrapolation=None, time_periodic=False, **kwargs):
         self.name = list(name)[0] if isinstance(name, dict) else name
-        self.filebuffername = name[list(name)[0]] if isinstance(name, dict) else None
+        self.filebuffername = name[list(name)[0]] if isinstance(name, dict) else name
         self.data = data
         time_origin = TimeConverter(0) if time_origin is None else time_origin
         if grid:
@@ -163,6 +163,8 @@ class Field(object):
             data_filenames = variable
             netcdf_engine = 'xarray'
         else:
+            if isinstance(variable, str):  # for backward compatibility with Parcels < 2.0.0
+                variable = {variable: variable}
             assert len(variable) == 1, 'There can only be one key in variable dictionary. Use FieldSet.from_netcdf() for multiple variables'
             if not isinstance(filenames, Iterable) or isinstance(filenames, str):
                 filenames = [filenames]

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -35,6 +35,12 @@ class FieldSet(object):
         self.compute_on_defer = None
 
     @classmethod
+    def checkvaliddimensionsdict(cls, dims):
+        for d in dims:
+            if d not in ['lon', 'lat', 'depth', 'time']:
+                raise NameError('%s is not a valid key in the dimensions dictionary' % d)
+
+    @classmethod
     def from_data(cls, data, dimensions, transpose=False, mesh='spherical',
                   allow_time_extrapolation=None, time_periodic=False, **kwargs):
         """Initialise FieldSet object from raw data
@@ -71,6 +77,7 @@ class FieldSet(object):
         for name, datafld in data.items():
             # Use dimensions[name] if dimensions is a dict of dicts
             dims = dimensions[name] if name in dimensions else dimensions
+            cls.checkvaliddimensionsdict(dims)
 
             if allow_time_extrapolation is None:
                 allow_time_extrapolation = False if 'time' in dims else True
@@ -225,6 +232,7 @@ class FieldSet(object):
 
             # Use dimensions[var] and indices[var] if either of them is a dict of dicts
             dims = dimensions[var] if var in dimensions else dimensions
+            cls.checkvaliddimensionsdict(dims)
             dims['data'] = name
             inds = indices[var] if (indices and var in indices) else indices
 

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -34,8 +34,8 @@ class FieldSet(object):
 
         self.compute_on_defer = None
 
-    @classmethod
-    def checkvaliddimensionsdict(cls, dims):
+    @staticmethod
+    def checkvaliddimensionsdict(dims):
         for d in dims:
             if d not in ['lon', 'lat', 'depth', 'time']:
                 raise NameError('%s is not a valid key in the dimensions dictionary' % d)
@@ -253,7 +253,7 @@ class FieldSet(object):
                         grid = fields[procvar].grid
                         kwargs['dataFiles'] = fields[procvar].dataFiles
                         break
-            fields[var] = Field.from_netcdf(paths, {var: name}, dims, inds, grid=grid, mesh=mesh,
+            fields[var] = Field.from_netcdf(paths, (var, name), dims, inds, grid=grid, mesh=mesh,
                                             allow_time_extrapolation=allow_time_extrapolation,
                                             time_periodic=time_periodic, full_load=full_load, **kwargs)
         u = fields.pop('U', None)

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -233,7 +233,6 @@ class FieldSet(object):
             # Use dimensions[var] and indices[var] if either of them is a dict of dicts
             dims = dimensions[var] if var in dimensions else dimensions
             cls.checkvaliddimensionsdict(dims)
-            dims['data'] = name
             inds = indices[var] if (indices and var in indices) else indices
 
             grid = None
@@ -247,14 +246,14 @@ class FieldSet(object):
                         sameGrid = True
                     elif type(filenames[procvar]) == dict:
                         sameGrid = True
-                        for dim in ['lon', 'lat', 'depth', 'data']:
+                        for dim in ['lon', 'lat', 'depth']:
                             if dim in dimensions:
                                 sameGrid *= filenames[procvar][dim] == filenames[var][dim]
                     if sameGrid:
                         grid = fields[procvar].grid
                         kwargs['dataFiles'] = fields[procvar].dataFiles
                         break
-            fields[var] = Field.from_netcdf(paths, var, dims, inds, grid=grid, mesh=mesh,
+            fields[var] = Field.from_netcdf(paths, {var: name}, dims, inds, grid=grid, mesh=mesh,
                                             allow_time_extrapolation=allow_time_extrapolation,
                                             time_periodic=time_periodic, full_load=full_load, **kwargs)
         u = fields.pop('U', None)

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -126,6 +126,26 @@ def test_fieldset_from_file_subsets(indslon, indslat, tmpdir, filename='test_sub
     assert np.allclose(fieldsetsub.V.data, fieldsetfull.V.data[ixgrid])
 
 
+@pytest.mark.parametrize('calltype', ['from_data', 'from_nemo'])
+def test_illegal_dimensionsdict(calltype):
+    error_thrown = False
+    try:
+        if calltype == 'from_data':
+            data, dimensions = generate_fieldset(10, 10)
+            dimensions['test'] = None
+            FieldSet.from_data(data, dimensions)
+        elif calltype == 'from_nemo':
+            fname = path.join(path.dirname(__file__), 'test_data', 'mask_nemo_cross_180lon.nc')
+            filenames = {'dx': fname, 'mesh_mask': fname}
+            variables = {'dx': 'e1u'}
+            dimensions = {'lon': 'glamu', 'lat': 'gphiu', 'test': 'test'}
+            error_thrown = False
+            FieldSet.from_nemo(filenames, variables, dimensions)
+    except NameError:
+        error_thrown = True
+    assert error_thrown
+
+
 @pytest.mark.parametrize('xdim', [100, 200])
 @pytest.mark.parametrize('ydim', [100, 200])
 def test_add_field(xdim, ydim, tmpdir, filename='test_add'):


### PR DESCRIPTION
This PR tests that the `dimensions` dictionary has no other keys than `lon`, `lat`, `depth` and `time`. Since other keys are not used, this prevents errors where users use the wrong key for e.g. `depth` and inadvertently use in 2D mode

Furthermore, this PR also cleans up the code by removing the `dimensions['data']` entry for the name of the variable in the filebuffer