### PR TITLE
Group imports according to pep8 and prevent merge conflicts

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -1,12 +1,17 @@
-from parcels.field import Field, VectorField, SummedField, NestedField
-from parcels.tools.loggers import logger
 import ast
-import cgen as c
 import collections
 import math
-import numpy as np
 import random
 from copy import copy
+
+import cgen as c
+import numpy as np
+
+from parcels.field import Field
+from parcels.field import NestedField
+from parcels.field import SummedField
+from parcels.field import VectorField
+from parcels.tools.loggers import logger
 
 
 class IntrinsicNode(ast.AST):

--- a/parcels/compiler.py
+++ b/parcels/compiler.py
@@ -1,7 +1,15 @@
 import subprocess
-from os import path, getenv
-from tempfile import gettempdir
+from os import getenv
+from os import path
 from struct import calcsize
+from tempfile import gettempdir
+
+try:
+    from os import getuid
+except:
+    # Windows does not have getuid(), so define to simply return 'tmp'
+    def getuid():
+        return 'tmp'
 try:
     from mpi4py import MPI
 except:
@@ -10,12 +18,6 @@ try:
     from pathlib import Path
 except ImportError:
     from pathlib2 import Path  # python 2 backport
-try:
-    from os import getuid
-except:
-    # Windows does not have getuid(), so define to simply return 'tmp'
-    def getuid():
-        return 'tmp'
 
 
 def get_package_dir():

--- a/parcels/examples/example_brownian.py
+++ b/parcels/examples/example_brownian.py
@@ -1,8 +1,15 @@
-from parcels import FieldSet, Field, ParticleSet, ScipyParticle, JITParticle, BrownianMotion2D
-import numpy as np
 from datetime import timedelta as delta
-from parcels import random
+
+import numpy as np
 import pytest
+
+from parcels import BrownianMotion2D
+from parcels import Field
+from parcels import FieldSet
+from parcels import JITParticle
+from parcels import ParticleSet
+from parcels import random
+from parcels import ScipyParticle
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 

--- a/parcels/examples/example_decaying_moving_eddy.py
+++ b/parcels/examples/example_decaying_moving_eddy.py
@@ -1,8 +1,13 @@
-from parcels import FieldSet, ParticleSet, ScipyParticle, JITParticle
-from parcels import AdvectionRK4
-import numpy as np
 from datetime import timedelta as delta
+
+import numpy as np
 import pytest
+
+from parcels import AdvectionRK4
+from parcels import FieldSet
+from parcels import JITParticle
+from parcels import ParticleSet
+from parcels import ScipyParticle
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 

--- a/parcels/examples/example_globcurrent.py
+++ b/parcels/examples/example_globcurrent.py
@@ -1,10 +1,18 @@
-from parcels import FieldSet, ParticleSet, ScipyParticle, JITParticle, AdvectionRK4, Variable, ErrorCode
 from datetime import timedelta as delta
-from os import path
 from glob import glob
+from os import path
+
 import numpy as np
 import pytest
 import xarray as xr
+
+from parcels import AdvectionRK4
+from parcels import ErrorCode
+from parcels import FieldSet
+from parcels import JITParticle
+from parcels import ParticleSet
+from parcels import ScipyParticle
+from parcels import Variable
 
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/parcels/examples/example_moving_eddies.py
+++ b/parcels/examples/example_moving_eddies.py
@@ -1,12 +1,19 @@
-from parcels import FieldSet, ParticleSet, ScipyParticle, JITParticle
-from parcels import AdvectionRK4, AdvectionEE, AdvectionRK45
-from argparse import ArgumentParser
-import numpy as np
+import gc
 import math
-import pytest
+from argparse import ArgumentParser
 from datetime import timedelta as delta
 from os import path
-import gc
+
+import numpy as np
+import pytest
+
+from parcels import AdvectionEE
+from parcels import AdvectionRK4
+from parcels import AdvectionRK45
+from parcels import FieldSet
+from parcels import JITParticle
+from parcels import ParticleSet
+from parcels import ScipyParticle
 
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/parcels/examples/example_nemo_curvilinear.py
+++ b/parcels/examples/example_nemo_curvilinear.py
@@ -1,10 +1,17 @@
-from parcels import FieldSet, ParticleSet, ScipyParticle, JITParticle, AdvectionRK4, ParticleFile
 from argparse import ArgumentParser
