### PR TITLE
Fixing interpolation order in Argo tutorial temperature interpolation

### DIFF
--- a/parcels/examples/tutorial_Argofloats.ipynb
+++ b/parcels/examples/tutorial_Argofloats.ipynb
@@ -50,7 +50,7 @@
     "    elif particle.cycle_phase == 3:\n",
     "        # Phase 3: Rising with vertical_speed until at surface\n",
     "        particle.depth -= vertical_speed * particle.dt\n",
-    "        #particle.temp = fieldset.temp[time, particle.lon, particle.lat, particle.depth]  # if fieldset has temperature\n",
+    "        #particle.temp = fieldset.temp[time, particle.depth, particle.lat, particle.lon]  # if fieldset has temperature\n",
     "        if particle.depth <= fieldset.mindepth:\n",
     "            particle.depth = fieldset.mindepth\n",
     "            #particle.temp = 0./0.  # reset temperature to NaN at end of sampling cycle\n",


### PR DESCRIPTION
Since temperature interpolation in the Argo tutorial is commented out, we didn't catch before that this still had the old (pre-v2.0) interpolation order. That is now fixed in this PR