### PR TITLE
Parallel output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ gh-pages/*
 *.nc
 *.nc4
 !*testfields*.nc
+out-*
 *.c
 *.pyc
 *.dSYM/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,11 @@ script:
         sh -e /etc/init.d/xvfb start;
         sleep 3;
       fi
+    - |
+      if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
+      	export CONDA_BUILD_SYSROOT=/
+        export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/:/Applications/Xcode.app/Contents//Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
+      fi
     - py.test -v -s tests/
     - |
       # only get examples on linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
       fi
     - |
       if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
-      	export CONDA_BUILD_SYSROOT=/
+        export CONDA_BUILD_SYSROOT=/
         export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/:/Applications/Xcode.app/Contents//Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
       fi
     - py.test -v -s tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ script:
       fi
     - |
       if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
-        export CONDA_BUILD_SYSROOT=/
         export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/:/Applications/Xcode.app/Contents//Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
       fi
     - py.test -v -s tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ script:
       fi
     - |
       if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
-        export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/:/Applications/Xcode.app/Contents//Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
+        export CONDA_BUILD_SYSROOT=/
+        export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
       fi
     - py.test -v -s tests/
     - |

--- a/environment_py3_win.yml
+++ b/environment_py3_win.yml
@@ -12,6 +12,7 @@ dependencies:
   - jupyter
   - m2w64-toolchain
   - matplotlib>=2.0.2
+  - mpi4py
   - netcdf4>=1.1.9
   - numpy>=1.9.1
   - progressbar2

--- a/environment_py3_win.yml
+++ b/environment_py3_win.yml
@@ -12,7 +12,6 @@ dependencies:
   - jupyter
   - m2w64-toolchain
   - matplotlib>=2.0.2
-  - mpi4py
   - netcdf4>=1.1.9
   - numpy>=1.9.1
   - progressbar2

--- a/parcels/compiler.py
+++ b/parcels/compiler.py
@@ -3,6 +3,10 @@ from os import path, getenv
 from tempfile import gettempdir
 from struct import calcsize
 try:
+    from mpi4py import MPI
+except:
+    MPI = None
+try:
     from pathlib import Path
 except ImportError:
     from pathlib2 import Path  # python 2 backport
@@ -79,4 +83,5 @@ class GNUCompiler(Compiler):
         cppargs = ['-Wall', '-fPIC', '-I%s' % path.join(get_package_dir(), 'include')] + opt_flags + cppargs
         cppargs += arch_flag
         ldargs = ['-shared'] + ldargs + arch_flag
-        super(GNUCompiler, self).__init__("mpicc", cppargs=cppargs, ldargs=ldargs)
+        compiler = "mpicc" if MPI else "gcc"
+        super(GNUCompiler, self).__init__(compiler, cppargs=cppargs, ldargs=ldargs)

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -4,10 +4,13 @@ from parcels.grid import Grid
 from parcels.tools.loggers import logger
 from parcels.tools.converters import TimeConverter
 import numpy as np
-from mpi4py import MPI
 from os import path
 from glob import glob
 from copy import deepcopy
+try:
+    from mpi4py import MPI
+except:
+    MPI = None
 
 
 __all__ = ['FieldSet']
@@ -711,7 +714,7 @@ class FieldSet(object):
 
         :param filename: Basename of the output fileset"""
 
-        if MPI.COMM_WORLD.Get_rank() == 0:
+        if MPI is None or MPI.COMM_WORLD.Get_rank() == 0:
             logger.info("Generating NEMO FieldSet output with basename: %s" % filename)
 
             if hasattr(self, 'U'):

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -4,6 +4,7 @@ from parcels.grid import Grid
 from parcels.tools.loggers import logger
 from parcels.tools.converters import TimeConverter
 import numpy as np
+from mpi4py import MPI
 from os import path
 from glob import glob
 from copy import deepcopy
@@ -709,16 +710,18 @@ class FieldSet(object):
         """Write FieldSet to NetCDF file using NEMO convention
 
         :param filename: Basename of the output fileset"""
-        logger.info("Generating NEMO FieldSet output with basename: %s" % filename)
 
-        if hasattr(self, 'U'):
-            self.U.write(filename, varname='vozocrtx')
-        if hasattr(self, 'V'):
-            self.V.write(filename, varname='vomecrty')
+        if MPI.COMM_WORLD.Get_rank() == 0:
+            logger.info("Generating NEMO FieldSet output with basename: %s" % filename)
 
-        for v in self.get_fields():
-            if (v.name != 'U') and (v.name != 'V'):
-                v.write(filename)
+            if hasattr(self, 'U'):
+                self.U.write(filename, varname='vozocrtx')
+            if hasattr(self, 'V'):
+                self.V.write(filename, varname='vomecrty')
+
+            for v in self.get_fields():
+                if (v.name != 'U') and (v.name != 'V'):
+                    v.write(filename)
 
     def advancetime(self, fieldset_new):
         """Replace oldest time on FieldSet with new FieldSet

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -18,7 +18,10 @@ import re
 from hashlib import md5
 import math  # noqa
 import random  # noqa
-from mpi4py import MPI
+try:
+    from mpi4py import MPI
+except:
+    MPI = None
 
 
 __all__ = ['Kernel']
@@ -130,15 +133,15 @@ class Kernel(object):
                 c_include_str = c_include
             self.ccode = loopgen.generate(self.funcname, self.field_args, self.const_args,
                                           kernel_ccode, c_include_str)
-
-            mpi_comm = MPI.COMM_WORLD
-            mpi_rank = mpi_comm.Get_rank()
-            if mpi_rank == 0:
-                basename = path.join(get_cache_dir(), self._cache_key)
+            if MPI:
+                mpi_comm = MPI.COMM_WORLD
+                mpi_rank = mpi_comm.Get_rank()
+                basename = path.join(get_cache_dir(), self._cache_key) if mpi_rank == 0 else None
+                basename = mpi_comm.bcast(basename, root=0)
+                basename = basename + "_%d" % mpi_rank
             else:
-                basename = None
-            basename = mpi_comm.bcast(basename, root=0)
-            basename = basename + "_%d" % mpi_rank
+                basename = path.join(get_cache_dir(), "%s_d" % self._cache_key)
+
             self.src_file = "%s.c" % basename
             self.lib_file = "%s.%s" % (basename, 'dll' if platform == 'win32' else 'so')
             self.log_file = "%s.log" % basename
@@ -171,12 +174,15 @@ class Kernel(object):
         # Python's ctype does not deal in any sort of manner well with dynamic linked libraries on this OS.
         if path.isfile(self.lib_file):
             [remove(s) for s in [self.src_file, self.lib_file, self.log_file]]
-            mpi_comm = MPI.COMM_WORLD
-            mpi_rank = mpi_comm.Get_rank()
-            if mpi_rank == 0:
-                basename = path.join(get_cache_dir(), self._cache_key)
-            basename = mpi_comm.bcast(basename, root=0)
-            basename = basename + "_%d" % mpi_rank
+            if MPI:
+                mpi_comm = MPI.COMM_WORLD
+                mpi_rank = mpi_comm.Get_rank()
+                basename = path.join(get_cache_dir(), self._cache_key) if mpi_rank == 0 else None
+                basename = mpi_comm.bcast(basename, root=0)
+                basename = basename + "_%d" % mpi_rank
+            else:
+                basename = path.join(get_cache_dir(), "%s_d" % self._cache_key)
+
             self.src_file = "%s.c" % basename
             self.lib_file = "%s.%s" % (basename, 'dll' if platform == 'win32' else 'so')
             self.log_file = "%s.log" % basename

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -140,7 +140,7 @@ class Kernel(object):
                 basename = mpi_comm.bcast(basename, root=0)
                 basename = basename + "_%d" % mpi_rank
             else:
-                basename = path.join(get_cache_dir(), "%s_d" % self._cache_key)
+                basename = path.join(get_cache_dir(), "%s_0" % self._cache_key)
 
             self.src_file = "%s.c" % basename
             self.lib_file = "%s.%s" % (basename, 'dll' if platform == 'win32' else 'so')
@@ -181,7 +181,7 @@ class Kernel(object):
                 basename = mpi_comm.bcast(basename, root=0)
                 basename = basename + "_%d" % mpi_rank
             else:
-                basename = path.join(get_cache_dir(), "%s_d" % self._cache_key)
+                basename = path.join(get_cache_dir(), "%s_0" % self._cache_key)
 
             self.src_file = "%s.c" % basename
             self.lib_file = "%s.%s" % (basename, 'dll' if platform == 'win32' else 'so')

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -8,9 +8,6 @@ from ctypes import c_void_p
 __all__ = ['ScipyParticle', 'JITParticle', 'Variable']
 
 
-lastID = 0  # module-level variable keeping track of last Particle ID used
-
-
 class Variable(object):
     """Descriptor class that delegates data access to particle data
 

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -112,6 +112,7 @@ class ParticleType(object):
 
 class _Particle(object):
     """Private base class for all particle types"""
+    lastID = 0  # class-level variable keeping track of last Particle ID used
 
     def __init__(self):
         ptype = self.getPType()
@@ -146,6 +147,10 @@ class _Particle(object):
     def getInitialValue(cls, ptype, name):
         return next((v.initial for v in ptype.variables if v.name is name), None)
 
+    @classmethod
+    def setLastID(cls, offset):
+        _Particle.lastID = offset
+
 
 class ScipyParticle(_Particle):
     """Class encapsulating the basic attributes of a particle,
@@ -168,16 +173,15 @@ class ScipyParticle(_Particle):
     dt = Variable('dt', dtype=np.float32, to_write=False)
     state = Variable('state', dtype=np.int32, initial=ErrorCode.Success, to_write=False)
 
-    def __init__(self, lon, lat, fieldset, depth=0., time=0., cptr=None):
-        global lastID
+    def __init__(self, lon, lat, fieldset, depth=0., time=0., cptr=None, offset=0):
 
         # Enforce default values through Variable descriptor
         type(self).lon.initial = lon
         type(self).lat.initial = lat
         type(self).depth.initial = depth
         type(self).time.initial = time
-        type(self).id.initial = lastID
-        lastID += 1
+        type(self).id.initial = _Particle.lastID
+        _Particle.lastID += 1
         type(self).dt.initial = None
         super(ScipyParticle, self).__init__()
 

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -173,7 +173,7 @@ class ScipyParticle(_Particle):
     dt = Variable('dt', dtype=np.float32, to_write=False)
     state = Variable('state', dtype=np.int32, initial=ErrorCode.Success, to_write=False)
 
-    def __init__(self, lon, lat, fieldset, depth=0., time=0., cptr=None, offset=0):
+    def __init__(self, lon, lat, fieldset, depth=0., time=0., cptr=None):
 
         # Enforce default values through Variable descriptor
         type(self).lon.initial = lon

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -182,7 +182,7 @@ class ParticleFile(object):
     def __del__(self):
         # The export can only start when all threads are done.
         comm.Barrier()
-        if self.to_export and rank == 0: # only export once. TODO: Look into usefulness of to_export variable. TODO: move task to a separate script.
+        if self.to_export and rank == 0: # only export once.
             self.close()
 
     def close(self):

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -200,9 +200,7 @@ class ParticleFile(object):
         """Close the ParticleFile object by exporting and then deleting
         the temporary npy files"""
         self.export()
-
         self.delete_tempwritedir(tempwritedir=self.tempwritedir_base)
-
         self.dataset.close()
         self.to_export = False
 
@@ -356,7 +354,7 @@ class ParticleFile(object):
                 global_maxid_written = np.max([global_maxid_written, pset_info_local['maxid_written']])
                 global_file_list += pset_info_local['file_list']
                 if len(self.var_names_once) > 0:
-                    global_file_list += pset_info_local['file_list_once']
+                    global_file_list_once += pset_info_local['file_list_once']
         self.maxid_written = global_maxid_written
 
         for var in self.var_names:

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -194,6 +194,8 @@ class ParticleFile(object):
             temp_names = pickle.load(f)
         for tempwritedir in temp_names:
             self.delete_tempwritedir(tempwritedir=tempwritedir)
+        
+        os.remove('tempwritedir_names')
 
         self.dataset.close()
         self.to_export = False

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -180,6 +180,8 @@ class ParticleFile(object):
             setattr(self.dataset, name, message)
 
     def __del__(self):
+        # The export can only start when all threads are done.
+        comm.Barrier()
         if self.to_export and rank == 0: # only export once. TODO: Look into usefulness of to_export variable. TODO: move task to a separate script.
             self.close()
 

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -351,7 +351,8 @@ class ParticleFile(object):
         """Exports outputs in temporary NPY-files to NetCDF file"""
 
         # Retrieve all temporary writing directories and sort them in numerical order
-        temp_names = sorted(glob("%s/*/" % self.tempwritedir_base), key=lambda x: int(x[:-1].rsplit('/', 1)[1]))
+        temp_names = sorted(glob(os.path.join("%s" % self.tempwritedir_base, "*")),
+                          key=lambda x: int(os.path.basename(x)))[0]
 
         global_maxid_written = -1
         global_file_list = []

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -352,7 +352,7 @@ class ParticleFile(object):
 
         # Retrieve all temporary writing directories and sort them in numerical order
         temp_names = sorted(glob(os.path.join("%s" % self.tempwritedir_base, "*")),
-                          key=lambda x: int(os.path.basename(x)))[0]
+                          key=lambda x: int(os.path.basename(x)))
 
         global_maxid_written = -1
         global_file_list = []

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -357,9 +357,11 @@ class ParticleFile(object):
 
         if len(self.var_names_once) > 0:
             for var in self.var_names_once:
-                getattr(self, var)[:] = self.read_from_npy(self.file_list_once, 1, var) # TODO: read the _once files separately?
+                getattr(self, var)[:] = self.read_from_npy(global_file_list_once, 1, var)
 
-    def delete_tempwritedir(self):
+    def delete_tempwritedir(self, tempwritedir=None):
         """Deleted all temporary npy files"""
-        if os.path.exists(self.tempwritedir):
-            shutil.rmtree(self.tempwritedir)
+        if tempwritedir is None:
+            tempwritedir = self.tempwritedir
+        if os.path.exists(tempwritedir):
+            shutil.rmtree(tempwritedir)

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -344,11 +344,12 @@ class ParticleFile(object):
         if len(self.var_names_once) > 0:
             global_file_list_once = []
         for tempwritedir in temp_names:
-            pset_info_local = np.load(tempwritedir + '/pset_info.npy', allow_pickle=True).item()
-            global_maxid_written = np.max([global_maxid_written, pset_info_local['maxid_written']])
-            global_file_list += pset_info_local['file_list']
-            if len(self.var_names_once) > 0:
-                global_file_list += pset_info_local['file_list_once']
+            if os.path.exists(tempwritedir):
+                pset_info_local = np.load(tempwritedir + '/pset_info.npy', allow_pickle=True).item()
+                global_maxid_written = np.max([global_maxid_written, pset_info_local['maxid_written']])
+                global_file_list += pset_info_local['file_list']
+                if len(self.var_names_once) > 0:
+                    global_file_list += pset_info_local['file_list_once']
         self.maxid_written = global_maxid_written
 
         memory_estimate_total = self.maxid_written+1 * len(self.time_written) * 8

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -141,7 +141,8 @@ class ParticleFile(object):
         self.dataset.parcels_mesh = self.parcels_mesh
 
         # Create ID variable according to CF conventions