+from datetime import timedelta as delta
+from glob import glob
+from os import path
+
 import numpy as np
 import pytest
-from glob import glob
-from datetime import timedelta as delta
-from os import path
+
+from parcels import AdvectionRK4
+from parcels import FieldSet
+from parcels import JITParticle
+from parcels import ParticleFile
+from parcels import ParticleSet
+from parcels import ScipyParticle
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 

--- a/parcels/examples/example_ofam.py
+++ b/parcels/examples/example_ofam.py
@@ -1,10 +1,16 @@
-from parcels import FieldSet, ParticleSet, ScipyParticle, JITParticle, AdvectionRK4
+import gc
 from datetime import timedelta as delta
+from os import path
+
+import numpy as np
 import pytest
 import xarray as xr
-import numpy as np
-from os import path
-import gc
+
+from parcels import AdvectionRK4
+from parcels import FieldSet
+from parcels import JITParticle
+from parcels import ParticleSet
+from parcels import ScipyParticle
 
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/parcels/examples/example_peninsula.py
+++ b/parcels/examples/example_peninsula.py
@@ -1,11 +1,19 @@
-from parcels import FieldSet, ParticleSet, ScipyParticle, JITParticle, Variable
-from parcels import AdvectionRK4, AdvectionEE, AdvectionRK45
-from argparse import ArgumentParser
-import numpy as np
-import math  # NOQA
-import pytest
-from datetime import timedelta as delta
 import gc
+import math  # NOQA
+from argparse import ArgumentParser
+from datetime import timedelta as delta
+
+import numpy as np
+import pytest
+
+from parcels import AdvectionEE
+from parcels import AdvectionRK4
+from parcels import AdvectionRK45
+from parcels import FieldSet
+from parcels import JITParticle
+from parcels import ParticleSet
+from parcels import ScipyParticle
+from parcels import Variable
 
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/parcels/examples/example_radial_rotation.py
+++ b/parcels/examples/example_radial_rotation.py
@@ -1,9 +1,14 @@
-from parcels import FieldSet, ParticleSet, ScipyParticle, JITParticle
-from parcels import AdvectionRK4
-import numpy as np
-from datetime import timedelta as delta
 import math
+from datetime import timedelta as delta
+
+import numpy as np
 import pytest
+
+from parcels import AdvectionRK4
+from parcels import FieldSet
+from parcels import JITParticle
+from parcels import ParticleSet
+from parcels import ScipyParticle
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 

--- a/parcels/examples/example_recursive_errorhandling.py
+++ b/parcels/examples/example_recursive_errorhandling.py
@@ -1,7 +1,12 @@
-from parcels import FieldSet, ParticleSet, JITParticle, ScipyParticle
-from parcels import random, ErrorCode
 import numpy as np
 import pytest
+
+from parcels import ErrorCode
+from parcels import FieldSet
+from parcels import JITParticle
+from parcels import ParticleSet
+from parcels import random
+from parcels import ScipyParticle
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 

--- a/parcels/examples/example_stommel.py
+++ b/parcels/examples/example_stommel.py
@@ -1,11 +1,19 @@
-from parcels import FieldSet, ParticleSet, ScipyParticle, JITParticle, Variable
-from parcels import AdvectionRK4, AdvectionEE, AdvectionRK45
-from parcels import timer
-from argparse import ArgumentParser
-import numpy as np
 import math
-import pytest
+from argparse import ArgumentParser
 from datetime import timedelta as delta
+
+import numpy as np
+import pytest
+
+from parcels import AdvectionEE
+from parcels import AdvectionRK4
+from parcels import AdvectionRK45
+from parcels import FieldSet
+from parcels import JITParticle
+from parcels import ParticleSet
+from parcels import ScipyParticle
+from parcels import timer
+from parcels import Variable
 
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1,17 +1,30 @@
-from parcels.tools.loggers import logger
-from parcels.tools.converters import unitconverters_map, UnitConverter, Geographic, GeographicPolar
-from parcels.tools.converters import TimeConverter
-from parcels.tools.error import FieldSamplingError, FieldOutOfBoundError, TimeExtrapolationError
-import parcels.tools.interpolation_utils as i_u
 import collections
