### PR TITLE
WIP: Chunked fields

### DIFF
--- a/parcels/examples/example_globcurrent.py
+++ b/parcels/examples/example_globcurrent.py
@@ -75,8 +75,8 @@ def test_globcurrent_particles(mode, use_xarray):
 
     pset = ParticleSet(fieldset, pclass=ptype[mode], lon=lonstart, lat=latstart)
 
-    #pset.execute(AdvectionRK4, runtime=delta(days=1), dt=delta(minutes=5))
-    pset.execute(AdvectionRK4, runtime=delta(minutes=50), dt=delta(minutes=5))
+    pset.execute(AdvectionRK4, runtime=delta(days=1), dt=delta(minutes=5))
+    #pset.execute(AdvectionRK4, runtime=delta(minutes=50), dt=delta(minutes=5))
 
     #assert(abs(pset[0].lon - 23.8) < 1)
     #assert(abs(pset[0].lat - -35.3) < 1)

--- a/parcels/examples/example_globcurrent.py
+++ b/parcels/examples/example_globcurrent.py
@@ -75,8 +75,8 @@ def test_globcurrent_particles(mode, use_xarray):
 
     pset = ParticleSet(fieldset, pclass=ptype[mode], lon=lonstart, lat=latstart)
 
-    pset.execute(AdvectionRK4, runtime=delta(days=1), dt=delta(minutes=5))
-    #pset.execute(AdvectionRK4, runtime=delta(minutes=50), dt=delta(minutes=5))
+    #pset.execute(AdvectionRK4, runtime=delta(days=1), dt=delta(minutes=5))
+    pset.execute(AdvectionRK4, runtime=delta(minutes=50), dt=delta(minutes=5))
 
     #assert(abs(pset[0].lon - 23.8) < 1)
     #assert(abs(pset[0].lat - -35.3) < 1)

--- a/parcels/examples/example_globcurrent.py
+++ b/parcels/examples/example_globcurrent.py
@@ -76,9 +76,11 @@ def test_globcurrent_particles(mode, use_xarray):
     pset = ParticleSet(fieldset, pclass=ptype[mode], lon=lonstart, lat=latstart)
 
     pset.execute(AdvectionRK4, runtime=delta(days=1), dt=delta(minutes=5))
+    #pset.execute(AdvectionRK4, runtime=delta(minutes=50), dt=delta(minutes=5))
 
-    assert(abs(pset[0].lon - 23.8) < 1)
-    assert(abs(pset[0].lat - -35.3) < 1)
+    #assert(abs(pset[0].lon - 23.8) < 1)
+    #assert(abs(pset[0].lat - -35.3) < 1)
+test_globcurrent_particles('jit', False)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/parcels/examples/example_peninsula.py
+++ b/parcels/examples/example_peninsula.py
@@ -5,6 +5,7 @@ import numpy as np
 import math  # NOQA
 import pytest
 from datetime import timedelta as delta
+import gc
 
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
@@ -140,6 +141,7 @@ def fieldsetfile(mesh):
 @pytest.mark.parametrize('mesh', ['flat', 'spherical'])
 def test_peninsula_file(mode, mesh):
     """Open fieldset files and execute"""
+    gc.collect()
     fieldset = FieldSet.from_parcels(fieldsetfile(mesh), extra_fields={'P': 'P'}, allow_time_extrapolation=True)
     pset = pensinsula_example(fieldset, 5, mode=mode, degree=1)
     # Test advection accuracy by comparing streamline values

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -877,6 +877,8 @@ class Field(object):
                 self.data_chunks[block_id] = np.array(self.data.blocks[block])
                 #self.load_chunk[block_id] = 1
 
+        # self.chunk_info format: number of dimensions; typical chunksizes; number of chunks per dimensions;
+        #                         chunksizes (the 0th dim sizes for all chunk of dim[0], then so on for next dims
         self.chunk_info = [[len(nchunks)], list(chunksize), list(nchunks), sum(list(list(ci) for ci in chunks), [])]
         self.chunk_info = sum(self.chunk_info, [])
         #print("chunk_info", self.chunk_info)

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -880,13 +880,15 @@ class Field(object):
 
     def chunk_data(self):
         if isinstance(self.data, da.core.Array):
-            npartitions = self.data.npartitions
             chunks = self.data.chunks
             self.nchunks = self.data.numblocks
-        else:
             npartitions = 1
+            for n in self.nchunks[1:]:
+                npartitions *= n
+        else:
             chunks = tuple((t,) for t in self.data.shape)
             self.nchunks = (1,) * len(self.data.shape)
+            npartitions = 1
 
         if len(self.data_chunks) == 0:
             self.data_chunks = [None] * npartitions

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -131,7 +131,6 @@ class Field(object):
         self.indices = kwargs.pop('indices', None)
         self.dataFiles = kwargs.pop('dataFiles', None)
         self.netcdf_engine = kwargs.pop('netcdf_engine', 'netcdf4')
-        self.loaded_time_indices = []
         self.creation_log = kwargs.pop('creation_log', '')
 
         # data_full_zdim is the vertical dimension of the complete field data, ignoring the indices.

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -880,8 +880,6 @@ class Field(object):
 
     def chunk_data(self):
         if isinstance(self.data, da.core.Array):
-            #if len(self.data.chunks[0]) > 1:
-            #    self.data = self.data.rechunk(sum(((self.grid.tdim,), self.data.chunksize[1:]), ()))
             npartitions = self.data.npartitions
             chunks = self.data.chunks
         else:
@@ -895,7 +893,6 @@ class Field(object):
 
         if len(self.grid.load_chunk) == 0:
             self.grid.load_chunk = np.zeros(npartitions, dtype=c_int)
-        #print(self.grid.load_chunk)
 
         # self.grid.load_chunk code:
         # 0: not loaded
@@ -909,34 +906,22 @@ class Field(object):
                     #block, local_index = self.find_in_block(chunksize, 0, 0, 20, 40)
                     #block_id = self.get_block_id(nchunks, block)
                     block = self.get_block(block_id)