-        self.id = self.dataset.createVariable("trajectory", "i4", coords)
+        self.id = self.dataset.createVariable("trajectory", "i4", coords,
+                                              fill_value=-2**(31))  # maxint32 fill_value
         self.id.long_name = "Unique identifier for each particle"
         self.id.cf_role = "trajectory_id"
 

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -274,7 +274,7 @@ class ParticleFile(object):
         """Buffer data to set of temporary numpy files, using np.save"""
 
         if not os.path.exists(self.tempwritedir):
-            os.makedirs(self.tempwritedir, exist_ok=True)
+            os.makedirs(self.tempwritedir)
 
         if len(data_dict) > 0:
             tmpfilename = os.path.join(self.tempwritedir, str(len(self.file_list)) + ".npy")

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import string
 import random
-import pickle
 from mpi4py import MPI
 from parcels.tools.error import ErrorCode
 from glob import glob
@@ -193,7 +192,7 @@ class ParticleFile(object):
     def __del__(self):
         # The export can only start when all threads are done.
         comm.Barrier()
-        if self.to_export and rank == 0: # only export once.
+        if self.to_export and rank == 0:  # only export once.
             self.close()
 
     def close(self):
@@ -326,7 +325,7 @@ class ParticleFile(object):
         t_ind_used = np.zeros(time_steps, dtype=int)
 
         # loop over all files