-from py import path
-import numpy as np
-from ctypes import Structure, c_int, c_float, POINTER, pointer
-import xarray as xr
 import datetime
 import math
-from .grid import Grid, CGrid, GridCode
+from ctypes import c_float
+from ctypes import c_int
+from ctypes import POINTER
+from ctypes import pointer
+from ctypes import Structure
+
 import dask.array as da
+import numpy as np
+import xarray as xr
+from py import path
+
+import parcels.tools.interpolation_utils as i_u
+from .grid import CGrid
+from .grid import Grid
+from .grid import GridCode
+from parcels.tools.converters import Geographic
+from parcels.tools.converters import GeographicPolar
+from parcels.tools.converters import TimeConverter
+from parcels.tools.converters import UnitConverter
+from parcels.tools.converters import unitconverters_map
+from parcels.tools.error import FieldOutOfBoundError
+from parcels.tools.error import FieldSamplingError
+from parcels.tools.error import TimeExtrapolationError
+from parcels.tools.loggers import logger
 
 
 __all__ = ['Field', 'VectorField', 'SummedField', 'NestedField']

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1,14 +1,19 @@
-from parcels.field import Field, VectorField, SummedField, NestedField
-from parcels.gridset import GridSet
+from copy import deepcopy
+from glob import glob
+from os import path
+
+import dask.array as da
+import numpy as np
+
+from parcels.field import Field
+from parcels.field import NestedField
+from parcels.field import SummedField
+from parcels.field import VectorField
 from parcels.grid import Grid
-from parcels.tools.loggers import logger
+from parcels.gridset import GridSet
 from parcels.tools.converters import TimeConverter
 from parcels.tools.error import TimeExtrapolationError
-import numpy as np
-from os import path
-from glob import glob
-from copy import deepcopy
-import dask.array as da
+from parcels.tools.loggers import logger
 try:
     from mpi4py import MPI
 except:

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -1,8 +1,17 @@
-from parcels.tools.loggers import logger
-from parcels.tools.converters import TimeConverter
-import numpy as np
-from ctypes import Structure, c_int, c_float, c_double, POINTER, cast, c_void_p, pointer
+from ctypes import c_double
+from ctypes import c_float
+from ctypes import c_int
+from ctypes import c_void_p
+from ctypes import cast
+from ctypes import POINTER
+from ctypes import pointer
+from ctypes import Structure
 from enum import IntEnum
+
+import numpy as np
+
+from parcels.tools.converters import TimeConverter
+from parcels.tools.loggers import logger
 
 __all__ = ['GridCode', 'RectilinearZGrid', 'RectilinearSGrid', 'CurvilinearZGrid', 'CurvilinearSGrid', 'CGrid', 'Grid']
 

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -1,27 +1,43 @@
-from parcels.codegenerator import KernelGenerator, LoopGenerator
-from parcels.compiler import get_cache_dir
-from parcels.tools.error import ErrorCode, recovery_map as recovery_base_map
-from parcels.field import FieldOutOfBoundError, Field, SummedField, NestedField, VectorField
-from parcels.tools.loggers import logger
-from parcels.kernels.advection import AdvectionRK4_3D
-from os import path, remove
-import numpy as np
-import numpy.ctypeslib as npct
-import time
-from ctypes import c_int, c_float, c_double, c_void_p, byref
 import _ctypes
-from sys import platform, version_info
-from ast import parse, FunctionDef, Module
 import inspect
-from copy import deepcopy
-import re
-from hashlib import md5
 import math  # noqa
 import random  # noqa
+import re
+import time
+from ast import FunctionDef
+from ast import Module
+from ast import parse
+from copy import deepcopy
+from ctypes import byref
+from ctypes import c_double
+from ctypes import c_float
+from ctypes import c_int
+from ctypes import c_void_p
+from hashlib import md5
+from os import path
+from os import remove
+from sys import platform
+from sys import version_info
+
+import numpy as np
+import numpy.ctypeslib as npct
 try:
     from mpi4py import MPI
 except:
     MPI = None