-                    #print(self.data.shape)
-                    #print(self.data.blocks[0,0,0].shape)
-                    #print(self.data.blocks[:,0,0].shape)
-                    self.data_chunks[block_id] = np.array(self.data.blocks[:,0,0])#block])
+                    self.data_chunks[block_id] = np.array(self.data.blocks[f.data.blocks[(slice(3),)+block])
                 elif self.grid.load_chunk[block_id] == 0:
                     self.data_chunks[block_id] = None
                     self.c_data_chunks[block_id] = None
         else:
             self.grid.load_chunk[0] = 3
             self.data_chunks[0] = self.data
-        #busyfiles('in chunk_data 2')
 
         # self.chunk_info format: number of dimensions (without tdim); number of chunks per dimensions;
         #                         chunksizes (the 0th dim sizes for all chunk of dim[0], then so on for next dims
         self.chunk_info = [[len(self.nchunks)-1], list(self.nchunks[1:]), sum(list(list(ci) for ci in chunks[1:]), [])]
         self.chunk_info = sum(self.chunk_info, [])
-        #print(self.chunk_info)
-        #exit(0)
-        #print("chunk_info", self.chunk_info)
-        #print(self.data.chunks)
-        #print(self.data.chunksize)
-        #print("block_id", block, block_id)
 
         #To put it as it use to be
         #timer.fChunk.start()
-        #busyfiles('in chunk_data 3')
         self.datatmp = np.array(self.data)
-        #busyfiles('in chunk_data 4')
         #timer.fChunk.stop()
         if not self.datatmp.flags.c_contiguous:
             self.datatmp = self.datatmp.copy()
@@ -967,7 +952,6 @@ class Field(object):
                 if not self.data_chunks[i].flags.c_contiguous:
                     self.data_chunks[i] = self.data_chunks[i].copy()
                 self.c_data_chunks[i] = self.data_chunks[i].ctypes.data_as(POINTER(POINTER(c_float)))
-                #print(self.data_chunks[i].shape)
 
         cstruct = CField(self.grid.xdim, self.grid.ydim, self.grid.zdim,
                          self.grid.tdim, self.igrid, allow_time_extrapolation, time_periodic,

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -298,7 +298,6 @@ class Field(object):
 
         if grid.time.size <= 3 or deferred_load is False:
             # Pre-allocate data before reading files into buffer
-            data = np.empty((grid.tdim, grid.zdim, grid.ydim, grid.xdim), dtype=np.float32)
             data_list = []
             ti = 0
             for tslice, fname in zip(grid.timeslices, data_filenames):
@@ -685,6 +684,8 @@ class Field(object):
                 xsi*(1-eta) * self.data[ti, yi, xi+1] + \
                 xsi*eta * self.data[ti, yi+1, xi+1] + \
                 (1-xsi)*eta * self.data[ti, yi+1, xi]
+            if isinstance(val, da.core.Array):
+                raise RuntimeError("This happens at p init from field")
             return val
         elif self.interp_method in ['cgrid_tracer', 'bgrid_tracer']:
             return self.data[ti, yi+1, xi+1]

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -907,7 +907,7 @@ class Field(object):
                     #block, local_index = self.find_in_block(chunksize, 0, 0, 20, 40)
                     #block_id = self.get_block_id(nchunks, block)
                     block = self.get_block(block_id)
-                    self.data_chunks[block_id] = np.array(self.data.blocks[(slice(3),)+block])
+                    self.data_chunks[block_id] = np.array(self.data.blocks[(slice(self.grid.tdim),)+block])
                 elif self.grid.load_chunk[block_id] == 0:
                     self.data_chunks[block_id] = None
                     self.c_data_chunks[block_id] = None

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -687,7 +687,8 @@ class Field(object):
                 xsi*eta * self.data[ti, yi+1, xi+1] + \
                 (1-xsi)*eta * self.data[ti, yi+1, xi]
             if isinstance(val, da.core.Array):
-                raise RuntimeError("This happens at p init from field")
+                val = val.compute()
+                #raise RuntimeError("This happens at p init from field")
             return val
         elif self.interp_method in ['cgrid_tracer', 'bgrid_tracer']:
             return self.data[ti, yi+1, xi+1]

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -965,28 +965,29 @@ class Field(object):
         :param halosize: size of the halo (in grid points). Default is 5 grid points
         :param data: if data is not None, the periodic halo will be achieved on data instead of self.data and data will be returned
         """
-        dataNone = not isinstance(data, np.ndarray)
+        dataNone = not isinstance(data, (np.ndarray, da.core.Array))
         if self.grid.defer_load and dataNone:
             return
         data = self.data if dataNone else data
+        lib = np if isinstance(data, np.ndarray) else da
         if zonal:
             if len(data.shape) == 3:
-                data = np.concatenate((data[:, :, -halosize:], data,
+                data = lib.concatenate((data[:, :, -halosize:], data,
                                        data[:, :, 0:halosize]), axis=len(data.shape)-1)
                 assert data.shape[2] == self.grid.xdim, "Third dim must be x."
             else:
-                data = np.concatenate((data[:, :, :, -halosize:], data,
+                data = lib.concatenate((data[:, :, :, -halosize:], data,
                                        data[:, :, :, 0:halosize]), axis=len(data.shape) - 1)
                 assert data.shape[3] == self.grid.xdim, "Fourth dim must be x."
             self.lon = self.grid.lon
             self.lat = self.grid.lat
         if meridional:
             if len(data.shape) == 3:
-                data = np.concatenate((data[:, -halosize:, :], data,
+                data = lib.concatenate((data[:, -halosize:, :], data,
                                        data[:, 0:halosize, :]), axis=len(data.shape)-2)
                 assert data.shape[1] == self.grid.ydim, "Second dim must be y."
             else:
-                data = np.concatenate((data[:, :, -halosize:, :], data,
+                data = lib.concatenate((data[:, :, -halosize:, :], data,
                                        data[:, :, 0:halosize, :]), axis=len(data.shape) - 2)
                 assert data.shape[2] == self.grid.ydim, "Third dim must be y."
             self.lat = self.grid.lat

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -139,6 +139,7 @@ class Field(object):
         self.data_full_zdim = kwargs.pop('data_full_zdim', None)
         self.data_chunks = []
         self.c_data_chunks = []
+        self.nchunks = []
 
     @classmethod
     def from_netcdf(cls, filenames, variable, dimensions, indices=None, grid=None,

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -310,15 +310,16 @@ class Field(object):
                         tslice = [tslice]
                     else:
                         filebuffer.name = filebuffer.parse_name(variable[1])
-                    if len(filebuffer.data.shape) == 2:
-                        data_list.append(filebuffer.data.reshape(sum(((len(tslice), 1), filebuffer.data.shape), ())))
-                    elif len(filebuffer.data.shape) == 3:
+                    buffer_data = filebuffer.data
+                    if len(buffer_data.shape) == 2:
+                        data_list.append(buffer_data.reshape(sum(((len(tslice), 1), buffer_data.shape), ())))
+                    elif len(buffer_data.shape) == 3:
                         if len(filebuffer.indices['depth']) > 1:
-                            data_list.append(filebuffer.data.reshape(sum(((1,), filebuffer.data.shape), ())))
+                            data_list.append(buffer_data.reshape(sum(((1,), buffer_data.shape), ())))
                         else:
-                            data_list.append(filebuffer.data.reshape(sum(((len(tslice), 1), filebuffer.data.shape[1:]), ())))
+                            data_list.append(buffer_data.reshape(sum(((len(tslice), 1), buffer_data.shape[1:]), ())))
                     else:
-                        data_list.append(filebuffer.data)
+                        data_list.append(buffer_data)
                 ti += len(tslice)
             data = da.concatenate(data_list, axis=0)
         else:

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -882,11 +882,12 @@ class Field(object):
         if isinstance(self.data, da.core.Array):
             npartitions = self.data.npartitions
             chunks = self.data.chunks
+            self.nchunks = self.data.numblocks
         else:
             npartitions = 1
             chunks = tuple((t,) for t in self.data.shape)
+            self.nchunks = (1,) * len(self.data.shape)
 
-        self.nchunks = tuple(len(chunks[i]) for i in range(len(chunks)))
         if len(self.data_chunks) == 0:
             self.data_chunks = [None] * npartitions
             self.c_data_chunks = [None] * npartitions

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -906,7 +906,7 @@ class Field(object):
                     #block, local_index = self.find_in_block(chunksize, 0, 0, 20, 40)
                     #block_id = self.get_block_id(nchunks, block)
                     block = self.get_block(block_id)
-                    self.data_chunks[block_id] = np.array(self.data.blocks[f.data.blocks[(slice(3),)+block])
+                    self.data_chunks[block_id] = np.array(self.data.blocks[(slice(3),)+block])
                 elif self.grid.load_chunk[block_id] == 0:
                     self.data_chunks[block_id] = None
                     self.c_data_chunks[block_id] = None

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -836,12 +836,12 @@ class Field(object):
         return self.units.ccode_to_target(x, y, z)
 
 
-    def find_in_block(self, chunksize, ti, zi, yi, xi):
-        #index = (ti, zi, yi, xi)
-        index = (ti, yi, xi)
-        block = tuple((int(index[i]/chunksize[i]) for i in range(len(index))))
-        local_index = tuple(index[i] - chunksize[i]*block[i] for i in range(len(index)))
-        return block, local_index
+    #def find_in_block(self, chunksize, ti, zi, yi, xi):
+    #    #index = (ti, zi, yi, xi)
+    #    index = (ti, yi, xi)
+    #    block = tuple((int(index[i]/chunksize[i]) for i in range(len(index))))
+    #    local_index = tuple(index[i] - chunksize[i]*block[i] for i in range(len(index)))
+    #    return block, local_index
 
 
     def get_block_id(self, nchunks, block):
@@ -870,7 +870,7 @@ class Field(object):
 
         if self.grid.load_chunk is None:
             self.grid.load_chunk = np.zeros(npartitions, dtype=c_int)
-        print(self.grid.load_chunk)
+        #print(self.grid.load_chunk)
 
         if isinstance(self.data, da.core.Array):
             for block_id in range(len(self.grid.load_chunk)):
@@ -1600,7 +1600,7 @@ class NetcdfFileBuffer(object):
             data = np.ma.filled(data, np.nan)
         data = da.from_array(data, chunks='auto')
         #data = da.from_array(data, chunks=(20,20))
-        #print(data)
+        #data = da.from_array(data, chunks=(1,10,50,50))
         return data
 
     @property

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -775,12 +775,6 @@ class FieldSet(object):
                 f.data = f.reshape(data)
             elif g.update_status == 'updated':
                 data = da.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
-                if signdt >= 0:
-                    f.data[:2, :] = f.data[1:, :]
-                    f.loaded_time_indices = [2]
-                else:
-                    f.data[1:, :] = f.data[:2, :]
-                    f.loaded_time_indices = [0]
                 data = f.computeTimeChunk(data, f.loaded_time_indices[0])
                 # ### do built-in computations on data
                 if f._scaling_factor:
@@ -793,7 +787,12 @@ class FieldSet(object):
                 if f.gradientx is not None:
                     assert False
                     f.gradient(update=True, tindex=tind)
-                f.data[f.loaded_time_indices[0], :] = f.reshape(data)[f.loaded_time_indices[0], :]
+                if signdt >= 0:
+                    data = f.reshape(data)[2:, :]
+                    f.data = da.concatenate([f.data[1:, :], data], axis=0)
+                else:
+                    data = f.reshape(data)[0:1, :]
+                    f.data = da.concatenate([data[0, :], data], axis=0)
             else:
                 f.loaded_time_indices = []
 

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -795,7 +795,7 @@ class FieldSet(object):
                     f.data = da.concatenate([f.data[1:, :], data], axis=0)
                 else:
                     data = f.reshape(data)[0:1, :]
-                    f.data = da.concatenate([data[0, :], data], axis=0)
+                    f.data = da.concatenate([data, f.data[:2, :]], axis=0)
 
             # ### do built-in computations on data
             # for tind in f.loaded_time_indices:

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -761,22 +761,42 @@ class FieldSet(object):
                 f.loaded_time_indices = range(3)
                 for tind in f.loaded_time_indices:
                     data = f.computeTimeChunk(data, tind)
+                # ### do built-in computations on data
+                if f._scaling_factor:
+                    data *= f._scaling_factor
+                data[np.isnan(data)] = 0
+                if f.vmin is not None:
+                    data[data < f.vmin] = 0
+                if f.vmax is not None:
+                    data[data > f.vmax] = 0
+                if f.gradientx is not None:
+                    assert False
+                    f.gradient(update=True, tindex=tind)
                 f.data = f.reshape(data)
             elif g.update_status == 'updated':
-                data = np.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
+                data = da.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
                 if signdt >= 0:
                     f.data[:2, :] = f.data[1:, :]
                     f.loaded_time_indices = [2]
                 else:
                     f.data[1:, :] = f.data[:2, :]
                     f.loaded_time_indices = [0]
-                f.computeTimeChunk(data, f.loaded_time_indices[0])
+                data = f.computeTimeChunk(data, f.loaded_time_indices[0])
+                # ### do built-in computations on data
+                if f._scaling_factor:
+                    data *= f._scaling_factor
+                data[np.isnan(data)] = 0
+                if f.vmin is not None:
+                    data[data < f.vmin] = 0
+                if f.vmax is not None:
+                    data[data > f.vmax] = 0
+                if f.gradientx is not None:
+                    assert False
+                    f.gradient(update=True, tindex=tind)
                 f.data[f.loaded_time_indices[0], :] = f.reshape(data)[f.loaded_time_indices[0], :]
             else:
                 f.loaded_time_indices = []
 
-            if f._scaling_factor:
-                assert False
             # ### do built-in computations on data
             # for tind in f.loaded_time_indices:
             #     if f._scaling_factor:

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -806,7 +806,6 @@ class FieldSet(object):
                 if len(g.load_chunk) > 0:
                     g.load_chunk = np.where(g.load_chunk == 2, 1, g.load_chunk)
                     g.load_chunk = np.where(g.load_chunk == 3, 0, g.load_chunk)
-                #f.data = np.zeros(f.data.shape)
             elif g.update_status == 'updated':
                 #timer.fset_computeTimeChunk_1.start()
                 data = da.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
@@ -831,28 +830,10 @@ class FieldSet(object):
                     f.gradient(update=True, tindex=tind)
                 if signdt >= 0:
                     data = f.reshape(data)[2:, :]
-                    if isinstance(f.data, da.core.Array):
-                        assert data.chunksize == sum(((1,), f.data.chunksize[1:]), ())
-                        # is it necessary?
-                    #busyfiles('******** BEFORE ********, %s' % f.name)
                     f.data = da.concatenate([f.data[1:, :], data], axis=0)
-                    #np.array(f.data[:])
-                    #busyfiles('******** AFTER  ********')
-                    #exit(0)
-                    #print('here  f.data.shape', f.data.shape)
                 else:
                     data = f.reshape(data)[0:1, :]
-                    if isinstance(f.data, da.core.Array):
-                        assert data.chunksize == sum(((1,), f.data.chunksize[1:]), ())
-                        # is it necessary?
                     f.data = da.concatenate([data, f.data[:2, :]], axis=0)
-                # # Option 1
-                # if len(g.load_chunk) > 0:
-                #     g.load_chunk = np.where(g.load_chunk == 2, 1, g.load_chunk)
-                #     g.load_chunk = np.where(g.load_chunk == 3, 0, g.load_chunk)
-                # Option 2
-                #if len(f.data.chunks[0]) > 1:
-                #    f.data = f.data.rechunk(sum(((f.grid.tdim,), f.data.chunksize[1:]), ()))
                 #timer.fset_computeTimeChunk_1.stop()
                 #timer.fset_computeTimeChunk_2.start()
                 if len(g.load_chunk) > 0:
@@ -867,9 +848,7 @@ class FieldSet(object):
                                 f.data_chunks[block_id][:2] = f.data_chunks[block_id][1:]
                                 #timer.fset_computeTimeChunk_21.stop()
                                 #timer.fset_computeTimeChunk_22.start()
-                                #busyfiles('fset computeTimeChunk 0')
                                 f.data_chunks[block_id][2] = np.array(f.data.blocks[(slice(3),)+block][2])
-                                #busyfiles('fset computeTimeChunk 1')
                                 #timer.fset_computeTimeChunk_22.stop()
                     else:
                         for block_id in range(len(g.load_chunk)):
@@ -881,7 +860,6 @@ class FieldSet(object):
                                 f.data_chunks[block_id][1:] = f.data_chunks[block_id][:2]
                                 f.data_chunks[block_id][0] = np.array(f.data.blocks[(slice(3),)+block][0])
                 #timer.fset_computeTimeChunk_2.stop()
-                #gc.collect()
 
             # ### do built-in computations on data
             # for tind in f.loaded_time_indices:

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -758,8 +758,8 @@ class FieldSet(object):
             g = f.grid
             if g.update_status == 'first_updated':  # First load of data
                 data = da.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
-                f.loaded_time_indices = range(3)
-                for tind in f.loaded_time_indices:
+                loaded_time_indices = range(3)
+                for tind in loaded_time_indices:
                     data = f.computeTimeChunk(data, tind)
                 # ### do built-in computations on data
                 if f._scaling_factor:
@@ -775,7 +775,10 @@ class FieldSet(object):
                 f.data = f.reshape(data)
             elif g.update_status == 'updated':
                 data = da.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
-                data = f.computeTimeChunk(data, f.loaded_time_indices[0])
+                if signdt >= 0:
+                    data = f.computeTimeChunk(data, 2)
+                else:
+                    data = f.computeTimeChunk(data, 0)
                 # ### do built-in computations on data
                 if f._scaling_factor:
                     data *= f._scaling_factor
@@ -793,8 +796,6 @@ class FieldSet(object):
                 else:
                     data = f.reshape(data)[0:1, :]
                     f.data = da.concatenate([data[0, :], data], axis=0)
-            else:
-                f.loaded_time_indices = []
 
             # ### do built-in computations on data
             # for tind in f.loaded_time_indices:

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -810,12 +810,18 @@ class FieldSet(object):
                     if signdt >= 0:
                         for block_id in range(len(g.load_chunk)):
                             if g.load_chunk[block_id] == 2:
+                                if len(f.nchunks) == 0:
+                                    break  # file chunks were never loaded.
+                                           # happens when field not called by kernel, but shares a grid with another field called by kernel
                                 block = f.get_block(block_id)
                                 f.data_chunks[block_id][:2] = f.data_chunks[block_id][1:]
                                 f.data_chunks[block_id][2] = np.array(f.data.blocks[block][2])
                     else:
                         for block_id in range(len(g.load_chunk)):
                             if g.load_chunk[block_id] == 2:
+                                if len(f.nchunks) == 0:
+                                    break  # file chunks were never loaded.
+                                           # happens when field not called by kernel, but shares a grid with another field called by kernel
                                 block = f.get_block(block_id)
                                 f.data_chunks[block_id][1:] = f.data_chunks[block_id][:2]
                                 f.data_chunks[block_id][0] = np.array(f.data.blocks[block][0])

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -7,6 +7,7 @@ import numpy as np
 from os import path
 from glob import glob
 from copy import deepcopy
+import dask.array as da
 
 
 __all__ = ['FieldSet']
@@ -756,10 +757,10 @@ class FieldSet(object):
                 continue
             g = f.grid
             if g.update_status == 'first_updated':  # First load of data
-                data = np.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
+                data = da.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
                 f.loaded_time_indices = range(3)
                 for tind in f.loaded_time_indices:
-                    f.computeTimeChunk(data, tind)
+                    data = f.computeTimeChunk(data, tind)
                 f.data = f.reshape(data)
             elif g.update_status == 'updated':
                 data = np.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
@@ -774,17 +775,19 @@ class FieldSet(object):
             else:
                 f.loaded_time_indices = []
 
-            # do built-in computations on data
-            for tind in f.loaded_time_indices:
-                if f._scaling_factor:
-                    f.data[tind, :] *= f._scaling_factor
-                f.data[tind, :] = np.where(np.isnan(f.data[tind, :]), 0, f.data[tind, :])
-                if f.vmin is not None:
-                    f.data[tind, :] = np.where(f.data[tind, :] < f.vmin, 0, f.data[tind, :])
-                if f.vmax is not None:
-                    f.data[tind, :] = np.where(f.data[tind, :] > f.vmax, 0, f.data[tind, :])
-                if f.gradientx is not None:
-                    f.gradient(update=True, tindex=tind)
+            if f._scaling_factor:
+                assert False
+            # ### do built-in computations on data
+            # for tind in f.loaded_time_indices:
+            #     if f._scaling_factor:
+            #         f.data[tind, :] *= f._scaling_factor
+            #     f.data[tind, :] = np.where(np.isnan(f.data[tind, :]), 0, f.data[tind, :])
+            #     if f.vmin is not None:
+            #         f.data[tind, :] = np.where(f.data[tind, :] < f.vmin, 0, f.data[tind, :])
+            #     if f.vmax is not None:
+            #         f.data[tind, :] = np.where(f.data[tind, :] > f.vmax, 0, f.data[tind, :])
+            #     if f.gradientx is not None:
+            #         f.gradient(update=True, tindex=tind)
 
         # do user-defined computations on fieldset data
         if self.compute_on_defer:

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -795,9 +795,13 @@ class FieldSet(object):
                     f.gradient(update=True, tindex=tind)
                 if signdt >= 0:
                     data = f.reshape(data)[2:, :]
+                    if isinstance(f.data, da.core.Array):
+                        data = data.rechunk(sum(((1,), f.data.chunksize[1:]), ()))
                     f.data = da.concatenate([f.data[1:, :], data], axis=0)
                 else:
                     data = f.reshape(data)[0:1, :]
+                    if isinstance(f.data, da.core.Array):
+                        data = data.rechunk(sum(((1,), f.data.chunksize[1:]), ()))
                     f.data = da.concatenate([data, f.data[:2, :]], axis=0)
                 # # Option 1
                 # if len(g.load_chunk) > 0:

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -51,7 +51,7 @@ class Grid(object):
         self.defer_load = False
         self.lonlat_minmax = np.array([np.nanmin(lon), np.nanmax(lon), np.nanmin(lat), np.nanmax(lat)], dtype=np.float32)
         self.periods = 0
-        self.load_chunk = None
+        self.load_chunk = []
 
     @staticmethod
     def create_grid(lon, lat, depth, time, time_origin, mesh, **kwargs):

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -51,6 +51,7 @@ class Grid(object):
         self.defer_load = False
         self.lonlat_minmax = np.array([np.nanmin(lon), np.nanmax(lon), np.nanmin(lat), np.nanmax(lat)], dtype=np.float32)
         self.periods = 0
+        self.load_chunk = None
 
     @staticmethod
     def create_grid(lon, lat, depth, time, time_origin, mesh, **kwargs):
@@ -85,7 +86,8 @@ class Grid(object):
                         ('tfull_min', c_double), ('tfull_max', c_double), ('periods', POINTER(c_int)),
                         ('lonlat_minmax', POINTER(c_float)),
                         ('lon', POINTER(c_float)), ('lat', POINTER(c_float)),
-                        ('depth', POINTER(c_float)), ('time', POINTER(c_double))
+                        ('depth', POINTER(c_float)), ('time', POINTER(c_double)),
+                        ('load_chunk', POINTER(c_int))
                         ]
 
         # Create and populate the c-struct object
@@ -101,7 +103,8 @@ class Grid(object):
                                            self.lon.ctypes.data_as(POINTER(c_float)),
                                            self.lat.ctypes.data_as(POINTER(c_float)),
                                            self.depth.ctypes.data_as(POINTER(c_float)),
-                                           self.time.ctypes.data_as(POINTER(c_double)))
+                                           self.time.ctypes.data_as(POINTER(c_double)),
+                                           self.load_chunk.ctypes.data_as(POINTER(c_int)))
         return self.cstruct
 
     def lon_grid_to_target(self):

--- a/parcels/include/index_search.h
+++ b/parcels/include/index_search.h
@@ -37,6 +37,7 @@ typedef struct
   float *lonlat_minmax;
   float *lon, *lat, *depth;
   double *time;
+  int *load_chunk;
 } CStructuredGrid;
 
 

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -363,8 +363,8 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
   float (*data)[f->zdim][f->ydim][f->xdim] = (float (*)[f->zdim][f->ydim][f->xdim]) f->data;
   double xsi, eta, zeta;
 
-  float data3D[2][2][2];
-  float data4D[2][2][2][2];
+  float data2D[2][2][2];
+  float data3D[2][2][2][2];
   float f0p, f1p;
   float valuep;
 
@@ -375,9 +375,9 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
     /* Identify grid cell to sample through local linear search */
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], time, t0, t1, interp_method); CHECKERROR(err);
     if (grid->zdim==1){
-      err = getCell2D(f, xi[igrid], yi[igrid], ti[igrid], data3D, 0); CHECKERROR(err);
+      err = getCell2D(f, xi[igrid], yi[igrid], ti[igrid], data2D, 0); CHECKERROR(err);
     } else{
-      err = getCell3D(f, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D, 0); CHECKERROR(err);
+      err = getCell3D(f, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D, 0); CHECKERROR(err);
     }
     if ((interp_method == LINEAR) || (interp_method == CGRID_VELOCITY) || (interp_method == BGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)){
       if ((interp_method == CGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)){ // interpolate w
@@ -389,27 +389,27 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       }
       if (grid->zdim==1){
         err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
-        err = spatial_interpolation_bilinear2(xsi, eta, data3D[0], &f0p); CHECKERROR(err);
+        err = spatial_interpolation_bilinear2(xsi, eta, data2D[0], &f0p); CHECKERROR(err);
         if (fabs(f0-f0p) > 1e-12){
           printf("error 0\n");
           return ERROR;
         }
         err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
-        err = spatial_interpolation_bilinear2(xsi, eta, data3D[1], &f1p); CHECKERROR(err);
+        err = spatial_interpolation_bilinear2(xsi, eta, data2D[1], &f1p); CHECKERROR(err);
         if (fabs(f1-f1p) > 1e-12){
           printf("error 0\n");
           return ERROR;
         }
       } else {
         err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
-        err = spatial_interpolation_trilinear2(xsi, eta, zeta, data4D[0], &f0p); CHECKERROR(err);
+        err = spatial_interpolation_trilinear2(xsi, eta, zeta, data3D[0], &f0p); CHECKERROR(err);
         if (fabs(f0-f0p) > 1e-12){
           printf("error 0\n");
           return ERROR;
         }
 
         err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
-        err = spatial_interpolation_trilinear2(xsi, eta, zeta, data4D[1], &f1p); CHECKERROR(err);
+        err = spatial_interpolation_trilinear2(xsi, eta, zeta, data3D[1], &f1p); CHECKERROR(err);
         if (fabs(f1-f1p) > 1e-12){
           printf("error 0\n");
           return ERROR;
@@ -419,13 +419,13 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
     else if  (interp_method == NEAREST){
       if (grid->zdim==1){
         err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
-        err = spatial_interpolation_nearest2D2(xsi, eta, data3D[0], &f0p); CHECKERROR(err);
+        err = spatial_interpolation_nearest2D2(xsi, eta, data2D[0], &f0p); CHECKERROR(err);
         if (fabs(f0-f0p) > 1e-12){
           printf("error 1\n");
           return ERROR;
         }
         err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
-        err = spatial_interpolation_nearest2D2(xsi, eta, data3D[1], &f1p); CHECKERROR(err);
+        err = spatial_interpolation_nearest2D2(xsi, eta, data2D[1], &f1p); CHECKERROR(err);
         if (fabs(f1-f1p) > 1e-12){
           printf("error 1\n");
           return ERROR;
@@ -433,14 +433,14 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       } else {
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                               (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
-        err = spatial_interpolation_nearest3D2(xsi, eta, zeta, data4D[0], &f0p); CHECKERROR(err);
+        err = spatial_interpolation_nearest3D2(xsi, eta, zeta, data3D[0], &f0p); CHECKERROR(err);
         if (fabs(f0-f0p) > 1e-12){
           printf("error 1\n");
           return ERROR;
         }
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                               (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
-        err = spatial_interpolation_nearest3D2(xsi, eta, zeta, data4D[1], &f1p); CHECKERROR(err);
+        err = spatial_interpolation_nearest3D2(xsi, eta, zeta, data3D[1], &f1p); CHECKERROR(err);
         if (fabs(f1-f1p) > 1e-12){
           printf("error 1\n");
           return ERROR;
@@ -450,13 +450,13 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
     else if  ((interp_method == CGRID_TRACER) || (interp_method == BGRID_TRACER)){
       if (grid->zdim==1){
         err = spatial_interpolation_tracer_c_grid_2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0);
-        err = spatial_interpolation_tracer_c_grid_2D2(data3D[0], &f0);
+        err = spatial_interpolation_tracer_c_grid_2D2(data2D[0], &f0);
         if (fabs(f0-f0p) > 1e-12){
           printf("error 1\n");
           return ERROR;
         }
         err = spatial_interpolation_tracer_c_grid_2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]+1]), &f1);
-        err = spatial_interpolation_tracer_c_grid_2D2(data3D[1], &f1);
+        err = spatial_interpolation_tracer_c_grid_2D2(data2D[1], &f1);
         if (fabs(f1-f1p) > 1e-12){
           printf("error 1\n");
           return ERROR;
@@ -464,14 +464,14 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       } else {
         err = spatial_interpolation_tracer_c_grid_3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                               (float**)(data[ti[igrid]]), &f0);
-        err = spatial_interpolation_tracer_c_grid_3D2(data4D[0], &f0p);
+        err = spatial_interpolation_tracer_c_grid_3D2(data3D[0], &f0p);
         if (fabs(f0-f0p) > 1e-12){
           printf("error 1\n");
           return ERROR;
         }
         err = spatial_interpolation_tracer_c_grid_3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                               (float**)(data[ti[igrid]+1]), &f1);
-        err = spatial_interpolation_tracer_c_grid_3D2(data4D[1], &f1p);
+        err = spatial_interpolation_tracer_c_grid_3D2(data3D[1], &f1p);
         if (fabs(f1-f1p) > 1e-12){
           printf("error 1\n");
           return ERROR;
@@ -487,9 +487,9 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
     double t0 = grid->time[ti[igrid]];
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], t0, t0, t0+1, interp_method); CHECKERROR(err);
     if (grid->zdim==1){
-      err = getCell2D(f, xi[igrid], yi[igrid], ti[igrid], data3D, 1); CHECKERROR(err);
+      err = getCell2D(f, xi[igrid], yi[igrid], ti[igrid], data2D, 1); CHECKERROR(err);
     } else{
-      err = getCell3D(f, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D, 1); CHECKERROR(err);
+      err = getCell3D(f, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D, 1); CHECKERROR(err);
     }
     if ((interp_method == LINEAR) || (interp_method == CGRID_VELOCITY) || (interp_method == BGRID_VELOCITY) ||(interp_method == BGRID_W_VELOCITY)){
       if ((interp_method == CGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)){ // interpolate w
@@ -503,7 +503,7 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       }    
       if (grid->zdim==1){
         err = spatial_interpolation_bilinear(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value); CHECKERROR(err);
-        err = spatial_interpolation_bilinear2(xsi, eta, data3D[0], &valuep); CHECKERROR(err);
+        err = spatial_interpolation_bilinear2(xsi, eta, data2D[0], &valuep); CHECKERROR(err);
         if (fabs(*value-valuep) > 1e-12){
           printf("error 2 %g %g\n", *value, valuep);
           return ERROR;
@@ -512,7 +512,7 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       else{
         err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                              (float**)(data[ti[igrid]]), value); CHECKERROR(err);
-        err = spatial_interpolation_trilinear2(xsi, eta, zeta, data4D[0], &valuep); CHECKERROR(err);
+        err = spatial_interpolation_trilinear2(xsi, eta, zeta, data3D[0], &valuep); CHECKERROR(err);
         if (fabs(*value-valuep) > 1e-12){
           printf("error 2 %g %g\n", *value, valuep);
           return ERROR;
@@ -522,7 +522,7 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
     else if (interp_method == NEAREST){
       if (grid->zdim==1){
         err = spatial_interpolation_nearest2D(xsi, eta, xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value); CHECKERROR(err);
-        err = spatial_interpolation_nearest2D2(xsi, eta, data3D[0], &valuep); CHECKERROR(err);
+        err = spatial_interpolation_nearest2D2(xsi, eta, data2D[0], &valuep); CHECKERROR(err);
         if (fabs(*value-valuep) > 1e-12){
           printf("error 2\n");
           return ERROR;
@@ -531,7 +531,7 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       else {
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                              (float**)(data[ti[igrid]]), value); CHECKERROR(err);
-        err = spatial_interpolation_nearest3D2(xsi, eta, zeta, data4D[0], &value); CHECKERROR(err);
+        err = spatial_interpolation_nearest3D2(xsi, eta, zeta, data3D[0], &value); CHECKERROR(err);
         if (fabs(*value-valuep) > 1e-12){
           printf("error 2\n");
           return ERROR;
@@ -541,7 +541,7 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
     else if ((interp_method == CGRID_TRACER) || (interp_method == BGRID_TRACER)){
       if (grid->zdim==1){
         err = spatial_interpolation_tracer_c_grid_2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), value);
-        err = spatial_interpolation_tracer_c_grid_2D2(data3D[0], &valuep);
+        err = spatial_interpolation_tracer_c_grid_2D2(data2D[0], &valuep);
         if (fabs(*value-valuep) > 1e-12){
           printf("error 2\n");
           return ERROR;
@@ -550,7 +550,7 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       else {
         err = spatial_interpolation_tracer_c_grid_3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                              (float**)(data[ti[igrid]]), value);
-        err = spatial_interpolation_tracer_c_grid_3D2(data4D[0], &valuep);
+        err = spatial_interpolation_tracer_c_grid_3D2(data3D[0], &valuep);
       }
     }
     else {
@@ -756,30 +756,30 @@ static inline ErrorCode temporal_interpolationUV_c_grid(type_coord x, type_coord
     /* Identify grid cell to sample through local linear search */
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], time, t0, t1, CGRID_VELOCITY); CHECKERROR(err);
     if (grid->zdim==1){
-      float data3D_U[2][2][2], data3D_V[2][2][2];
+      float data2D_U[2][2][2], data2D_V[2][2][2];
       float u0p, u1p, v0p, v1p;
-      err = getCell2D(U, xi[igrid], yi[igrid], ti[igrid], data3D_U, 0); CHECKERROR(err);
-      err = getCell2D(V, xi[igrid], yi[igrid], ti[igrid], data3D_V, 0); CHECKERROR(err);
+      err = getCell2D(U, xi[igrid], yi[igrid], ti[igrid], data2D_U, 0); CHECKERROR(err);
+      err = getCell2D(V, xi[igrid], yi[igrid], ti[igrid], data2D_V, 0); CHECKERROR(err);
       err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]])  , (float**)(dataV[ti[igrid]]),   &u0, &v0); CHECKERROR(err);
       err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1]), (float**)(dataV[ti[igrid]+1]), &u1, &v1); CHECKERROR(err);
 
-      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data3D_U[0], data3D_V[0], &u0p, &v0p); CHECKERROR(err);
-      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data3D_U[1], data3D_V[1], &u1p, &v1p); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data2D_U[0], data2D_V[0], &u0p, &v0p); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data2D_U[1], data2D_V[1], &u1p, &v1p); CHECKERROR(err);
       if ( (fabs(u0-u0p) > 1e-12) || (fabs(u1-u1p) > 1e-12) ||(fabs(v0-v0p) > 1e-12) || (fabs(v1-v1p) > 1e-12) ) {
         printf("error uv c 0\n");
         return ERROR;
       }
 
     } else {
-      float data4D_U[2][2][2][2], data4D_V[2][2][2][2];
+      float data3D_U[2][2][2][2], data3D_V[2][2][2][2];
       float u0p, u1p, v0p, v1p;
-      err = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_U, 0); CHECKERROR(err);
-      err = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_V, 0); CHECKERROR(err);
+      err = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_U, 0); CHECKERROR(err);
+      err = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_V, 0); CHECKERROR(err);
       err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]),   &u0, &v0); CHECKERROR(err);
       err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1][zi[igrid]]), (float**)(dataV[ti[igrid]+1][zi[igrid]]), &u1, &v1); CHECKERROR(err);
 
-      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data4D_U[0][0], data4D_V[0][0], &u0p, &v0p); CHECKERROR(err);
-      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data4D_U[1][0], data4D_V[1][0], &u1p, &v1p); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data3D_U[0][0], data3D_V[0][0], &u0p, &v0p); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data3D_U[1][0], data3D_V[1][0], &u1p, &v1p); CHECKERROR(err);
       if ( (fabs(u0-u0p) > 1e-12) || (fabs(u1-u1p) > 1e-12) ||(fabs(v0-v0p) > 1e-12) || (fabs(v1-v1p) > 1e-12) ) {
         printf("error uv c 0\n");
         return ERROR;
@@ -792,24 +792,24 @@ static inline ErrorCode temporal_interpolationUV_c_grid(type_coord x, type_coord
     double t0 = grid->time[ti[igrid]];
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], t0, t0, t0+1, CGRID_VELOCITY); CHECKERROR(err);
     if (grid->zdim==1){
-      float data3D_U[2][2][2], data3D_V[2][2][2];
+      float data2D_U[2][2][2], data2D_V[2][2][2];
       float up, vp;
-      err = getCell2D(U, xi[igrid], yi[igrid], ti[igrid], data3D_U, 1); CHECKERROR(err);
-      err = getCell2D(V, xi[igrid], yi[igrid], ti[igrid], data3D_V, 1); CHECKERROR(err);
+      err = getCell2D(U, xi[igrid], yi[igrid], ti[igrid], data2D_U, 1); CHECKERROR(err);
+      err = getCell2D(V, xi[igrid], yi[igrid], ti[igrid], data2D_V, 1); CHECKERROR(err);
       err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]])  , (float**)(dataV[ti[igrid]]), u, v); CHECKERROR(err);
-      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data3D_U[0], data3D_V[0], &up, &vp); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data2D_U[0], data2D_V[0], &up, &vp); CHECKERROR(err);
       if ( (fabs(*u-up) > 1e-12) || (fabs(*v-vp) > 1e-12)  ) {
         printf("error uv c 1\n");
         return ERROR;
       }
     }
     else{
-      float data4D_U[2][2][2][2], data4D_V[2][2][2][2];
+      float data3D_U[2][2][2][2], data3D_V[2][2][2][2];
       float up, vp;
-      err = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_U, 1); CHECKERROR(err);
-      err = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_V, 1); CHECKERROR(err);
+      err = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_U, 1); CHECKERROR(err);
+      err = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_V, 1); CHECKERROR(err);
       err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]), u, v); CHECKERROR(err);
-      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data4D_U[0][0], data4D_V[0][0], &up, &vp); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data3D_U[0][0], data3D_V[0][0], &up, &vp); CHECKERROR(err);
       if ( (fabs(*u-up) > 1e-12) || (fabs(*v-vp) > 1e-12)  ) {
         printf("error uv c 1\n");
         return ERROR;
@@ -1112,9 +1112,9 @@ static inline ErrorCode temporal_interpolationUVW_c_grid(type_coord x, type_coor
   float (*dataV)[V->zdim][V->ydim][V->xdim] = (float (*)[V->zdim][V->ydim][V->xdim]) V->data;
   float (*dataW)[W->zdim][W->ydim][W->xdim] = (float (*)[W->zdim][W->ydim][W->xdim]) W->data;
   double xsi, eta, zet;
-  float data4D_U[2][2][2][2];
-  float data4D_V[2][2][2][2];
-  float data4D_W[2][2][2][2];
+  float data3D_U[2][2][2][2];
+  float data3D_V[2][2][2][2];
+  float data3D_W[2][2][2][2];
   float u0p, u1p, v0p, v1p, w0p, w1p, up, vp, wp;
 
 
@@ -1123,17 +1123,17 @@ static inline ErrorCode temporal_interpolationUVW_c_grid(type_coord x, type_coor
     double t0 = grid->time[ti[igrid]]; double t1 = grid->time[ti[igrid]+1];
     /* Identify grid cell to sample through local linear search */
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zet, gcode, ti[igrid], time, t0, t1, CGRID_VELOCITY); CHECKERROR(err);
-    err = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_U, 0); CHECKERROR(err);
-    err = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_V, 0); CHECKERROR(err);
-    err = getCell3D(W, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_W, 0); CHECKERROR(err);
+    err = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_U, 0); CHECKERROR(err);
+    err = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_V, 0); CHECKERROR(err);
+    err = getCell3D(W, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_W, 0); CHECKERROR(err);
     if (grid->zdim==1){
       return ERROR;
     } else {
       err = spatial_interpolation_UVW_c_grid(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid]  , grid, gcode, (float**)(dataU[ti[igrid]])  , (float**)(dataV[ti[igrid]]),   (float**)(dataW[ti[igrid]]),   &u0, &v0, &w0); CHECKERROR(err);
       err = spatial_interpolation_UVW_c_grid(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid]+1, grid, gcode, (float**)(dataU[ti[igrid]+1]), (float**)(dataV[ti[igrid]+1]), (float**)(dataW[ti[igrid]+1]), &u1, &v1, &w1); CHECKERROR(err);
 
-      err = spatial_interpolation_UVW_c_grid2(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid],   grid, gcode, data4D_U[0], data4D_V[0], data4D_W[0], &u0p, &v0p, &w0p); CHECKERROR(err);
-      err = spatial_interpolation_UVW_c_grid2(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid]+1, grid, gcode, data4D_U[1], data4D_V[1], data4D_W[1], &u1p, &v1p, &w1p); CHECKERROR(err);
+      err = spatial_interpolation_UVW_c_grid2(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid],   grid, gcode, data3D_U[0], data3D_V[0], data3D_W[0], &u0p, &v0p, &w0p); CHECKERROR(err);
+      err = spatial_interpolation_UVW_c_grid2(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid]+1, grid, gcode, data3D_U[1], data3D_V[1], data3D_W[1], &u1p, &v1p, &w1p); CHECKERROR(err);
       if ( (fabs(u0-u0p) > 1e-12) || (fabs(u1-u1p) > 1e-12) || (fabs(v0-v0p) > 1e-12) || (fabs(v1-v1p) > 1e-12) || (fabs(w0-w0p) > 1e-12) || (fabs(w1-w1p) > 1e-12)) {
         printf("error uvw c 0\n");
         return ERROR;
@@ -1146,16 +1146,16 @@ static inline ErrorCode temporal_interpolationUVW_c_grid(type_coord x, type_coor
   } else {
     double t0 = grid->time[ti[igrid]];
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zet, gcode, ti[igrid], t0, t0, t0+1, CGRID_VELOCITY); CHECKERROR(err);
-    err = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_U, 1); CHECKERROR(err);
-    err = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_V, 1); CHECKERROR(err);
-    err = getCell3D(W, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_W, 1); CHECKERROR(err);
+    err = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_U, 1); CHECKERROR(err);
+    err = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_V, 1); CHECKERROR(err);
+    err = getCell3D(W, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_W, 1); CHECKERROR(err);
     if (grid->zdim==1){
       return ERROR;
     }
     else{
       err = spatial_interpolation_UVW_c_grid(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid], grid, gcode, (float**)(dataU[ti[igrid]]), (float**)(dataV[ti[igrid]]), (float**)(dataW[ti[igrid]]), u, v, w); CHECKERROR(err);
 
-      err = spatial_interpolation_UVW_c_grid2(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid], grid, gcode, data4D_U[0], data4D_V[0], data4D_W[0], &up, &vp, &wp); CHECKERROR(err);
+      err = spatial_interpolation_UVW_c_grid2(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid], grid, gcode, data3D_U[0], data3D_V[0], data3D_W[0], &up, &vp, &wp); CHECKERROR(err);
       if ( (fabs(*u-up) > 1e-12) || (fabs(*v-vp) > 1e-12) || (fabs(*w-wp) > 1e-12) ) {
         printf("error uvw c 1\n");
         return ERROR;

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -184,11 +184,12 @@ static inline ErrorCode getCell3D(CField *f, int xi, int yi, int ti, float cell_
   int tii, yii, xii;
 
   int blockid = getBlock3D(chunk_info, ti, yi, xi, block, ilocal);
-  if (grid->load_chunk[blockid] != 1){
-    grid->load_chunk[blockid] = 2;
+  if (grid->load_chunk[blockid] < 2){
+    grid->load_chunk[blockid] = 1;
     //printf("CHUNK NOT LOADED\n");
     return REPEAT;
   }
+  grid->load_chunk[blockid] = 2;
   int tdim = chunk_info[1+2*ndim+block[0]];
   int zdim = 1;
   int tshift = chunk_info[1+ndim];
@@ -203,11 +204,12 @@ static inline ErrorCode getCell3D(CField *f, int xi, int yi, int ti, float cell_
       for (yii=0; yii<2; ++yii){
         for (xii=0; xii<2; ++xii){
           blockid = getBlock3D(chunk_info, ti+tii, yi+yii, xi+xii, block, ilocal);
-          if (grid->load_chunk[blockid] != 1){
-            grid->load_chunk[blockid] = 2;
+          if (grid->load_chunk[blockid] < 1){
+            grid->load_chunk[blockid] = 1;
             //printf("CHUNK NOT LOADED\n");
             return REPEAT;
           }
+          grid->load_chunk[blockid] = 2;
           tdim = chunk_info[1+2*ndim+block[0]];
           tshift = chunk_info[1+ndim];
           ydim = chunk_info[1+2*ndim+tshift+block[1]];
@@ -271,11 +273,11 @@ static inline ErrorCode getCell4D(CField *f, int xi, int yi, int zi, int ti, flo
   int tii, zii, yii, xii;
 
   int blockid = getBlock4D(chunk_info, ti, zi, yi, xi, block, ilocal);
-  if (grid->load_chunk[blockid] != 1){
-    grid->load_chunk[blockid] = 2;
-    //printf("CHUNK NOT LOADED\n");
+  if (grid->load_chunk[blockid] < 2){
+    grid->load_chunk[blockid] = 1;
     return REPEAT;
   }
+  grid->load_chunk[blockid] = 2;
   int tdim = chunk_info[1+2*ndim+block[0]];
   int tshift = chunk_info[1+ndim];
   int zdim = chunk_info[1+2*ndim+tshift+block[1]];
@@ -292,11 +294,12 @@ static inline ErrorCode getCell4D(CField *f, int xi, int yi, int zi, int ti, flo
         for (yii=0; yii<2; ++yii){
           for (xii=0; xii<2; ++xii){
             blockid = getBlock4D(chunk_info, ti+tii, zi+zii, yi+yii, xi+xii, block, ilocal);
-            if (grid->load_chunk[blockid] != 1){
-              grid->load_chunk[blockid] = 2;
+            if (grid->load_chunk[blockid] < 2){
+              grid->load_chunk[blockid] = 1;
               //printf("CHUNK NOT LOADED\n");
               return REPEAT;
             }
+            grid->load_chunk[blockid] = 2;
             tdim = chunk_info[1+2*ndim+block[0]];
             tshift = chunk_info[1+ndim];
             zdim = chunk_info[1+2*ndim+tshift+block[1]];

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -20,7 +20,6 @@ typedef struct
   float ***data;
   int *chunk_info;
   float ****data_chunks;
-  int *load_chunk;
   CGrid *grid;
 } CField;
 
@@ -118,6 +117,9 @@ static inline int find_block(int *chunk_info, int ti, int yi, int xi, int *block
   int bid =  block[0]*shape[1]*shape[2] +
              block[1]*shape[2]+
              block[2];
+
+
+
   return bid;
 }
 
@@ -127,10 +129,11 @@ static inline ErrorCode test_func(CField *f, double xsi, double eta, int xi, int
   int ndim = chunk_info[0];
   int block[ndim];
   int index_local[ndim];
+  CStructuredGrid *grid = f->grid->grid;
 
   int blockid = find_block(chunk_info, ti, yi, xi, block, index_local);
-  if (f->load_chunk[blockid] == 0){
-    f->load_chunk[blockid] = 1;
+  if (grid->load_chunk[blockid] == 0){
+    grid->load_chunk[blockid] = 1;
     printf("CHUNK NOT LOADED\n");
     return REPEAT;
   }

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -139,9 +139,9 @@ static inline ErrorCode getCell3D(CField *f, double xsi, double eta, int xi, int
   int tii, yii, xii;
 
   int blockid = getBlock3D(chunk_info, ti, yi, xi, block, ilocal);
-  if (grid->load_chunk[blockid] == 0){
-    grid->load_chunk[blockid] = 1;
-    printf("CHUNK NOT LOADED\n");
+  if (grid->load_chunk[blockid] != 1){
+    grid->load_chunk[blockid] = 2;
+    //printf("CHUNK NOT LOADED\n");
     return REPEAT;
   }
   int tdim = chunk_info[1+2*ndim+block[0]];
@@ -153,23 +153,22 @@ static inline ErrorCode getCell3D(CField *f, double xsi, double eta, int xi, int
 
   if (((ilocal[0] == tdim-1) && (first_tstep_only == 0)) || (ilocal[1] == ydim-1) || (ilocal[2] == xdim-1))
   {
-    printf("Cell is on multiple chunks\n");
+    //printf("Cell is on multiple chunks\n");
     for (tii=0; tii<2; ++tii){
       for (yii=0; yii<2; ++yii){
         for (xii=0; xii<2; ++xii){
           blockid = getBlock3D(chunk_info, ti+tii, yi+yii, xi+xii, block, ilocal);
-          if (grid->load_chunk[blockid] == 0){
-            grid->load_chunk[blockid] = 1;
-            printf("CHUNK NOT LOADED\n");
+          if (grid->load_chunk[blockid] != 1){
+            grid->load_chunk[blockid] = 2;
+            //printf("CHUNK NOT LOADED\n");
             return REPEAT;
           }
           tdim = chunk_info[1+2*ndim+block[0]];
-          zdim = 1;
           tshift = chunk_info[1+ndim];
           ydim = chunk_info[1+2*ndim+tshift+block[1]];
           yshift = chunk_info[1+ndim+1];
           xdim = chunk_info[1+2*ndim+1+yshift+block[2]];
-          float (*data_block)[1][ydim][xdim] = (float (*)[1][ydim][xdim]) f->data_chunks[blockid];
+          float (*data_block)[zdim][ydim][xdim] = (float (*)[zdim][ydim][xdim]) f->data_chunks[blockid];
           float (*data)[xdim] = (float (*)[xdim]) (data_block[ilocal[0]]);
           cell_data[tii][yii][xii] = data[ilocal[1]][ilocal[2]];
         }
@@ -180,7 +179,7 @@ static inline ErrorCode getCell3D(CField *f, double xsi, double eta, int xi, int
   }
   else
   {
-    float (*data_block)[1][ydim][xdim] = (float (*)[1][ydim][xdim]) f->data_chunks[blockid];
+    float (*data_block)[zdim][ydim][xdim] = (float (*)[zdim][ydim][xdim]) f->data_chunks[blockid];
     for (tii=0; tii<2; ++tii){
       float (*data)[xdim] = (float (*)[xdim]) (data_block[ilocal[0]+tii]);
       for (yii=0; yii<2; ++yii)

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -211,7 +211,7 @@ static inline ErrorCode getCell2D(CField *f, int xi, int yi, int ti, float cell_
       for (yii=0; yii<2; ++yii){
         for (xii=0; xii<2; ++xii){
           blockid = getBlock2D(chunk_info, yi+yii, xi+xii, block, ilocal);
-          if (grid->load_chunk[blockid] < 1){
+          if (grid->load_chunk[blockid] < 2){
             grid->load_chunk[blockid] = 1;
             //printf("CHUNK NOT LOADED\n");
             return REPEAT;

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -62,6 +62,21 @@ static inline ErrorCode spatial_interpolation_trilinear(double xsi, double eta, 
   *value = (1-zeta) * f0 + zeta * f1;
   return SUCCESS;
 }
+static inline ErrorCode spatial_interpolation_trilinear2(double xsi, double eta, double zeta,
+                                                        float data[2][2][2], float *value)
+{
+  float f0, f1;
+  f0 = (1-xsi)*(1-eta) * data[0][0][0]
+     +    xsi *(1-eta) * data[0][0][1]
+     +    xsi *   eta  * data[0][1][1]
+     + (1-xsi)*   eta  * data[0][1][0];
+  f1 = (1-xsi)*(1-eta) * data[1][0][0]
+     +    xsi *(1-eta) * data[1][0][1]
+     +    xsi *   eta  * data[1][1][1]
+     + (1-xsi)*   eta  * data[1][1][0];
+  *value = (1-zeta) * f0 + zeta * f1;
+  return SUCCESS;
+}
 
 /* Nearest neighbour interpolation routine for 2D grid */
 static inline ErrorCode spatial_interpolation_nearest2D(double xsi, double eta, int xi, int yi, int xdim,
@@ -112,6 +127,16 @@ static inline ErrorCode spatial_interpolation_nearest3D(double xsi, double eta, 
   *value = data[kk][jj][ii];
   return SUCCESS;
 }
+static inline ErrorCode spatial_interpolation_nearest3D2(double xsi, double eta, double zeta,
+                                                        float data[2][2][2], float *value)
+{
+  int i, j, k;
+  if (xsi < .5) {i = 0;} else {i = 1;}
+  if (eta < .5) {j = 0;} else {j = 1;}
+  if (zeta < .5) {k = 0;} else {k = 1;}
+  *value = data[k][j][i];
+  return SUCCESS;
+}
 
 /* C grid interpolation routine for tracers on 3D grid */
 static inline ErrorCode spatial_interpolation_tracer_c_grid_3D(int xi, int yi, int zi,
@@ -119,6 +144,11 @@ static inline ErrorCode spatial_interpolation_tracer_c_grid_3D(int xi, int yi, i
 {
   float (*data)[ydim][xdim] = (float (*)[ydim][xdim]) f_data;
   *value = data[zi][yi+1][xi+1];
+  return SUCCESS;
+}
+static inline ErrorCode spatial_interpolation_tracer_c_grid_3D2(float data[2][2][2], float *value)
+{
+  *value = data[0][1][1];
   return SUCCESS;
 }
 
@@ -182,7 +212,7 @@ static inline ErrorCode getCell3D(CField *f, int xi, int yi, int ti, float cell_
           tshift = chunk_info[1+ndim];
           ydim = chunk_info[1+2*ndim+tshift+block[1]];
           yshift = chunk_info[1+ndim+1];
-          xdim = chunk_info[1+2*ndim+1+yshift+block[2]];
+          xdim = chunk_info[1+2*ndim+tshift+yshift+block[2]];
           float (*data_block)[zdim][ydim][xdim] = (float (*)[zdim][ydim][xdim]) f->data_chunks[blockid];
           float (*data)[xdim] = (float (*)[xdim]) (data_block[ilocal[0]]);
           cell_data[tii][yii][xii] = data[ilocal[1]][ilocal[2]];
@@ -207,6 +237,101 @@ static inline ErrorCode getCell3D(CField *f, int xi, int yi, int ti, float cell_
   return SUCCESS;
 }
 
+static inline int getBlock4D(int *chunk_info, int ti, int zi, int yi, int xi, int *block, int *index_local)
+{
+  int ndim = chunk_info[0];
+  if (ndim != 4)
+    exit(-1);
+  int chunksize, i;
+  int shape[ndim];
+  int index[4] = {ti, zi, yi, xi};
+  for(i=0; i<ndim; ++i){
+    shape[i] = chunk_info[ndim+1+i];
+    chunksize = chunk_info[1+i];
+    block[i] = (int) index[i] / chunksize;
+    index_local[i] = index[i] - chunksize * block[i];
+  }
+
+  int bid =  block[0]*shape[1]*shape[2]*shape[3] +
+             block[1]*shape[2]*shape[3]+
+             block[2]*shape[3]+
+             block[3];
+  return bid;
+}
+
+
+static inline ErrorCode getCell4D(CField *f, int xi, int yi, int zi, int ti, float cell_data[2][2][2][2], int first_tstep_only)
+{
+  int *chunk_info = f->chunk_info;
+  int ndim = chunk_info[0];
+  int block[ndim];
+  int ilocal[ndim];
+  CStructuredGrid *grid = f->grid->grid;
+
+  int tii, zii, yii, xii;
+
+  int blockid = getBlock4D(chunk_info, ti, zi, yi, xi, block, ilocal);
+  if (grid->load_chunk[blockid] != 1){
+    grid->load_chunk[blockid] = 2;
+    //printf("CHUNK NOT LOADED\n");
+    return REPEAT;
+  }
+  int tdim = chunk_info[1+2*ndim+block[0]];
+  int tshift = chunk_info[1+ndim];
+  int zdim = chunk_info[1+2*ndim+tshift+block[1]];
+  int zshift = chunk_info[1+ndim+1];
+  int ydim = chunk_info[1+2*ndim+tshift+zshift+block[2]];
+  int yshift = chunk_info[1+ndim+2];
+  int xdim = chunk_info[1+2*ndim+tshift+zshift+yshift+block[3]];
+
+  if (((ilocal[0] == tdim-1) && (first_tstep_only == 0)) || (ilocal[1] == zdim-1) || (ilocal[2] == ydim-1) || (ilocal[3] == xdim-1))
+  {
+    //printf("Cell is on multiple chunks\n");
+    for (tii=0; tii<2; ++tii){
+      for (zii=0; zii<2; ++zii){
+        for (yii=0; yii<2; ++yii){
+          for (xii=0; xii<2; ++xii){
+            blockid = getBlock4D(chunk_info, ti+tii, zi+zii, yi+yii, xi+xii, block, ilocal);
+            if (grid->load_chunk[blockid] != 1){
+              grid->load_chunk[blockid] = 2;
+              //printf("CHUNK NOT LOADED\n");
+              return REPEAT;
+            }
+            tdim = chunk_info[1+2*ndim+block[0]];
+            tshift = chunk_info[1+ndim];
+            zdim = chunk_info[1+2*ndim+tshift+block[1]];
+            zshift = chunk_info[1+ndim+1];
+            ydim = chunk_info[1+2*ndim+tshift+zshift+block[2]];
+            yshift = chunk_info[1+ndim+2];
+            xdim = chunk_info[1+2*ndim+tshift+zshift+yshift+block[3]];
+
+            float (*data_block)[zdim][ydim][xdim] = (float (*)[zdim][ydim][xdim]) f->data_chunks[blockid];
+            float (*data)[ydim][xdim] = (float (*)[ydim][xdim]) (data_block[ilocal[0]]);
+            cell_data[tii][zii][yii][xii] = data[ilocal[1]][ilocal[2]][ilocal[3]];
+          }
+        }
+      }
+      if (first_tstep_only == 1)
+         break;
+    }
+  }
+  else
+  {
+    float (*data_block)[zdim][ydim][xdim] = (float (*)[zdim][ydim][xdim]) f->data_chunks[blockid];
+    for (tii=0; tii<2; ++tii){
+      float (*data)[ydim][xdim] = (float (*)[ydim][xdim]) (data_block[ilocal[0]+tii]);
+      for (zii=0; zii<2; ++zii)
+        for (yii=0; yii<2; ++yii)
+          for (xii=0; xii<2; ++xii)
+            cell_data[tii][zii][yii][xii] = data[ilocal[1]+zii][ilocal[2]+yii][ilocal[3]+xii];
+      if (first_tstep_only == 1)
+         break;
+    }
+  }
+  return SUCCESS;
+}
+
+
 /* Linear interpolation along the time axis */
 static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, type_coord y, type_coord z, double time, CField *f,
                                                                GridCode gcode, int *xi, int *yi, int *zi, int *ti,
@@ -227,6 +352,7 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
   double xsi, eta, zeta;
 
   float data3D[2][2][2];
+  float data4D[2][2][2][2];
   float f0p, f1p;
   float valuep;
 
@@ -236,8 +362,11 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
     double t0 = grid->time[ti[igrid]]; double t1 = grid->time[ti[igrid]+1];
     /* Identify grid cell to sample through local linear search */
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], time, t0, t1, interp_method); CHECKERROR(err);
-    if (grid->zdim==1)
+    if (grid->zdim==1){
       err = getCell3D(f, xi[igrid], yi[igrid], ti[igrid], data3D, 0); CHECKERROR(err);
+    } else{
+      err = getCell4D(f, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D, 0); CHECKERROR(err);
+    }
     if ((interp_method == LINEAR) || (interp_method == CGRID_VELOCITY) || (interp_method == BGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)){
       if ((interp_method == CGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)){ // interpolate w
         xsi = 1;
@@ -261,7 +390,18 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
         }
       } else {
         err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
+        err = spatial_interpolation_trilinear2(xsi, eta, zeta, data4D[0], &f0p); CHECKERROR(err);
+        if (fabs(f0-f0p) > 1e-12){
+          printf("error 0\n");
+          return ERROR;
+        }
+
         err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim, (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
+        err = spatial_interpolation_trilinear2(xsi, eta, zeta, data4D[1], &f1p); CHECKERROR(err);
+        if (fabs(f1-f1p) > 1e-12){
+          printf("error 0\n");
+          return ERROR;
+        }
       }
     }
     else if  (interp_method == NEAREST){
@@ -281,11 +421,21 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       } else {
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                               (float**)(data[ti[igrid]]), &f0); CHECKERROR(err);
+        err = spatial_interpolation_nearest3D2(xsi, eta, zeta, data4D[0], &f0p); CHECKERROR(err);
+        if (fabs(f0-f0p) > 1e-12){
+          printf("error 1\n");
+          return ERROR;
+        }
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                               (float**)(data[ti[igrid]+1]), &f1); CHECKERROR(err);
+        err = spatial_interpolation_nearest3D2(xsi, eta, zeta, data4D[1], &f1p); CHECKERROR(err);
+        if (fabs(f1-f1p) > 1e-12){
+          printf("error 1\n");
+          return ERROR;
+        }
       }
     }
-	else if  ((interp_method == CGRID_TRACER) || (interp_method == BGRID_TRACER)){
+    else if  ((interp_method == CGRID_TRACER) || (interp_method == BGRID_TRACER)){
       if (grid->zdim==1){
         err = spatial_interpolation_tracer_c_grid_2D(xi[igrid], yi[igrid], grid->xdim, (float**)(data[ti[igrid]]), &f0);
         err = spatial_interpolation_tracer_c_grid_2D2(data3D[0], &f0);
@@ -302,8 +452,18 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       } else {
         err = spatial_interpolation_tracer_c_grid_3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                               (float**)(data[ti[igrid]]), &f0);
+        err = spatial_interpolation_tracer_c_grid_3D2(data4D[0], &f0p);
+        if (fabs(f0-f0p) > 1e-12){
+          printf("error 1\n");
+          return ERROR;
+        }
         err = spatial_interpolation_tracer_c_grid_3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                               (float**)(data[ti[igrid]+1]), &f1);
+        err = spatial_interpolation_tracer_c_grid_3D2(data4D[1], &f1p);
+        if (fabs(f1-f1p) > 1e-12){
+          printf("error 1\n");
+          return ERROR;
+        }
       }
     }
     else {
@@ -314,8 +474,11 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
   } else {
     double t0 = grid->time[ti[igrid]];
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], t0, t0, t0+1, interp_method); CHECKERROR(err);
-    if (grid->zdim==1)
+    if (grid->zdim==1){
       err = getCell3D(f, xi[igrid], yi[igrid], ti[igrid], data3D, 1); CHECKERROR(err);
+    } else{
+      err = getCell4D(f, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D, 1); CHECKERROR(err);
+    }
     if ((interp_method == LINEAR) || (interp_method == CGRID_VELOCITY) || (interp_method == BGRID_VELOCITY) ||(interp_method == BGRID_W_VELOCITY)){
       if ((interp_method == CGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)){ // interpolate w
         xsi = 1;
@@ -337,6 +500,11 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       else{
         err = spatial_interpolation_trilinear(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                              (float**)(data[ti[igrid]]), value); CHECKERROR(err);
+        err = spatial_interpolation_trilinear2(xsi, eta, zeta, data4D[0], &valuep); CHECKERROR(err);
+        if (fabs(*value-valuep) > 1e-12){
+          printf("error 2 %g %g\n", *value, valuep);
+          return ERROR;
+        }
       }
     }
     else if (interp_method == NEAREST){
@@ -351,6 +519,11 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       else {
         err = spatial_interpolation_nearest3D(xsi, eta, zeta, xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                              (float**)(data[ti[igrid]]), value); CHECKERROR(err);
+        err = spatial_interpolation_nearest3D2(xsi, eta, zeta, data4D[0], &value); CHECKERROR(err);
+        if (fabs(*value-valuep) > 1e-12){
+          printf("error 2\n");
+          return ERROR;
+        }
       }
     }
     else if ((interp_method == CGRID_TRACER) || (interp_method == BGRID_TRACER)){
@@ -365,6 +538,7 @@ static inline ErrorCode temporal_interpolation_structured_grid(type_coord x, typ
       else {
         err = spatial_interpolation_tracer_c_grid_3D(xi[igrid], yi[igrid], zi[igrid], grid->xdim, grid->ydim,
                                              (float**)(data[ti[igrid]]), value);
+        err = spatial_interpolation_tracer_c_grid_3D2(data4D[0], &valuep);
       }
     }
     else {
@@ -585,8 +759,19 @@ static inline ErrorCode temporal_interpolationUV_c_grid(type_coord x, type_coord
       }
 
     } else {
+      float data4D_U[2][2][2][2], data4D_V[2][2][2][2];
+      float u0p, u1p, v0p, v1p;
+      err = getCell4D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_U, 0); CHECKERROR(err);
+      err = getCell4D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_V, 0); CHECKERROR(err);
       err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]),   &u0, &v0); CHECKERROR(err);
       err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1][zi[igrid]]), (float**)(dataV[ti[igrid]+1][zi[igrid]]), &u1, &v1); CHECKERROR(err);
+
+      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data4D_U[0][0], data4D_V[0][0], &u0p, &v0p); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data4D_U[1][0], data4D_V[1][0], &u1p, &v1p); CHECKERROR(err);
+      if ( (fabs(u0-u0p) > 1e-12) || (fabs(u1-u1p) > 1e-12) ||(fabs(v0-v0p) > 1e-12) || (fabs(v1-v1p) > 1e-12) ) {
+        printf("error uv c 0\n");
+        return ERROR;
+      }
     }
     *u = u0 + (u1 - u0) * (float)((time - t0) / (t1 - t0));
     *v = v0 + (v1 - v0) * (float)((time - t0) / (t1 - t0));
@@ -607,7 +792,16 @@ static inline ErrorCode temporal_interpolationUV_c_grid(type_coord x, type_coord
       }
     }
     else{
+      float data4D_U[2][2][2][2], data4D_V[2][2][2][2];
+      float up, vp;
+      err = getCell4D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_U, 1); CHECKERROR(err);
+      err = getCell4D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_V, 1); CHECKERROR(err);
       err = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gcode, (float**)(dataU[ti[igrid]][zi[igrid]])  , (float**)(dataV[ti[igrid]][zi[igrid]]), u, v); CHECKERROR(err);
+      err = spatial_interpolation_UV_c_grid2(xsi, eta, xi[igrid], yi[igrid], grid, gcode, data4D_U[0][0], data4D_V[0][0], &up, &vp); CHECKERROR(err);
+      if ( (fabs(*u-up) > 1e-12) || (fabs(*v-vp) > 1e-12)  ) {
+        printf("error uv c 1\n");
+        return ERROR;
+      }
     }
     return SUCCESS;
   }
@@ -752,6 +946,141 @@ static inline ErrorCode spatial_interpolation_UVW_c_grid(double xsi, double eta,
   return SUCCESS;
 }
 
+static inline ErrorCode spatial_interpolation_UVW_c_grid2(double xsi, double eta, double zet, int xi, int yi, int zi, int ti, CStructuredGrid *grid,
+                                                        GridCode gcode, float dataU[2][2][2], float dataV[2][2][2], float dataW[2][2][2], float *u, float *v, float *w)
+{
+  /* Cast data array into data[lat][lon] as per NEMO convention */
+  int xdim = grid->xdim;
+  int ydim = grid->ydim;
+  int zdim = grid->zdim;
+
+  float xgrid_loc[4];
+  float ygrid_loc[4];
+  int iN;
+  if( gcode == RECTILINEAR_S_GRID ){
+    float *xgrid = grid->lon;
+    float *ygrid = grid->lat;
+    for (iN=0; iN < 4; ++iN){
+      xgrid_loc[iN] = xgrid[xi+min(1, (iN%3))];
+      ygrid_loc[iN] = ygrid[yi+iN/2];
+    }
+  }
+  else{
+    float (* xgrid)[xdim] = (float (*)[xdim]) grid->lon;
+    float (* ygrid)[xdim] = (float (*)[xdim]) grid->lat;
+    for (iN=0; iN < 4; ++iN){
+      xgrid_loc[iN] = xgrid[yi+iN/2][xi+min(1, (iN%3))];
+      ygrid_loc[iN] = ygrid[yi+iN/2][xi+min(1, (iN%3))];
+    }
+  }
+  int i4;
+  for (i4 = 1; i4 < 4; ++i4){
+    if (xgrid_loc[i4] < xgrid_loc[0] - 180) xgrid_loc[i4] += 360;
+    if (xgrid_loc[i4] > xgrid_loc[0] + 180) xgrid_loc[i4] -= 360;
+  }
+
+  float u0 = dataU[0][1][0];
+  float u1 = dataU[0][1][1];
+  float v0 = dataV[0][0][1];
+  float v1 = dataV[0][1][1];
+  float w0 = dataW[0][1][1];
+  float w1 = dataW[1][1][1];
+
+  double px[8] = {xgrid_loc[0], xgrid_loc[1], xgrid_loc[2], xgrid_loc[3],
+                  xgrid_loc[0], xgrid_loc[1], xgrid_loc[2], xgrid_loc[3]};
+  double py[8] = {ygrid_loc[0], ygrid_loc[1], ygrid_loc[2], ygrid_loc[3],
+                  ygrid_loc[0], ygrid_loc[1], ygrid_loc[2], ygrid_loc[3]};
+  double pz[8];
+  if (grid->z4d == 1){
+    float (*zvals)[zdim][ydim][xdim] = (float (*)[zdim][ydim][xdim]) grid->depth;
+    for (iN=0; iN < 4; ++iN){
+      pz[iN] = zvals[ti][zi][yi+iN/2][xi+min(1, (iN%3))];
+      pz[iN+4] = zvals[ti][zi+1][yi+iN/2][xi+min(1, (iN%3))];
+    }
+  }
+  else{
+    float (*zvals)[ydim][xdim] = (float (*)[zdim][ydim][xdim]) grid->depth;
+    for (iN=0; iN < 4; ++iN){
+      pz[iN] = zvals[zi][yi+iN/2][xi+min(1, (iN%3))];
+      pz[iN+4] = zvals[zi+1][yi+iN/2][xi+min(1, (iN%3))];
+    }
+  }
+
+  double U0 = u0 * jacobian3D_lin_face(px, py, pz, 0, eta, zet, ZONAL, grid->sphere_mesh);
+  double U1 = u1 * jacobian3D_lin_face(px, py, pz, 1, eta, zet, ZONAL, grid->sphere_mesh);
+  double V0 = v0 * jacobian3D_lin_face(px, py, pz, xsi, 0, zet, MERIDIONAL, grid->sphere_mesh);
+  double V1 = v1 * jacobian3D_lin_face(px, py, pz, xsi, 1, zet, MERIDIONAL, grid->sphere_mesh);
+  double W0 = w0 * jacobian3D_lin_face(px, py, pz, xsi, eta, 0, VERTICAL, grid->sphere_mesh);
+  double W1 = w1 * jacobian3D_lin_face(px, py, pz, xsi, eta, 1, VERTICAL, grid->sphere_mesh);
+
+  // Computing fluxes in half left hexahedron -> flux_u05
+  double xxu[8] = {px[0], (px[0]+px[1])/2, (px[2]+px[3])/2, px[3], px[4], (px[4]+px[5])/2, (px[6]+px[7])/2, px[7]};
+  double yyu[8] = {py[0], (py[0]+py[1])/2, (py[2]+py[3])/2, py[3], py[4], (py[4]+py[5])/2, (py[6]+py[7])/2, py[7]};
+  double zzu[8] = {pz[0], (pz[0]+pz[1])/2, (pz[2]+pz[3])/2, pz[3], pz[4], (pz[4]+pz[5])/2, (pz[6]+pz[7])/2, pz[7]};
+  double flux_u0 = u0 * jacobian3D_lin_face(xxu, yyu, zzu, 0, .5, .5, ZONAL, grid->sphere_mesh);
+  double flux_v0_halfx = v0 * jacobian3D_lin_face(xxu, yyu, zzu, .5, 0, .5, MERIDIONAL, grid->sphere_mesh);
+  double flux_v1_halfx = v1 * jacobian3D_lin_face(xxu, yyu, zzu, .5, 1, .5, MERIDIONAL, grid->sphere_mesh);
+  double flux_w0_halfx = w0 * jacobian3D_lin_face(xxu, yyu, zzu, .5, .5, 0, VERTICAL, grid->sphere_mesh);
+  double flux_w1_halfx = w1 * jacobian3D_lin_face(xxu, yyu, zzu, .5, .5, 1, VERTICAL, grid->sphere_mesh);
+  double flux_u05 = flux_u0 + flux_v0_halfx - flux_v1_halfx + flux_w0_halfx - flux_w1_halfx;
+
+  // Computing fluxes in half front hexahedron -> flux_v05
+  double xxv[8] = {px[0], px[1], (px[1]+px[2])/2, (px[0]+px[3])/2, px[4], px[5], (px[5]+px[6])/2, (px[4]+px[7])/2};
+  double yyv[8] = {py[0], py[1], (py[1]+py[2])/2, (py[0]+py[3])/2, py[4], py[5], (py[5]+py[6])/2, (py[4]+py[7])/2};
+  double zzv[8] = {pz[0], pz[1], (pz[1]+pz[2])/2, (pz[0]+pz[3])/2, pz[4], pz[5], (pz[5]+pz[6])/2, (pz[4]+pz[7])/2};
+  double flux_u0_halfy = u0 * jacobian3D_lin_face(xxv, yyv, zzv, 0, .5, .5, ZONAL, grid->sphere_mesh);
+  double flux_u1_halfy = u1 * jacobian3D_lin_face(xxv, yyv, zzv, 1, .5, .5, ZONAL, grid->sphere_mesh);
+  double flux_v0 = v0 * jacobian3D_lin_face(xxv, yyv, zzv, .5, 0, .5, MERIDIONAL, grid->sphere_mesh);
+  double flux_w0_halfy = w0 * jacobian3D_lin_face(xxv, yyv, zzv, .5, .5, 0, VERTICAL, grid->sphere_mesh);
+  double flux_w1_halfy = w1 * jacobian3D_lin_face(xxv, yyv, zzv, .5, .5, 1, VERTICAL, grid->sphere_mesh);
+  double flux_v05 = flux_u0_halfy - flux_u1_halfy + flux_v0 + flux_w0_halfy - flux_w1_halfy;
+
+  // Computing fluxes in half lower hexahedron -> flux_w05
+  double xx[8] = {px[0], px[1], px[2], px[3], (px[0]+px[4])/2, (px[1]+px[5])/2, (px[2]+px[6])/2, (px[3]+px[7])/2};
+  double yy[8] = {py[0], py[1], py[2], py[3], (py[0]+py[4])/2, (py[1]+py[5])/2, (py[2]+py[6])/2, (py[3]+py[7])/2};
+  double zz[8] = {pz[0], pz[1], pz[2], pz[3], (pz[0]+pz[4])/2, (pz[1]+pz[5])/2, (pz[2]+pz[6])/2, (pz[3]+pz[7])/2};
+  double flux_u0_halfz = u0 * jacobian3D_lin_face(xx, yy, zz, 0, .5, .5, ZONAL, grid->sphere_mesh);
+  double flux_u1_halfz = u1 * jacobian3D_lin_face(xx, yy, zz, 1, .5, .5, ZONAL, grid->sphere_mesh);
+  double flux_v0_halfz = v0 * jacobian3D_lin_face(xx, yy, zz, .5, 0, .5, MERIDIONAL, grid->sphere_mesh);
+  double flux_v1_halfz = v1 * jacobian3D_lin_face(xx, yy, zz, .5, 1, .5, MERIDIONAL, grid->sphere_mesh);
+  double flux_w0 = w0 * jacobian3D_lin_face(xx, yy, zz, .5, .5, 0, VERTICAL, grid->sphere_mesh);
+  double flux_w05 = flux_u0_halfz - flux_u1_halfz + flux_v0_halfz - flux_v1_halfz + flux_w0;
+
+  double surf_u05 = jacobian3D_lin_face(px, py, pz, .5, .5, .5, ZONAL, grid->sphere_mesh);
+  double jac_u05 = jacobian3D_lin_face(px, py, pz, .5, eta, zet, ZONAL, grid->sphere_mesh);
+  double U05 = flux_u05 / surf_u05 * jac_u05;
+
+  double surf_v05 = jacobian3D_lin_face(px, py, pz, .5, .5, .5, MERIDIONAL, grid->sphere_mesh);
+  double jac_v05 = jacobian3D_lin_face(px, py, pz, xsi, .5, zet, MERIDIONAL, grid->sphere_mesh);
+  double V05 = flux_v05 / surf_v05 * jac_v05;
+
+  double surf_w05 = jacobian3D_lin_face(px, py, pz, .5, .5, .5, VERTICAL, grid->sphere_mesh);
+  double jac_w05 = jacobian3D_lin_face(px, py, pz, xsi, eta, .5, VERTICAL, grid->sphere_mesh);
+  double W05 = flux_w05 / surf_w05 * jac_w05;
+
+  double jac = jacobian3D_lin(px, py, pz, xsi, eta, zet, grid->sphere_mesh);
+
+  double phi[3];
+  phi1D_quad(xsi, phi);
+  double uvec[3] = {U0, U05, U1};
+  double dxsidt = dot_prod(phi, uvec, 3) / jac;
+  phi1D_quad(eta, phi);
+  double vvec[3] = {V0, V05, V1};
+  double detadt = dot_prod(phi, vvec, 3) / jac;
+  phi1D_quad(zet, phi);
+  double wvec[3] = {W0, W05, W1};
+  double dzetdt = dot_prod(phi, wvec, 3) / jac;
+
+  double dphidxsi[8], dphideta[8], dphidzet[8];
+  dphidxsi3D_lin(xsi, eta, zet, dphidxsi, dphideta, dphidzet);
+
+  *u = dot_prod(dphidxsi, px, 8) * dxsidt + dot_prod(dphideta, px, 8) * detadt + dot_prod(dphidzet, px, 8) * dzetdt;
+  *v = dot_prod(dphidxsi, py, 8) * dxsidt + dot_prod(dphideta, py, 8) * detadt + dot_prod(dphidzet, py, 8) * dzetdt;
+  *w = dot_prod(dphidxsi, pz, 8) * dxsidt + dot_prod(dphideta, pz, 8) * detadt + dot_prod(dphidzet, pz, 8) * dzetdt;
+
+  return SUCCESS;
+}
+
 static inline ErrorCode temporal_interpolationUVW_c_grid(type_coord x, type_coord y, type_coord z, double time, CField *U, CField *V, CField *W,
                                                          GridCode gcode, int *xi, int *yi, int *zi, int *ti,
                                                          float *u, float *v, float *w)
@@ -771,6 +1100,10 @@ static inline ErrorCode temporal_interpolationUVW_c_grid(type_coord x, type_coor
   float (*dataV)[V->zdim][V->ydim][V->xdim] = (float (*)[V->zdim][V->ydim][V->xdim]) V->data;
   float (*dataW)[W->zdim][W->ydim][W->xdim] = (float (*)[W->zdim][W->ydim][W->xdim]) W->data;
   double xsi, eta, zet;
+  float data4D_U[2][2][2][2];
+  float data4D_V[2][2][2][2];
+  float data4D_W[2][2][2][2];
+  float u0p, u1p, v0p, v1p, w0p, w1p, up, vp, wp;
 
 
   if (ti[igrid] < grid->tdim-1 && time > grid->time[ti[igrid]]) {
@@ -778,11 +1111,21 @@ static inline ErrorCode temporal_interpolationUVW_c_grid(type_coord x, type_coor
     double t0 = grid->time[ti[igrid]]; double t1 = grid->time[ti[igrid]+1];
     /* Identify grid cell to sample through local linear search */
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zet, gcode, ti[igrid], time, t0, t1, CGRID_VELOCITY); CHECKERROR(err);
+    err = getCell4D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_U, 0); CHECKERROR(err);
+    err = getCell4D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_V, 0); CHECKERROR(err);
+    err = getCell4D(W, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_W, 0); CHECKERROR(err);
     if (grid->zdim==1){
       return ERROR;
     } else {
-      err = spatial_interpolation_UVW_c_grid(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid], grid, gcode, (float**)(dataU[ti[igrid]])  , (float**)(dataV[ti[igrid]]),   (float**)(dataW[ti[igrid]]),   &u0, &v0, &w0); CHECKERROR(err);
-      err = spatial_interpolation_UVW_c_grid(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid], grid, gcode, (float**)(dataU[ti[igrid]+1]), (float**)(dataV[ti[igrid]+1]), (float**)(dataW[ti[igrid]+1]), &u1, &v1, &w1); CHECKERROR(err);
+      err = spatial_interpolation_UVW_c_grid(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid]  , grid, gcode, (float**)(dataU[ti[igrid]])  , (float**)(dataV[ti[igrid]]),   (float**)(dataW[ti[igrid]]),   &u0, &v0, &w0); CHECKERROR(err);
+      err = spatial_interpolation_UVW_c_grid(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid]+1, grid, gcode, (float**)(dataU[ti[igrid]+1]), (float**)(dataV[ti[igrid]+1]), (float**)(dataW[ti[igrid]+1]), &u1, &v1, &w1); CHECKERROR(err);
+
+      err = spatial_interpolation_UVW_c_grid2(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid],   grid, gcode, data4D_U[0], data4D_V[0], data4D_W[0], &u0p, &v0p, &w0p); CHECKERROR(err);
+      err = spatial_interpolation_UVW_c_grid2(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid]+1, grid, gcode, data4D_U[1], data4D_V[1], data4D_W[1], &u1p, &v1p, &w1p); CHECKERROR(err);
+      if ( (fabs(u0-u0p) > 1e-12) || (fabs(u1-u1p) > 1e-12) || (fabs(v0-v0p) > 1e-12) || (fabs(v1-v1p) > 1e-12) || (fabs(w0-w0p) > 1e-12) || (fabs(w1-w1p) > 1e-12)) {
+        printf("error uvw c 0\n");
+        return ERROR;
+      }
     }
     *u = u0 + (u1 - u0) * (float)((time - t0) / (t1 - t0));
     *v = v0 + (v1 - v0) * (float)((time - t0) / (t1 - t0));
@@ -791,11 +1134,20 @@ static inline ErrorCode temporal_interpolationUVW_c_grid(type_coord x, type_coor
   } else {
     double t0 = grid->time[ti[igrid]];
     err = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zet, gcode, ti[igrid], t0, t0, t0+1, CGRID_VELOCITY); CHECKERROR(err);
+    err = getCell4D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_U, 1); CHECKERROR(err);
+    err = getCell4D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_V, 1); CHECKERROR(err);
+    err = getCell4D(W, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data4D_W, 1); CHECKERROR(err);
     if (grid->zdim==1){
       return ERROR;
     }
     else{
       err = spatial_interpolation_UVW_c_grid(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid], grid, gcode, (float**)(dataU[ti[igrid]]), (float**)(dataV[ti[igrid]]), (float**)(dataW[ti[igrid]]), u, v, w); CHECKERROR(err);
+
+      err = spatial_interpolation_UVW_c_grid2(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid], grid, gcode, data4D_U[0], data4D_V[0], data4D_W[0], &up, &vp, &wp); CHECKERROR(err);
+      if ( (fabs(*u-up) > 1e-12) || (fabs(*v-vp) > 1e-12) || (fabs(*w-wp) > 1e-12) ) {
+        printf("error uvw c 1\n");
+        return ERROR;
+      }
     }
     return SUCCESS;
   }

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -180,10 +180,10 @@ class Kernel(object):
         self._function = self._lib.particle_loop
 
     def execute_jit(self, pset, endtime, dt):
-        for f in self.fieldset.get_fields():
-            if type(f) in [VectorField, NestedField, SummedField]:
-                continue
-            f.data = np.array(f.data)
+        #for f in self.fieldset.get_fields():
+        #    if type(f) in [VectorField, NestedField, SummedField]:
+        #        continue
+        #    f.data = np.array(f.data)
         """Invokes JIT engine to perform the core update loop"""
         if len(pset.particles) > 0:
             assert pset.fieldset.gridset.size == len(pset.particles[0].xi), \
@@ -192,9 +192,9 @@ class Kernel(object):
             g.cstruct = None  # This force to point newly the grids from Python to C
         # Make a copy of the transposed array to enforce
         # C-contiguous memory layout for JIT mode.
-        for f in self.field_args.values():
-            if not f.data.flags.c_contiguous:
-                f.data = f.data.copy()
+        #for f in self.field_args.values():
+        #    if not f.data.flags.c_contiguous:
+        #        f.data = f.data.copy()
         for g in pset.fieldset.gridset.grids:
             if not g.depth.flags.c_contiguous:
                 g.depth = g.depth.copy()

--- a/parcels/kernels/advection.py
+++ b/parcels/kernels/advection.py
@@ -19,6 +19,7 @@ def AdvectionRK4(particle, fieldset, time):
     (u4, v4) = fieldset.UV[time + particle.dt, particle.depth, lat3, lon3]
     particle.lon += (u1 + 2*u2 + 2*u3 + u4) / 6. * particle.dt
     particle.lat += (v1 + 2*v2 + 2*v3 + v4) / 6. * particle.dt
+    print("plon plat %g %g" % (particle.lon, particle.lat))
 
 
 def AdvectionRK4_3D(particle, fieldset, time):

--- a/parcels/kernels/advection.py
+++ b/parcels/kernels/advection.py
@@ -19,7 +19,7 @@ def AdvectionRK4(particle, fieldset, time):
     (u4, v4) = fieldset.UV[time + particle.dt, particle.depth, lat3, lon3]
     particle.lon += (u1 + 2*u2 + 2*u3 + u4) / 6. * particle.dt
     particle.lat += (v1 + 2*v2 + 2*v3 + v4) / 6. * particle.dt
-    print("plon plat %g %g" % (particle.lon, particle.lat))
+    #print("plon plat %g %g" % (particle.lon, particle.lat))
 
 
 def AdvectionRK4_3D(particle, fieldset, time):

--- a/tests/customed_header.h
+++ b/tests/customed_header.h
@@ -1,7 +1,9 @@
 
-static inline void func(CField *f, double *lon, float *dt)
+static inline ErrorCode func(CField *f, double *lon, float *dt)
 {
-  float (*data)[f->xdim] = (float (*)[f->xdim]) f->data;
-  float u = data[2][1];
+  float data2D[2][2][2];
+  ErrorCode err = getCell2D(f, 1, 2, 0, data2D, 1); CHECKERROR(err);
+  float u = data2D[0][0][0];
   *lon += u * *dt;
+  return SUCCESS;
 }

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -434,6 +434,7 @@ def test_fieldset_defer_loading_function(zdim, scale_fac, tmpdir, filename='test
     def compute(fieldset):
         # Calculating vertical weighted average
         for f in [fieldset.U, fieldset.V]:
+            f.data = np.array(f.data)
             for tind in f.loaded_time_indices:
                 f.data[tind, :] = np.sum(f.data[tind, :] * DZ, axis=0) / sum(dz)
 

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -261,18 +261,20 @@ def test_c_kernel(fieldset, mode, c_inc):
 
     if c_inc == 'str':
         c_include = """
-                 static inline void func(CField *f, float *lon, float *dt)
+                 static inline ErrorCode func(CField *f, float *lon, float *dt)
                  {
-                   float (*data)[f->xdim] = (float (*)[f->xdim]) f->data;
-                   float u = data[2][1];
+                   float data2D[2][2][2];
+                   ErrorCode err = getCell2D(f, 1, 2, 0, data2D, 1); CHECKERROR(err);
+                   float u = data2D[0][0][0];
                    *lon += u * *dt;
+                   return SUCCESS;
                  }
                  """
     else:
         c_include = path.join(path.dirname(__file__), 'customed_header.h')
 
     def ckernel(particle, fieldset, time):
-        func('pointer_args', fieldset.U, particle.lon, particle.dt)
+        func('parcels_customed_Cfunc_pointer_args', fieldset.U, particle.lon, particle.dt)
 
     def pykernel(particle, fieldset, time):
         particle.lon = func(fieldset.U, particle.lon, particle.dt)


### PR DESCRIPTION
Field.data is now an dask.array, from which only necessary chunked are converted into np.array before C call.

But something is wrong with the dask.array: example_peninsula test breaks, it seems that something is still into memory such that the files related to the fieldset are still attached even after fieldset is completely deleted.
@willirath, if you wanna have a look at the dask construction of the field: Basically, we don't use indices, that are not available in dask, but concatenate the different time steps of the data. Maybe something is wrong there.


So far, the tests are by construction more expensive, since we interpolate everything twice in C lib, and compare that the chunked interpolation is equal to the original one.