-        for npyfile in file_list: 
+        for npyfile in file_list:
             data_dict = np.load(npyfile, allow_pickle=True).item()
             id_ind = np.array(data_dict["id"], dtype=int)
             t_ind = time_index[id_ind] if 'once' not in file_list[0] else 0

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -352,7 +352,7 @@ class ParticleFile(object):
 
         # Retrieve all temporary writing directories and sort them in numerical order
         temp_names = sorted(glob(os.path.join("%s" % self.tempwritedir_base, "*")),
-                          key=lambda x: int(os.path.basename(x)))
+                            key=lambda x: int(os.path.basename(x)))
 
         global_maxid_written = -1
         global_file_list = []

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -104,6 +104,8 @@ class ParticleFile(object):
                 basename = os.path.join(os.path.dirname(str(self.name)), "out-%s" % ''.join(random.choice(string.ascii_uppercase) for _ in range(8)))
             else:
                 basename = tempwritedir
+        else:
+            basename = None
 
         if MPI:
             self.tempwritedir_base = mpi_comm.bcast(basename, root=0)

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -355,6 +355,9 @@ class ParticleFile(object):
         temp_names = sorted(glob(os.path.join("%s" % self.tempwritedir_base, "*")),
                             key=lambda x: int(os.path.basename(x)))
 
+        if len(temp_names) == 0:
+            raise RuntimeError("No npy files found in %s" % self.tempwritedir_base)
+
         global_maxid_written = -1
         global_file_list = []
         if len(self.var_names_once) > 0:

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -109,7 +109,8 @@ class ParticleFile(object):
         self.tempwritedir_base = mpi_comm.bcast(basename, root=0)
         self.tempwritedir = self.tempwritedir_base + "/%d" % mpi_rank
 
-        self.delete_tempwritedir()
+        if pset_info is None:  # otherwise arrive here from convert_npydir_to_netcdf
+            self.delete_tempwritedir()
 
     def open_netcdf_file(self, data_shape):
         """Initialise NetCDF4.Dataset for trajectory output.
@@ -342,8 +343,8 @@ class ParticleFile(object):
     def export(self):
         """Exports outputs in temporary NPY-files to NetCDF file"""
 
-        # Retrieve all temporary writing directories
-        temp_names = glob("%s/*/" % self.tempwritedir_base)
+        # Retrieve all temporary writing directories and sort them in numerical order
+        temp_names = sorted(glob("%s/*/" % self.tempwritedir_base), key=lambda x: int(x[:-1].rsplit('/', 1)[1]))
 
         global_maxid_written = -1
         global_file_list = []

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -370,7 +370,9 @@ class ParticleFile(object):
                 getattr(self, var)[:] = self.read_from_npy(global_file_list_once, 1, var)
 
     def delete_tempwritedir(self, tempwritedir=None):
-        """Deleted all temporary npy files"""
+        """Deleted all temporary npy files
+        :param tempwritedir Optional path of the directory to delete
+        """
         if tempwritedir is None:
             tempwritedir = self.tempwritedir
         if os.path.exists(tempwritedir):

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -187,7 +187,12 @@ class ParticleFile(object):
         """Close the ParticleFile object by exporting and then deleting
         the temporary npy files"""
         self.export()
-        self.delete_tempwritedir() # TODO: replace by: remove all tempwritedirs from list
+
+        with open('tempwritedir_names', 'rb') as f:
+            temp_names = pickle.load(f)
+        for tempwritedir in temp_names:
+            self.delete_tempwritedir(tempwritedir=tempwritedir)
+
         self.dataset.close()
         self.to_export = False
 

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -315,15 +315,15 @@ class ParticleFile(object):
         :param var: name of the variable to read
         """
 
-        data = np.nan * np.zeros((self.maxid_written+1, time_steps)) # TODO: maxid_written has to be deduced in some other way (can be extracted from each pset_info.npy)
+        data = np.nan * np.zeros((self.maxid_written+1, time_steps))
         time_index = np.zeros(self.maxid_written+1, dtype=int)
         t_ind_used = np.zeros(time_steps, dtype=int)
 
         # loop over all files
-        for npyfile in file_list: #TODO: create file_list here (not globally) from all tempwritedirs (can be extracted from each pset_info.npy)
+        for npyfile in file_list: 
             data_dict = np.load(npyfile, allow_pickle=True).item()
             id_ind = np.array(data_dict["id"], dtype=int)
-            t_ind = time_index[id_ind] if 'once' not in file_list[0] else 0 # Interesting one as well, how to handle _once files...
+            t_ind = time_index[id_ind] if 'once' not in file_list[0] else 0
             t_ind_used[t_ind] = 1
             data[id_ind, t_ind] = data_dict[var]
             time_index[id_ind] = time_index[id_ind] + 1

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -88,7 +88,7 @@ class ParticleSet(object):
         depth = convert_to_list(depth)
 
         # Determine offset
-        offset = sum(i < mpi_rank for i in partition)
+        offset = MPI.COMM_WORLD.allreduce(pclass.lastID, op=MPI.MAX) + sum(i < mpi_rank for i in partition)
         pclass.setLastID(offset)
 
         self.time_origin = fieldset.time_origin

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -71,28 +71,31 @@ class ParticleSet(object):
         mpi_rank = mpi_comm.Get_rank()
         mpi_size = mpi_comm.Get_size()
 
