### PR TITLE
Comparing really the time converters type

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -156,7 +156,7 @@ class FieldSet(object):
             g.check_zonal_periodic()
             if len(g.time) == 1:
                 continue
-            assert isinstance(g.time_origin, type(self.time_origin)), 'time origins of different grids must be have the same type'
+            assert isinstance(g.time_origin.time_origin, type(self.time_origin.time_origin)), 'time origins of different grids must be have the same type'
             g.time = g.time + self.time_origin.reltime(g.time_origin)
             if g.defer_load:
                 g.time_full = g.time_full + self.time_origin.reltime(g.time_origin)


### PR DESCRIPTION

Before we were just checking that both `time_origin` were Parcels `TimeConverter`, but we actually wanted to check the type of TimeConverter...