### PR TITLE
Management of grid.load_chunk

### DIFF
--- a/parcels/examples/example_globcurrent.py
+++ b/parcels/examples/example_globcurrent.py
@@ -216,6 +216,4 @@ def test_globcurrent_particle_independence(mode, rundays=5):
                   runtime=delta(days=rundays),
                   dt=delta(minutes=5))
 
-
-    print([pset0[-1].lon, pset0[-1].lat], [pset1[-1].lon, pset1[-1].lat])
     assert np.allclose([pset0[-1].lon, pset0[-1].lat], [pset1[-1].lon, pset1[-1].lat])

--- a/parcels/examples/example_globcurrent.py
+++ b/parcels/examples/example_globcurrent.py
@@ -216,4 +216,6 @@ def test_globcurrent_particle_independence(mode, rundays=5):
                   runtime=delta(days=rundays),
                   dt=delta(minutes=5))
 
+
+    print([pset0[-1].lon, pset0[-1].lat], [pset1[-1].lon, pset1[-1].lat])
     assert np.allclose([pset0[-1].lon, pset0[-1].lat], [pset1[-1].lon, pset1[-1].lat])

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -864,11 +864,12 @@ class Field(object):
                 if self.grid.load_chunk[block_id] == 1 or self.grid.load_chunk[block_id] > 1 and self.data_chunks[block_id] is None:
                     block = self.get_block(block_id)
                     self.data_chunks[block_id] = np.array(self.data.blocks[(slice(self.grid.tdim),)+block])
+                    self.grid.load_chunk[block_id] = 2
                 elif self.grid.load_chunk[block_id] == 0:
                     self.data_chunks[block_id] = None
                     self.c_data_chunks[block_id] = None
         else:
-            self.grid.load_chunk[0] = 3
+            self.grid.load_chunk[0] = 2
             self.data_chunks[0] = self.data
 
     @property

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -816,6 +816,7 @@ class FieldSet(object):
                 else:
                     data = f.reshape(data)[0:1, :]
                     f.data = da.concatenate([data, f.data[:2, :]], axis=0)
+                g.load_chunk = np.where(g.load_chunk == 3, 0, g.load_chunk)
                 if len(g.load_chunk) > 0:
                     if signdt >= 0:
                         for block_id in range(len(g.load_chunk)):

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -218,7 +218,6 @@ class Kernel(object):
 
         for g in pset.fieldset.gridset.grids:
             if len(g.load_chunk) > 0:  # not the case if a field in not called in the kernel
-                g.load_chunk = np.where(g.load_chunk > 0, 3, g.load_chunk)
                 if not g.load_chunk.flags.c_contiguous:
                     g.load_chunk = g.load_chunk.copy()
             if not g.depth.flags.c_contiguous:
@@ -305,6 +304,10 @@ class Kernel(object):
             recovery = {}
         recovery_map = recovery_base_map.copy()
         recovery_map.update(recovery)
+
+        for g in pset.fieldset.gridset.grids:
+            if len(g.load_chunk) > 0:  # not the case if a field in not called in the kernel
+                g.load_chunk = np.where(g.load_chunk > 0, 3, g.load_chunk)
 
         # Execute the kernel over the particle set
         if self.ptype.uses_jit:


### PR DESCRIPTION
The idea behind `grid.load_chunk`
A chunk can have 4 different status:
* 0: it is not loaded
* 1: the chunk is requested to be loaded (a C-call should never start with a chunk having this status)
* 2: chunk loaded and at least a particle on the chunk
* 3: chunk loaded, not used

A few important points:
* At `field.computeTimeChunk()`, all chunks with status 3 should be reset to 0 (This was not done) AND the actual chunks, reset to None, to avoid errors (to be done)
* During `kernel.execution()`, particles with status different than `SUCCESS` are rerun. This was affecting the chunks, which could pass from status 2 to 3, because of the multiple calls to JIT kernels for the same time steps. We have changed this by moving the 2->3 status conversion from `kernel.execute_jit()` (called multiple times) to `kernel.execute()` (called once)