-        if len(lon) < mpi_size:
+        if len(lon) < mpi_size and mpi_size > 1:
             raise RuntimeError('Cannot initialise with fewer particles than MPI processors')
 
-        if mpi_rank == 0:
-            coords = np.vstack((lon, lat)).transpose()
-            kmeans = KMeans(n_clusters=mpi_size, random_state=0).fit(coords)
-            partition = kmeans.labels_
+        if mpi_size > 1:
+            if mpi_rank == 0:
+                coords = np.vstack((lon, lat)).transpose()
+                kmeans = KMeans(n_clusters=mpi_size, random_state=0).fit(coords)
+                partition = kmeans.labels_
+            else:
+                partition = None
+            partition = mpi_comm.bcast(partition, root=0)
+            lon = np.array(lon)[partition == mpi_rank]
+            lat = np.array(lat)[partition == mpi_rank]
+            time = np.array(time)[partition == mpi_rank]
+            depth = np.array(depth)[partition == mpi_rank]
+            offset = MPI.COMM_WORLD.allreduce(pclass.lastID, op=MPI.MAX) + sum(i < mpi_rank for i in partition)
         else:
-            partition = None
-        partition = mpi_comm.bcast(partition, root=0)
-        lon = np.array(lon)[partition == mpi_rank]
-        lat = np.array(lat)[partition == mpi_rank]
-        time = np.array(time)[partition == mpi_rank]
-        depth = np.array(depth)[partition == mpi_rank]
+            offset = MPI.COMM_WORLD.allreduce(pclass.lastID, op=MPI.MAX)
+        pclass.setLastID(offset)
+
         lon = convert_to_list(lon)
         lat = convert_to_list(lat)
         time = convert_to_list(time)
         depth = convert_to_list(depth)
 
-        # Determine offset
-        offset = MPI.COMM_WORLD.allreduce(pclass.lastID, op=MPI.MAX) + sum(i < mpi_rank for i in partition)
-        pclass.setLastID(offset)
 
         self.time_origin = fieldset.time_origin
         if len(time) > 0 and isinstance(time[0], np.timedelta64) and not self.time_origin:

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -12,8 +12,12 @@ import time as time_module
 import collections
 from datetime import timedelta as delta
 from datetime import datetime, date
-from sklearn.cluster import KMeans
-from mpi4py import MPI
+try:
+    from mpi4py import MPI
+except:
+    MPI = None
+if MPI:
+    from sklearn.cluster import KMeans
 
 __all__ = ['ParticleSet']
 
@@ -67,35 +71,38 @@ class ParticleSet(object):
         time = [np.datetime64(t) if isinstance(t, datetime) else t for t in time]
         time = [np.datetime64(t) if isinstance(t, date) else t for t in time]
 
-        mpi_comm = MPI.COMM_WORLD
-        mpi_rank = mpi_comm.Get_rank()
-        mpi_size = mpi_comm.Get_size()
+        if MPI:
+            mpi_comm = MPI.COMM_WORLD
+            mpi_rank = mpi_comm.Get_rank()
+            mpi_size = mpi_comm.Get_size()
 
-        if len(lon) < mpi_size and mpi_size > 1:
-            raise RuntimeError('Cannot initialise with fewer particles than MPI processors')
+            if len(lon) < mpi_size and mpi_size > 1:
+                raise RuntimeError('Cannot initialise with fewer particles than MPI processors')
 
-        if mpi_size > 1:
-            if mpi_rank == 0:
-                coords = np.vstack((lon, lat)).transpose()
-                kmeans = KMeans(n_clusters=mpi_size, random_state=0).fit(coords)
-                partition = kmeans.labels_
+            if mpi_size > 1:
+                if mpi_rank == 0:
+                    coords = np.vstack((lon, lat)).transpose()
+                    kmeans = KMeans(n_clusters=mpi_size, random_state=0).fit(coords)
+                    partition = kmeans.labels_
+                else:
+                    partition = None
+                partition = mpi_comm.bcast(partition, root=0)
+                lon = np.array(lon)[partition == mpi_rank]
+                lat = np.array(lat)[partition == mpi_rank]
+                time = np.array(time)[partition == mpi_rank]
+                depth = np.array(depth)[partition == mpi_rank]
+                offset = MPI.COMM_WORLD.allreduce(pclass.lastID, op=MPI.MAX) + sum(i < mpi_rank for i in partition)
             else:
-                partition = None
-            partition = mpi_comm.bcast(partition, root=0)
-            lon = np.array(lon)[partition == mpi_rank]
-            lat = np.array(lat)[partition == mpi_rank]
-            time = np.array(time)[partition == mpi_rank]
-            depth = np.array(depth)[partition == mpi_rank]
-            offset = MPI.COMM_WORLD.allreduce(pclass.lastID, op=MPI.MAX) + sum(i < mpi_rank for i in partition)
+                offset = MPI.COMM_WORLD.allreduce(pclass.lastID, op=MPI.MAX)
         else:
-            offset = MPI.COMM_WORLD.allreduce(pclass.lastID, op=MPI.MAX)
+            offset = pclass.lastID
+
         pclass.setLastID(offset)
 
         lon = convert_to_list(lon)
         lat = convert_to_list(lat)
         time = convert_to_list(time)
         depth = convert_to_list(depth)
