### PR TITLE
Multiple timestamps

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -948,7 +948,7 @@ class LoopGenerator(object):
         body += [c.Assign("particles[p].state", "res")]  # Store return code on particle
         update_pdt = c.If("_next_dt_set == 1", c.Block([c.Assign("_next_dt_set", "0"), c.Assign("particles[p].dt", "_next_dt")]))
         body += [c.If("res == SUCCESS || res == DELETE", c.Block([c.Statement("particles[p].time += particles[p].dt"), update_pdt,
-                                                 dt_pos, dt_0_break, c.Statement("continue")]),
+                                                                  dt_pos, dt_0_break, c.Statement("continue")]),
                  c.Block([c.Statement("get_particle_backup(&particle_backup, &(particles[p]))"),
                           dt_pos, c.Statement("break")]))]
 

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -206,7 +206,7 @@ class Field(object):
         :param netcdf_engine: engine to use for netcdf reading in xarray. Default is 'netcdf',
                but in cases where this doesn't work, setting netcdf_engine='scipy' could help
         """
-#         Ensure the timestamps array is compatible with the user-provided datafiles.
+        # Ensure the timestamps array is compatible with the user-provided datafiles.
         if timestamps is not None:
             if isinstance(filenames, list):
                 assert len(filenames) == len(timestamps), \
@@ -1055,7 +1055,7 @@ class Field(object):
     def computeTimeChunk(self, data, tindex):
         g = self.grid
         timestamp = None if self.timestamps is None else self.timestamps[tindex]
-        filebuffer = NetcdfFileBuffer(self.dataFiles[tindex], self.dimensions, self.indices,
+        filebuffer = NetcdfFileBuffer(self.dataFiles[g.ti + tindex], self.dimensions, self.indices,
                                       self.netcdf_engine, timestamp=timestamp,
                                       interp_method=self.interp_method,
                                       data_full_zdim=self.data_full_zdim,

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -108,7 +108,7 @@ class Field(object):
                 self.timestamps = timestamps
         else:
             self.timestamps = timestamps
-        # Note by DaanR: self.timestamps seems to be assigned twice: first as  
+        # Note by DaanR: self.timestamps seems to be assigned twice: first as
         # flattened array, second as nested array. Uncomment next line to see
         # this behavior.
         # print("self.timestamps:", timestamps)
@@ -240,14 +240,12 @@ class Field(object):
         # Ensure the timestamps array is compatible with the user-provided datafiles.
         if timestamps is not None:
             if isinstance(filenames, list):
-                assert len(filenames) == len(timestamps), \
-                'Outer dimension of timestamps should correspond to number of files.'
+                assert len(filenames) == len(timestamps), 'Outer dimension of timestamps should correspond to number of files.'
             elif isinstance(filenames, dict):
                 for k in filenames.keys():
-                    assert(len(filenames[k]) == len(timestamps)), \
-                    'Outer dimension of timestamps should correspond to number of files.'    
+                    assert(len(filenames[k]) == len(timestamps)), 'Outer dimension of timestamps should correspond to number of files.'
             else:
-                raise TypeError("Filenames type is inconsistent with manual timestamp provision." \
+                raise TypeError("Filenames type is inconsistent with manual timestamp provision."
                                 + "Should be dict or list")
 
         if isinstance(variable, xr.core.dataarray.DataArray):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -197,14 +197,14 @@ class Field(object):
                but in cases where this doesn't work, setting netcdf_engine='scipy' could help
         """
         # Ensure the timestamps array is compatible with the user-provided datafiles.
-        if timestamps is not None:
-            if isinstance(filenames, list):
-                assert len(filenames) == len(timestamps), 'Number of files and number of timestamps must be equal.'
-            elif isinstance(filenames, dict):
-                for k in filenames.keys():
-                    assert(len(filenames[k]) == len(timestamps)), 'Number of files and number of timestamps must be equal.'
-            else:
-                raise TypeError("filenames type is inconsistent with manual timestamp provision.")
+ #       if timestamps is not None:
+#            if isinstance(filenames, list):
+#                assert len(filenames) == len(timestamps), 'Number of files and number of timestamps must be equal.'
+  #          elif isinstance(filenames, dict):
+   #             for k in filenames.keys():
+    #                assert(len(filenames[k]) == len(timestamps)), 'Number of files and number of timestamps must be equal.'
+     #       else:
+      #          raise TypeError("filenames type is inconsistent with manual timestamp provision.")
 
         if isinstance(variable, xr.core.dataarray.DataArray):
             lonlat_filename = variable
