### PR TITLE
Pinning conda to version 4.6.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ matrix:
 install:
   - "powershell ./appveyor/install_miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "conda update --yes conda"
+  - "conda install --yes conda=4.6.4"
   - "conda env create -f %ENV_NAME% -n parcels"
   - "activate parcels"
   - "python setup.py install"


### PR DESCRIPTION
 Since appveyor with conda 4.6.7 apparently does not install pip packages, the `pytest --nbval-lax` of the jupyter notebooks fail. Here, pinning conda to 4.6.4, for that reason

I suggest to merge this into master for now, and then also open an unpinned branch, so that we can keep track when the issue is fixed upstream at either conda or appveyor