+
+from parcels.codegenerator import KernelGenerator
+from parcels.codegenerator import LoopGenerator
+from parcels.compiler import get_cache_dir
+from parcels.field import Field
+from parcels.field import FieldOutOfBoundError
+from parcels.field import NestedField
+from parcels.field import SummedField
+from parcels.field import VectorField
+from parcels.kernels.advection import AdvectionRK4_3D
+from parcels.tools.error import ErrorCode
+from parcels.tools.error import recovery_map as recovery_base_map
+from parcels.tools.loggers import logger
 
 
 __all__ = ['Kernel']

--- a/parcels/kernels/advection.py
+++ b/parcels/kernels/advection.py
@@ -1,6 +1,7 @@
 """Collection of pre-built advection kernels"""
-from parcels.tools.error import ErrorCode
 import math
+
+from parcels.tools.error import ErrorCode
 
 
 __all__ = ['AdvectionRK4', 'AdvectionEE', 'AdvectionRK45', 'AdvectionRK4_3D']

--- a/parcels/kernels/diffusion.py
+++ b/parcels/kernels/diffusion.py
@@ -1,6 +1,7 @@
 """Collection of pre-built diffusion kernels"""
-from parcels import rng as random
 import math
+
+from parcels import rng as random
 
 
 __all__ = ['BrownianMotion2D', 'SpatiallyVaryingBrownianMotion2D']

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -1,8 +1,10 @@
-from parcels.tools.error import ErrorCode
-from parcels.field import Field
-from operator import attrgetter
-import numpy as np
 from ctypes import c_void_p
+from operator import attrgetter
+
+import numpy as np
+
+from parcels.field import Field
+from parcels.tools.error import ErrorCode
 from parcels.tools.loggers import logger
 
 

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -1,14 +1,16 @@
 """Module controlling the writing of ParticleSets to NetCDF file"""
-import numpy as np
-import netCDF4
-from datetime import timedelta as delta
-from parcels.tools.loggers import logger
 import os
+import random
 import shutil
 import string
-import random
-from parcels.tools.error import ErrorCode
+from datetime import timedelta as delta
 from glob import glob
+
+import netCDF4
+import numpy as np
+
+from parcels.tools.error import ErrorCode
+from parcels.tools.loggers import logger
 try:
     from mpi4py import MPI
 except:

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -1,17 +1,21 @@
-from parcels.kernel import Kernel
-from parcels.particle import JITParticle
-from parcels.compiler import GNUCompiler
-from parcels.kernels.advection import AdvectionRK4
-from parcels.particlefile import ParticleFile
-from parcels.tools.loggers import logger
-from parcels.grid import GridCode
-from parcels.field import NestedField, SummedField
+import collections
+import time as time_module
+from datetime import date
+from datetime import datetime
+from datetime import timedelta as delta
+
 import numpy as np
 import progressbar
-import time as time_module
-import collections
-from datetime import timedelta as delta
-from datetime import datetime, date
+
+from parcels.compiler import GNUCompiler
+from parcels.field import NestedField
+from parcels.field import SummedField
+from parcels.grid import GridCode
+from parcels.kernel import Kernel
+from parcels.kernels.advection import AdvectionRK4
+from parcels.particle import JITParticle
+from parcels.particlefile import ParticleFile
+from parcels.tools.loggers import logger
 try:
     from mpi4py import MPI
     from sklearn.cluster import KMeans

--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -1,10 +1,14 @@
-from parcels.field import Field, VectorField
-from parcels.grid import CurvilinearGrid, GridCode
-from parcels.tools.loggers import logger
-from parcels.tools.error import TimeExtrapolationError
-import numpy as np
-from datetime import timedelta as delta
 from datetime import datetime
