### PR TITLE
Fixing Warnings thrown from other packages

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -2,7 +2,7 @@ from parcels.field import Field, VectorField, SummedField, SummedVectorField, Ne
 from parcels.tools.loggers import logger
 import ast
 import cgen as c
-from collections import OrderedDict
+import collections
 import math
 import numpy as np
 import random
@@ -362,9 +362,9 @@ class KernelGenerator(ast.NodeVisitor):
     def __init__(self, fieldset, ptype):
         self.fieldset = fieldset
         self.ptype = ptype
-        self.field_args = OrderedDict()
-        self.vector_field_args = OrderedDict()
-        self.const_args = OrderedDict()
+        self.field_args = collections.OrderedDict()
+        self.vector_field_args = collections.OrderedDict()
+        self.const_args = collections.OrderedDict()
 
     def generate(self, py_ast, funcvars):
         # Replace occurences of intrinsic objects in Python AST

--- a/parcels/examples/example_moving_eddies.py
+++ b/parcels/examples/example_moving_eddies.py
@@ -150,7 +150,6 @@ def test_moving_eddies_fieldset(mode, mesh):
         assert(pset[1].lon < 2.0 and 48.8 < pset[1].lat < 48.85)
 
 
-@pytest.fixture(scope='module')
 def fieldsetfile(mesh):
     """Generate fieldset files for moving_eddies test"""
     filename = 'moving_eddies'

--- a/parcels/examples/example_peninsula.py
+++ b/parcels/examples/example_peninsula.py
@@ -128,7 +128,6 @@ def test_peninsula_fieldset(mode, mesh):
     assert(err_smpl <= 1.e-3).all()
 
 
-@pytest.fixture(scope='module')
 def fieldsetfile(mesh):
     """Generate fieldset files for peninsula test"""
     filename = 'peninsula'

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -3,7 +3,7 @@ from parcels.tools.converters import unitconverters_map, UnitConverter, Geograph
 from parcels.tools.converters import TimeConverter
 from parcels.tools.error import FieldSamplingError, TimeExtrapolationError
 import parcels.tools.interpolation_utils as i_u
-from collections import Iterable
+import collections
 from py import path
 import numpy as np
 from ctypes import Structure, c_int, c_float, POINTER, pointer
@@ -184,7 +184,7 @@ class Field(object):
             if isinstance(variable, str):  # for backward compatibility with Parcels < 2.0.0
                 variable = (variable, variable)
             assert len(variable) == 2, 'The variable tuple must have length 2. Use FieldSet.from_netcdf() for multiple variables'
-            if not isinstance(filenames, Iterable) or isinstance(filenames, str):
+            if not isinstance(filenames, collections.Iterable) or isinstance(filenames, str):
                 filenames = [filenames]
 
             data_filenames = filenames['data'] if type(filenames) is dict else filenames
@@ -197,7 +197,7 @@ class Field(object):
                     raise NotImplementedError('longitude and latitude dimensions are currently processed together from one single file')
                 lonlat_filename = filenames['lon'][0]
                 if 'depth' in dimensions:
-                    if not isinstance(filenames['depth'], Iterable) or isinstance(filenames['depth'], str):
+                    if not isinstance(filenames['depth'], collections.Iterable) or isinstance(filenames['depth'], str):
                         filenames['depth'] = [filenames['depth']]
                     if len(filenames['depth']) != 1:
                         raise NotImplementedError('Vertically adaptive meshes not implemented for from_netcdf()')

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -10,7 +10,7 @@ import numpy.ctypeslib as npct
 import time
 from ctypes import c_int, c_float, c_double, c_void_p, byref
 import _ctypes
-from sys import platform
+from sys import platform, version_info
 from ast import parse, FunctionDef, Module
 import inspect
 from copy import deepcopy
@@ -95,7 +95,13 @@ class Kernel(object):
             self.pyfunc = user_ctx[self.funcname]
         else:
             self.pyfunc = pyfunc
-        assert len(inspect.getargspec(self.pyfunc).args) == 3, \
+
+        if version_info[0] < 3:
+            numkernelargs = len(inspect.getargspec(self.pyfunc).args)
+        else:
+            numkernelargs = len(inspect.getfullargspec(self.pyfunc).args)
+
+        assert numkernelargs == 3, \
             'Since Parcels v2.0, kernels do only take 3 arguments: particle, fieldset, time !! AND !! Argument order in field interpolation is time, depth, lat, lon.'
 
         self.name = "%s%s" % (ptype.name, self.funcname)

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -8,7 +8,7 @@ from parcels.grid import GridCode
 import numpy as np
 import progressbar
 import time as time_module
-from collections import Iterable
+import collections
 from datetime import timedelta as delta
 from datetime import datetime, date
 
@@ -225,7 +225,7 @@ class ParticleSet(object):
         """Method to add particles to the ParticleSet"""
         if isinstance(particles, ParticleSet):
             particles = particles.particles
-        if not isinstance(particles, Iterable):
+        if not isinstance(particles, collections.Iterable):
             particles = [particles]
         self.particles = np.append(self.particles, particles)
         if self.ptype.uses_jit:
@@ -237,7 +237,7 @@ class ParticleSet(object):
 
     def remove(self, indices):
         """Method to remove particles from the ParticleSet, based on their `indices`"""
-        if isinstance(indices, Iterable):
+        if isinstance(indices, collections.Iterable):
             particles = [self.particles[i] for i in indices]
         else:
             particles = self.particles[indices]


### PR DESCRIPTION
This PR fixes:
- an `inspect.getargspec() DeprecationWarning`
- an `importing from 'collections' DepreciationWarning`
- a `Fixture RemovedInPytest4Warning`