### PR TITLE
Allowing dt to be a variable in kernel defintion

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -357,7 +357,7 @@ class KernelGenerator(ast.NodeVisitor):
     attriibute on nodes in the Python AST."""
 
     # Intrinsic variables that appear as function arguments
-    kernel_vars = ['particle', 'fieldset', 'time', 'dt', 'output_time', 'tol']
+    kernel_vars = ['particle', 'fieldset', 'time', 'output_time', 'tol']
     array_vars = []
 
     def __init__(self, fieldset, ptype):

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -128,6 +128,16 @@ def test_nested_if(fieldset, mode):
     assert np.allclose([pset[0].p0, pset[0].p1], [0, 1])
 
 
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_dt_as_variable_in_kernel(fieldset, mode):
+    pset = ParticleSet(fieldset, pclass=ptype[mode], lon=0, lat=0)
+
+    def kernel(particle, fieldset, time):
+        dt = 1.  # noqa
+
+    pset.execute(kernel, endtime=10, dt=1.)
+
+
 def test_parcels_tmpvar_in_kernel(fieldset):
     """Tests for error thrown if vartiable with 'tmp' defined in custom kernel"""
     error_thrown = False


### PR DESCRIPTION
This fixes #615, and was introduced when `dt` was removed as special variable from kernel definition in v2