-
 
         self.time_origin = fieldset.time_origin
         if len(time) > 0 and isinstance(time[0], np.timedelta64) and not self.time_origin:

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -38,8 +38,10 @@ class ParticleSet(object):
     """
 
     def __init__(self, fieldset, pclass=JITParticle, lon=None, lat=None, depth=None, time=None, repeatdt=None, lonlatdepth_dtype=None, **kwargs):
+        global lastID
         self.fieldset = fieldset
         self.fieldset.check_complete()
+        lastID = 0
 
         def convert_to_list(var):
             # Convert numpy arrays and single integers/floats to one-dimensional lists

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -67,7 +67,6 @@ class ParticleSet(object):
         time = [np.datetime64(t) if isinstance(t, datetime) else t for t in time]
         time = [np.datetime64(t) if isinstance(t, date) else t for t in time]
 
-
         mpi_comm = MPI.COMM_WORLD
         mpi_rank = mpi_comm.Get_rank()
         mpi_size = mpi_comm.Get_size()
@@ -285,7 +284,7 @@ class ParticleSet(object):
         self.add(particles)
         return self
 
-    def add(self, particles): # This does not align with the global ID
+    def add(self, particles):
         """Method to add particles to the ParticleSet"""
         if isinstance(particles, ParticleSet):
             particles = particles.particles

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -38,10 +38,8 @@ class ParticleSet(object):
     """
 
     def __init__(self, fieldset, pclass=JITParticle, lon=None, lat=None, depth=None, time=None, repeatdt=None, lonlatdepth_dtype=None, **kwargs):
-        global lastID
         self.fieldset = fieldset
         self.fieldset.check_complete()
-        lastID = 0
 
         def convert_to_list(var):
             # Convert numpy arrays and single integers/floats to one-dimensional lists
@@ -89,6 +87,9 @@ class ParticleSet(object):
         time = convert_to_list(time)
         depth = convert_to_list(depth)
 
+        # Determine offset
+        offset = sum(i < mpi_rank for i in partition)
+        pclass.setLastID(offset)
 
         self.time_origin = fieldset.time_origin
         if len(time) > 0 and isinstance(time[0], np.timedelta64) and not self.time_origin:

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -287,8 +287,6 @@ class ParticleSet(object):
 
     def add(self, particles): # This does not align with the global ID
         """Method to add particles to the ParticleSet"""
-        raise NotImplementedError("Parallel execution currently does not allow for adding particles after initialization, "
-            "as there is currently no way to ensure a unique global ID when adding particles.")
         if isinstance(particles, ParticleSet):
             particles = particles.particles
         if not isinstance(particles, collections.Iterable):

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -70,6 +70,10 @@ class ParticleSet(object):
         mpi_comm = MPI.COMM_WORLD
         mpi_rank = mpi_comm.Get_rank()
         mpi_size = mpi_comm.Get_size()
+
+        if len(lon) < mpi_size:
+            raise RuntimeError('Cannot initialise with fewer particles than MPI processors')
+
         if mpi_rank == 0:
             coords = np.vstack((lon, lat)).transpose()
             kmeans = KMeans(n_clusters=mpi_size, random_state=0).fit(coords)

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -439,9 +439,9 @@ class ParticleSet(object):
             if verbose_progress is None and time_module.time() - walltime_start > 10:
                 # Showing progressbar if runtime > 10 seconds
                 if output_file:
-                    logger.info('Temporary output files are stored in %s.' % output_file.tempwritedir)
+                    logger.info('Temporary output files are stored in %s.' % output_file.tempwritedir_base)
                     logger.info('You can use "parcels_convert_npydir_to_netcdf %s" to convert these '
-                                'to a NetCDF file during the run.' % output_file.tempwritedir)
+                                'to a NetCDF file during the run.' % output_file.tempwritedir_base)
                 pbar = progressbar.ProgressBar(max_value=abs(endtime - _starttime)).start()
                 verbose_progress = True
             if dt > 0:

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -285,8 +285,10 @@ class ParticleSet(object):
         self.add(particles)
         return self
 
-    def add(self, particles):
+    def add(self, particles): # This does not align with the global ID
         """Method to add particles to the ParticleSet"""
+        raise NotImplementedError("Parallel execution currently does not allow for adding particles after initialization, "
+            "as there is currently no way to ensure a unique global ID when adding particles.")
         if isinstance(particles, ParticleSet):
             particles = particles.particles
         if not isinstance(particles, collections.Iterable):

--- a/parcels/scripts/convert_npydir_to_netcdf.py
+++ b/parcels/scripts/convert_npydir_to_netcdf.py
@@ -5,7 +5,7 @@ from glob import glob
 from argparse import ArgumentParser
 
 