@@ -1036,7 +1036,12 @@ class Field(object):
     def computeTimeChunk(self, data, tindex):
         g = self.grid
         timestamp = None if self.timestamps is None else self.timestamps[tindex]
-        filebuffer = NetcdfFileBuffer(self.dataFiles[g.ti+tindex], self.dimensions, self.indices,
+        # Temporary override for timestamp issue
+        if self.dataFiles.shape[0] == 1:
+            ftindex = 0
+        else:
+            ftindex = g.ti+tindex
+        filebuffer = NetcdfFileBuffer(self.dataFiles[ftindex], self.dimensions, self.indices,
                                       self.netcdf_engine, timestamp=timestamp,
                                       interp_method=self.interp_method,
                                       data_full_zdim=self.data_full_zdim,

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -100,18 +100,12 @@ class Field(object):
             raise ValueError("Unsupported mesh type. Choose either: 'spherical' or 'flat'")
         if timestamps is not None:
             # Check whether flattened or not
-            if all(isinstance(file, np.ndarray) for file in timestamps):
-                # Flatten
-                self.timestamps = np.array([stamp for file in timestamps for stamp in file])
+            if all(isinstance(f, np.ndarray) for f in timestamps):
+                self.timestamps = np.array([stamp for f in timestamps for stamp in f])
             if all(isinstance(stamp, np.datetime64) for stamp in timestamps):
-                # Pass
                 self.timestamps = timestamps
         else:
             self.timestamps = timestamps
-        # Note by DaanR: self.timestamps seems to be assigned twice: first as
-        # flattened array, second as nested array. Uncomment next line to see
-        # this behavior.
-        # print("self.timestamps:", timestamps)
         if type(interp_method) is dict:
             if self.name in interp_method:
                 self.interp_method = interp_method[self.name]
@@ -316,11 +310,9 @@ class Field(object):
             # across multiple files
             if timestamps is not None:
                 dataFiles = []
-                # Timesteps are nested.
                 for findex in range(len(data_filenames)):
                     for f in [data_filenames[findex]] * len(timestamps[findex]):
                         dataFiles.append(f)
-                # Flatten back
                 timestamps = np.array([stamp for file in timestamps for stamp in file])
                 timeslices = timestamps
                 time = timeslices

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -85,12 +85,13 @@ class Field(object):
             raise ValueError("Unsupported mesh type. Choose either: 'spherical' or 'flat'")
         self.timestamps = timestamps
         # Check whether flattened or not
-        if all(isinstance(file, np.ndarray) for file in timestamps):
-            # Flatten
-            self.timestamps = np.array([stamp for file in timestamps for stamp in file])
-        if all(isinstance(stamp, np.datetime64) for stamp in timestamps):
-            # Pass
-            self.timestamps = timestamps
+        if timestamps is not None:
+            if all(isinstance(file, np.ndarray) for file in timestamps):
+                # Flatten
+                self.timestamps = np.array([stamp for file in timestamps for stamp in file])
+            if all(isinstance(stamp, np.datetime64) for stamp in timestamps):
+                # Pass
+                self.timestamps = timestamps
         # Note by DaanR: self.timestamps seems to be assigned twice: first as  
         # flattened array, second as nested array. Uncomment next line to see
         # this behavior.

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -83,15 +83,16 @@ class Field(object):
             self.units = unitconverters_map[self.fieldtype]
         else:
             raise ValueError("Unsupported mesh type. Choose either: 'spherical' or 'flat'")
-        self.timestamps = timestamps
-        # Check whether flattened or not
         if timestamps is not None:
+            # Check whether flattened or not
             if all(isinstance(file, np.ndarray) for file in timestamps):
                 # Flatten
                 self.timestamps = np.array([stamp for file in timestamps for stamp in file])
             if all(isinstance(stamp, np.datetime64) for stamp in timestamps):
                 # Pass
                 self.timestamps = timestamps
+        else:
+            self.timestamps = timestamps
         # Note by DaanR: self.timestamps seems to be assigned twice: first as  
         # flattened array, second as nested array. Uncomment next line to see
         # this behavior.

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -235,7 +235,7 @@ class FieldSet(object):
                1. spherical (default): Lat and lon in degree, with a
                   correction for zonal velocity U near the poles.
                2. flat: No conversion, lat/lon are assumed to be in m.
-        :param timestamps: list of list or array of arrays containing the timestamps for
+        :param timestamps: list of lists or array of arrays containing the timestamps for
                each of the files in filenames. Outer list/array corresponds to files, inner
                array corresponds to indices within files.
                Default is None if dimensions includes time.

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -230,7 +230,9 @@ class FieldSet(object):
                1. spherical (default): Lat and lon in degree, with a
                   correction for zonal velocity U near the poles.
                2. flat: No conversion, lat/lon are assumed to be in m.
-        :param timestamps: A numpy array containing the timestamps for each of the files in filenames.
+        :param timestamps: list of list or array of arrays containing the timestamps for 
+               each of the files in filenames. Outer list/array corresponds to files, inner
+               array corresponds to indices within files.
                Default is None if dimensions includes time.
         :param allow_time_extrapolation: boolean whether to allow for extrapolation
                (i.e. beyond the last available time snapshot)
@@ -250,12 +252,19 @@ class FieldSet(object):
             logger.warning_once("Time already provided, defaulting to dimensions['time'] over timestamps.")
             timestamps = None
 
-        # Typecast timestamps to numpy array & correct shape.
+        # Typecast timestamps to (nested) numpy array.
         if timestamps is not None:
             if isinstance(timestamps, list):
                 timestamps = np.array(timestamps)
-            timestamps = np.reshape(timestamps, [timestamps.size, 1])
-
+                if any(isinstance(i, list) for i in timestamps):
+                    timestamps = np.array([np.array(sub) for sub in timestamps])
+            assert(isinstance(timestamps, np.ndarray), 
+                   "Timestamps must be nested list or array")
+            assert(all(isinstance(file, np.ndarray) for file in timestamps),  
+                   "Timestamps must be nested list or array")
+            assert(all(isinstance(stamp, np.datetime64) for file in timestamps for stamp in file),  
+                   "Timestamps must be nested list or array. Outer array corresponds to files, "
+                   "while inner array corresponds to time indices within each file.")
         fields = {}
         if 'creation_log' not in kwargs.keys():
             kwargs['creation_log'] = 'from_netcdf'

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -265,8 +265,6 @@ class FieldSet(object):
                     timestamps = np.array([np.array(sub) for sub in timestamps])
             assert isinstance(timestamps, np.ndarray), "Timestamps must be nested list or array"
             assert all(isinstance(file, np.ndarray) for file in timestamps), "Timestamps must be nested list or array"
-            if all(isinstance(stamp, np.datetime64) for file in timestamps for stamp in file):
-                raise AssertionError("Timestamps must be nested list or array. Outer array corresponds to files, while inner array corresponds to time indices within each file.")
         fields = {}
         if 'creation_log' not in kwargs.keys():
             kwargs['creation_log'] = 'from_netcdf'

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -235,7 +235,7 @@ class FieldSet(object):
                1. spherical (default): Lat and lon in degree, with a
                   correction for zonal velocity U near the poles.
                2. flat: No conversion, lat/lon are assumed to be in m.
-        :param timestamps: list of list or array of arrays containing the timestamps for 
+        :param timestamps: list of list or array of arrays containing the timestamps for
                each of the files in filenames. Outer list/array corresponds to files, inner
                array corresponds to indices within files.
                Default is None if dimensions includes time.
@@ -263,13 +263,10 @@ class FieldSet(object):
                 timestamps = np.array(timestamps)
                 if any(isinstance(i, list) for i in timestamps):
                     timestamps = np.array([np.array(sub) for sub in timestamps])
-            assert(isinstance(timestamps, np.ndarray), 
-                   "Timestamps must be nested list or array")
-            assert(all(isinstance(file, np.ndarray) for file in timestamps),  
-                   "Timestamps must be nested list or array")
-            assert(all(isinstance(stamp, np.datetime64) for file in timestamps for stamp in file),  
-                   "Timestamps must be nested list or array. Outer array corresponds to files, "
-                   "while inner array corresponds to time indices within each file.")
+            assert isinstance(timestamps, np.ndarray), "Timestamps must be nested list or array"
+            assert all(isinstance(file, np.ndarray) for file in timestamps), "Timestamps must be nested list or array"
+            if all(isinstance(stamp, np.datetime64) for file in timestamps for stamp in file):
+                raise AssertionError("Timestamps must be nested list or array. Outer array corresponds to files, while inner array corresponds to time indices within each file.")
         fields = {}
         if 'creation_log' not in kwargs.keys():
             kwargs['creation_log'] = 'from_netcdf'

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -334,14 +334,20 @@ def test_vector_fields(mode, swapUV):
         assert abs(pset[0].lat - .5) < 1e-9
 
 
-def test_timestaps(tmpdir):
+@pytest.mark.parametrize('datetype', ['float', 'datetime64'])
+def test_timestaps(datetype, tmpdir):
     data1, dims1 = generate_fieldset(10, 10, 1, 10)
-    dims1['time'] = np.arange(0, 10, 1) * 3600
+    data2, dims2 = generate_fieldset(10, 10, 1, 4)
+    if datetype == 'float':
+        dims1['time'] = np.arange(0, 10, 1) * 3600
+        dims2['time'] = np.arange(10, 14, 1) * 3600
+    else:
+        dims1['time'] = np.arange('2005-02-01', '2005-02-11', dtype='datetime64[D]')
+        dims2['time'] = np.arange('2005-02-11', '2005-02-15', dtype='datetime64[D]')
+
     fieldset1 = FieldSet.from_data(data1, dims1)
     fieldset1.write(tmpdir.join('file1'))
 
-    data2, dims2 = generate_fieldset(10, 10, 1, 4)
-    dims2['time'] = np.arange(11, 15, 1) * 3600
     fieldset2 = FieldSet.from_data(data2, dims2)
     fieldset2.write(tmpdir.join('file2'))
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -353,7 +353,7 @@ def test_timestaps(datetype, tmpdir):
 
     fieldset3 = FieldSet.from_parcels(tmpdir.join('file*'))
     timestamps = [dims1['time'], dims2['time']]
-    fieldset4 = FieldSet.from_parcels('file*', timestamps=timestamps)
+    fieldset4 = FieldSet.from_parcels(tmpdir.join('file*'), timestamps=timestamps)
     assert np.allclose(fieldset3.U.grid.time_full, fieldset4.U.grid.time_full)
 
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -334,6 +334,23 @@ def test_vector_fields(mode, swapUV):
         assert abs(pset[0].lat - .5) < 1e-9
 
 
+def test_timestaps(tmpdir):
+    data1, dims1 = generate_fieldset(10, 10, 1, 10)
+    dims1['time'] = np.arange(0, 10, 1) * 3600
+    fieldset1 = FieldSet.from_data(data1, dims1)
+    fieldset1.write(tmpdir.join('file1'))
+
+    data2, dims2 = generate_fieldset(10, 10, 1, 4)
+    dims2['time'] = np.arange(11, 15, 1) * 3600
+    fieldset2 = FieldSet.from_data(data2, dims2)
+    fieldset2.write(tmpdir.join('file2'))
+
+    fieldset3 = FieldSet.from_parcels('file*')
+    timestamps = [dims1['time'], dims2['time']]
+    fieldset4 = FieldSet.from_parcels('file*', timestamps=timestamps)
+    assert np.allclose(fieldset3.U.grid.time_full, fieldset4.U.grid.time_full)
+
+
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 @pytest.mark.parametrize('time_periodic', [True, False])
 @pytest.mark.parametrize('dt_sign', [-1, 1])

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -345,7 +345,7 @@ def test_timestaps(tmpdir):
     fieldset2 = FieldSet.from_data(data2, dims2)
     fieldset2.write(tmpdir.join('file2'))
 
-    fieldset3 = FieldSet.from_parcels('file*')
+    fieldset3 = FieldSet.from_parcels(tmpdir.join('file*'))
     timestamps = [dims1['time'], dims2['time']]
     fieldset4 = FieldSet.from_parcels('file*', timestamps=timestamps)
     assert np.allclose(fieldset3.U.grid.time_full, fieldset4.U.grid.time_full)


### PR DESCRIPTION
Solution for issue #648 

`timestamps` must now always be a nested list or array. The outer list indices correspond to each datafile, while the inner list indices correspond to time indices within a NetCDF file. This allows `timestamps` to work for:
- multiple snapshot (i.e. one time index) files: inner array length is 1, outer array length corresponds to number of snapshots
- one NetCDF file with time indices that Parcels cannot readily process: outer array length is 1, inner array length corresponds to number of time indices
- combination of the above