### PR TITLE
Make ErrorCode a plain object, not IntEnum

### DIFF
--- a/parcels/tools/error.py
+++ b/parcels/tools/error.py
@@ -1,12 +1,11 @@
 """Collection of pre-built recovery kernels"""
-from enum import IntEnum
 
 
 __all__ = ['ErrorCode', 'FieldSamplingError', 'FieldOutOfBoundError', 'TimeExtrapolationError',
            'KernelError', 'OutOfBoundsError', 'recovery_map']
 
 
-class ErrorCode(IntEnum):
+class ErrorCode(object):
     Success = 0
     Repeat = 1
     Delete = 2


### PR DESCRIPTION
Something surprising is that Python enums are really slow. In Python 3.4, member lookup was 20x slower than normal class attributes (https://bugs.python.org/issue23486), and even though it has been "fixed" in subsequent Python versions, it's still significantly slower. I don't see any reason why ErrorCode needs to be an enum, so we can get a surprising performance improvement for higher particle counts by changing a normal class.