-def convert_npydir_to_netcdf(tempwritedir_base):
+def convert_npydir_to_netcdf(tempwritedir_base, delete_tempfiles=False):
     """Convert npy files in tempwritedir to a NetCDF file
     :param tempwritedir_base: directory where the directories for temporary npy files
             are stored (can be obtained from ParticleFile.tempwritedir_base attribute)
@@ -21,18 +21,26 @@ def convert_npydir_to_netcdf(tempwritedir_base):
 
     pset_info = np.load(pyset_file, allow_pickle=True).item()
     pfile = ParticleFile(None, None, pset_info=pset_info, tempwritedir=tempwritedir_base)
-    pfile.export()
-    pfile.dataset.close()
+    if delete_tempfiles:
+        pfile.close()
+    else:
+        pfile.export()
+        pfile.dataset.close()
 
 
-def main(tempwritedir_base=None):
+def main(tempwritedir_base=None, delete_tempfiles=False):
     if tempwritedir_base is None:
         p = ArgumentParser(description="""Script to convert temporary npy output files to NetCDF""")
-        p.add_argument('tempwritedir', help='Name of directory where temporary npy files are stored')
+        p.add_argument('tempwritedir', help='Name of directory where temporary npy files are stored '
+                                            '(not including numbered subdirectories)')
+        p.add_argument('-d', '--delete_tempfiles', default=False,
+                       help='Flag to delete temporary files at end of call (default False)')
         args = p.parse_args()
         tempwritedir_base = args.tempwritedir
+        if hasattr(args, 'delete_tempfiles'):
+            delete_tempfiles = args.delete_tempfiles
 
-    convert_npydir_to_netcdf(tempwritedir_base)
+    convert_npydir_to_netcdf(tempwritedir_base, delete_tempfiles)
 
 
 if __name__ == "__main__":

--- a/parcels/scripts/convert_npydir_to_netcdf.py
+++ b/parcels/scripts/convert_npydir_to_netcdf.py
@@ -5,11 +5,13 @@ from glob import glob
 from argparse import ArgumentParser
 
 
-def convert_npydir_to_netcdf(tempwritedir, tempwritedir_base):
+def convert_npydir_to_netcdf(tempwritedir_base):
     """Convert npy files in tempwritedir to a NetCDF file
-    :param tempwritedir: directory where the temporary npy files are stored (can be obtained from ParticleFile.tempwritedir attribute)
+    :param tempwritedir_base: directory where the directories for temporary npy files
+            are stored (can be obtained from ParticleFile.tempwritedir_base attribute)
     """
 
+    tempwritedir = sorted(glob("%s/*/" % tempwritedir_base), key=lambda x: int(x[:-1].rsplit('/', 1)[1]))[0]
     pyset_file = path.join(tempwritedir, 'pset_info.npy')
     if not path.isdir(tempwritedir):
         raise ValueError('Output directory "%s" does not exist' % tempwritedir)
@@ -29,9 +31,7 @@ def main(tempwritedir_base=None):
         args = p.parse_args()
         tempwritedir_base = args.tempwritedir
 
-    temp_names = sorted(glob("%s/*/" % tempwritedir_base), key=lambda x: int(x[:-1].rsplit('/', 1)[1]))
-
-    convert_npydir_to_netcdf(temp_names[0], tempwritedir_base)
+    convert_npydir_to_netcdf(tempwritedir_base)
 
 
 if __name__ == "__main__":

--- a/parcels/scripts/convert_npydir_to_netcdf.py
+++ b/parcels/scripts/convert_npydir_to_netcdf.py
@@ -1,10 +1,11 @@
 from parcels import ParticleFile
 import numpy as np
 from os import path
+from glob import glob
 from argparse import ArgumentParser
 
 
-def convert_npydir_to_netcdf(tempwritedir):
+def convert_npydir_to_netcdf(tempwritedir, tempwritedir_base):
     """Convert npy files in tempwritedir to a NetCDF file
     :param tempwritedir: directory where the temporary npy files are stored (can be obtained from ParticleFile.tempwritedir attribute)
     """
@@ -16,19 +17,21 @@ def convert_npydir_to_netcdf(tempwritedir):
         raise ValueError('Output directory "%s" does not contain a pset_info.npy file' % tempwritedir)
 
     pset_info = np.load(pyset_file, allow_pickle=True).item()
-    pfile = ParticleFile(None, None, pset_info=pset_info)
+    pfile = ParticleFile(None, None, pset_info=pset_info, tempwritedir=tempwritedir_base)
     pfile.export()
     pfile.dataset.close()
 
 
-def main(tempwritedir=None):
-    if tempwritedir is None:
+def main(tempwritedir_base=None):
+    if tempwritedir_base is None:
         p = ArgumentParser(description="""Script to convert temporary npy output files to NetCDF""")
         p.add_argument('tempwritedir', help='Name of directory where temporary npy files are stored')
         args = p.parse_args()
-        tempwritedir = args.tempwritedir
+        tempwritedir_base = args.tempwritedir
 
-    convert_npydir_to_netcdf(tempwritedir)
+    temp_names = sorted(glob("%s/*/" % tempwritedir_base), key=lambda x: int(x[:-1].rsplit('/', 1)[1]))
+
+    convert_npydir_to_netcdf(temp_names[0], tempwritedir_base)
 
 
 if __name__ == "__main__":

--- a/parcels/scripts/convert_npydir_to_netcdf.py
+++ b/parcels/scripts/convert_npydir_to_netcdf.py
@@ -11,8 +11,8 @@ def convert_npydir_to_netcdf(tempwritedir_base):
             are stored (can be obtained from ParticleFile.tempwritedir_base attribute)
     """
 
-    tempwritedir = sorted(glob(path.join("%s" % tempwritedir_base, "*", "")),
-                          key=lambda x: int(x[:-1].rsplit('/', 1)[1]))[0]
+    tempwritedir = sorted(glob(path.join("%s" % tempwritedir_base, "*")),
+                          key=lambda x: int(path.basename(x)))[0]
     pyset_file = path.join(tempwritedir, 'pset_info.npy')
     if not path.isdir(tempwritedir):
         raise ValueError('Output directory "%s" does not exist' % tempwritedir)