+from datetime import timedelta as delta
+
+import numpy as np
+
+from parcels.field import Field
+from parcels.field import VectorField
+from parcels.grid import CurvilinearGrid
+from parcels.grid import GridCode
+from parcels.tools.error import TimeExtrapolationError
+from parcels.tools.loggers import logger
 
 
 def plotparticles(particles, with_particles=True, show_time=None, field=None, domain=None, projection=None,

--- a/parcels/rng.py
+++ b/parcels/rng.py
@@ -1,9 +1,13 @@
-from parcels.compiler import get_cache_dir, GNUCompiler
-from parcels.tools.loggers import logger
-from os import path
-import numpy.ctypeslib as npct
-from ctypes import c_int, c_float
 import uuid
+from ctypes import c_float
+from ctypes import c_int
+from os import path
+
+import numpy.ctypeslib as npct
+
+from parcels.compiler import get_cache_dir
+from parcels.compiler import GNUCompiler
+from parcels.tools.loggers import logger
 
 
 __all__ = ['seed', 'random', 'uniform', 'randint', 'normalvariate', 'expovariate']

--- a/parcels/scripts/convert_npydir_to_netcdf.py
+++ b/parcels/scripts/convert_npydir_to_netcdf.py
@@ -1,8 +1,10 @@
-from parcels import ParticleFile
-import numpy as np
-from os import path
-from glob import glob
 from argparse import ArgumentParser
+from glob import glob
+from os import path
+
+import numpy as np
+
+from parcels import ParticleFile
 
 
 def convert_npydir_to_netcdf(tempwritedir_base, delete_tempfiles=False):

--- a/parcels/scripts/get_examples.py
+++ b/parcels/scripts/get_examples.py
@@ -1,20 +1,23 @@
 """Get example scripts, notebooks, and data files."""
-
 import argparse
-from datetime import datetime, timedelta
-from glob import glob
 import json
 import os
+from datetime import datetime
+from datetime import timedelta
+from glob import glob
+import shutil
+import sys
+
 import pkg_resources
 from progressbar import ProgressBar
+
 try:
     # For Python 3.0 and later
     from urllib.request import urlopen
 except ImportError:
     # Fall back to Python 2's urllib2
     from urllib2 import urlopen
-import shutil
-import sys
+
 
 example_data_files = (
     ["MovingEddies_data/" + fn for fn in [

--- a/parcels/scripts/plottrajectoriesfile.py
+++ b/parcels/scripts/plottrajectoriesfile.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
-import xarray as xr
-import numpy as np
-from argparse import ArgumentParser
-from parcels import Field
-from os import environ
-from parcels.plotting import create_parcelsfig_axis, plotfield, cartopy_colorbar
 import sys
+from argparse import ArgumentParser
+from os import environ
+
+import numpy as np
+import xarray as xr
+
+from parcels import Field
+from parcels.plotting import cartopy_colorbar
+from parcels.plotting import create_parcelsfig_axis
+from parcels.plotting import plotfield
 try:
     if sys.platform == 'darwin' and sys.version_info[0] == 3:
         import matplotlib

--- a/parcels/tools/__init__.py
+++ b/parcels/tools/__init__.py
@@ -1,5 +1,5 @@
-from .timer import *  # noqa
 from .converters import *  # noqa
-from .loggers import *  # noqa
 from .error import *  # noqa
 from .interpolation_utils import *  # noqa
+from .loggers import *  # noqa
+from .timer import *  # noqa

--- a/parcels/tools/converters.py
+++ b/parcels/tools/converters.py
@@ -1,8 +1,10 @@
-from math import cos, pi
-import numpy as np
-import cftime
 import inspect
 from datetime import timedelta as delta
+from math import cos
+from math import pi
+
+import cftime
+import numpy as np
 
 __all__ = ['UnitConverter', 'Geographic', 'GeographicPolar', 'GeographicSquare',
            'GeographicPolarSquare', 'unitconverters_map',

--- a/parcels/tools/timer.py
+++ b/parcels/tools/timer.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
-import time
+
 import datetime
+import time
 try:
     from mpi4py import MPI
 except:


### PR DESCRIPTION
Group imports according to pep8 guidelines for better dependency management. https://www.python.org/dev/peps/pep-0008/#imports. The second group consists of external deps. 