--- a/parcels/scripts/convert_npydir_to_netcdf.py
+++ b/parcels/scripts/convert_npydir_to_netcdf.py
@@ -11,7 +11,8 @@ def convert_npydir_to_netcdf(tempwritedir_base):
             are stored (can be obtained from ParticleFile.tempwritedir_base attribute)
     """
 
-    tempwritedir = sorted(glob("%s/*/" % tempwritedir_base), key=lambda x: int(x[:-1].rsplit('/', 1)[1]))[0]
+    tempwritedir = sorted(glob(path.join("%s" % tempwritedir_base, "*", "")),
+                          key=lambda x: int(x[:-1].rsplit('/', 1)[1]))[0]
     pyset_file = path.join(tempwritedir, 'pset_info.npy')
     if not path.isdir(tempwritedir):
         raise ValueError('Output directory "%s" does not exist' % tempwritedir)

--- a/parcels/scripts/convert_npydir_to_netcdf.py
+++ b/parcels/scripts/convert_npydir_to_netcdf.py
@@ -20,7 +20,7 @@ def convert_npydir_to_netcdf(tempwritedir_base, delete_tempfiles=False):
         raise ValueError('Output directory "%s" does not contain a pset_info.npy file' % tempwritedir)
 
     pset_info = np.load(pyset_file, allow_pickle=True).item()
-    pfile = ParticleFile(None, None, pset_info=pset_info, tempwritedir=tempwritedir_base)
+    pfile = ParticleFile(None, None, pset_info=pset_info, tempwritedir=tempwritedir_base, convert_at_end=False)
     if delete_tempfiles:
         pfile.close()
     else:

--- a/tests/test_mpirun.py
+++ b/tests/test_mpirun.py
@@ -1,0 +1,27 @@
+import os
+from netCDF4 import Dataset
+import numpy as np
+try:
+    from mpi4py import MPI
+except:
+    MPI = None
+
+
+def test_mpi_run():
+    if MPI:
+        releasedt = 200*86400
+        os.system('mpirun -np 2 python parcels/examples/example_stommel.py -p 4 -o StommelMPI.nc -r %d' % releasedt)
+        os.system('python parcels/examples/example_stommel.py -p 4 -o StommelNoMPI.nc -r %d' % releasedt)
+
+        ncfile1 = Dataset('StommelMPI.nc', 'r', 'NETCDF4')
+        ncfile2 = Dataset('StommelNoMPI.nc', 'r', 'NETCDF4')
+
+        for v in ncfile2.variables.keys():
+            assert np.allclose(ncfile1.variables[v][:], ncfile2.variables[v][:])
+
+        for a in ncfile2.ncattrs():
+            if a != 'parcels_version':
+                assert getattr(ncfile1, a) == getattr(ncfile2, a)
+
+        ncfile1.close()
+        ncfile2.close()

--- a/tests/test_particle_file.py
+++ b/tests/test_particle_file.py
@@ -25,10 +25,10 @@ def fieldset(xdim=40, ydim=100):
 
 def close_and_compare_netcdffiles(filepath, ofile, assystemcall=False):
     if assystemcall:
-        os.system('parcels_convert_npydir_to_netcdf %s' % ofile.tempwritedir)
+        os.system('parcels_convert_npydir_to_netcdf %s' % ofile.tempwritedir_base)
     else:
         import parcels.scripts.convert_npydir_to_netcdf as convert
-        convert.convert_npydir_to_netcdf(ofile.tempwritedir)
+        convert.convert_npydir_to_netcdf(ofile.tempwritedir_base)
 
     ncfile1 = Dataset(filepath, 'r', 'NETCDF4')
 

--- a/tests/test_particle_file.py
+++ b/tests/test_particle_file.py
@@ -41,7 +41,8 @@ def close_and_compare_netcdffiles(filepath, ofile, assystemcall=False):
         assert np.allclose(ncfile1.variables[v][:], ncfile2.variables[v][:])
 
     for a in ncfile2.ncattrs():
-        assert getattr(ncfile1, a) == getattr(ncfile2, a)
+        if a!= 'parcels_version':
+            assert getattr(ncfile1, a) == getattr(ncfile2, a)
 
     ncfile2.close()
     return ncfile1

--- a/tests/test_particle_file.py
+++ b/tests/test_particle_file.py
@@ -41,7 +41,7 @@ def close_and_compare_netcdffiles(filepath, ofile, assystemcall=False):
         assert np.allclose(ncfile1.variables[v][:], ncfile2.variables[v][:])
 
     for a in ncfile2.ncattrs():
-        if a!= 'parcels_version':
+        if a != 'parcels_version':
             assert getattr(ncfile1, a) == getattr(ncfile2, a)
 
     ncfile2.close()


### PR DESCRIPTION
Changed in this pull request

- Unique ID at initialization of ParticleSet
- Communication of temp_file location of each process
- Limiting writing to only process 0
- Process 0 gathers output from all temp_files instead of only its own file_list

Issues
- Unique ID not unique when adding particles during run 
- Creation of netCDF file requires everything to be in memory at the same time, does not scale with large runs (in terms of time steps or particles)
- Export depends on to_export variable which is not communicated across processes
- IDs not (necessarily) the same as serial run (because of spreading of particles over processors)

TODO:

- [x] Ensure uniqueness of ID. Suggestions: private/public .add() in ParticleSet (public one only accepts ParticleSet, private also allows particles) & find current max ID on processors using in ParticleSet initialization
- [x] Add flag to enable/disable export of netCDF file in current run (when disabled, temporary files are left untouched, so a follow-up process can collect all output)
- [x] Find alternative for the self.to_export variable in ParticleFile. Suggestion: just assume it is true and then check for existence of any .npy files in export(), throw exception if none exist.
- [x] Change script convert_npydir_to_netcdf.py to include a delete_temp_files flag (when true call .close() instead of .export())
- [x] Review coding style etc.