### PR TITLE
Cheap fieldset loading

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -798,7 +798,8 @@ class FieldSet(object):
                     g.load_chunk = np.where(g.load_chunk == 2, 1, g.load_chunk)
                     g.load_chunk = np.where(g.load_chunk == 3, 0, g.load_chunk)
             elif g.update_status == 'updated':
-                data = da.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
+                lib = np if isinstance(f.data, np.ndarray) else da
+                data = lib.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
                 if signdt >= 0:
                     f.loaded_time_indices = [2]
                     f.filebuffers[0].dataset.close()
@@ -812,12 +813,12 @@ class FieldSet(object):
                 data = f.rescale_and_set_minmax(data)
                 if signdt >= 0:
                     data = f.reshape(data)[2:, :]
-                    f.data = da.concatenate([f.data[1:, :], data], axis=0)
+                    f.data = lib.concatenate([f.data[1:, :], data], axis=0)
                 else:
                     data = f.reshape(data)[0:1, :]
-                    f.data = da.concatenate([data, f.data[:2, :]], axis=0)
+                    f.data = lib.concatenate([data, f.data[:2, :]], axis=0)
                 g.load_chunk = np.where(g.load_chunk == 3, 0, g.load_chunk)
-                if len(g.load_chunk) > 0:
+                if isinstance(f.data, da.core.Array) and len(g.load_chunk) > 0:
                     if signdt >= 0:
                         for block_id in range(len(g.load_chunk)):
                             if g.load_chunk[block_id] == 2:

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -813,10 +813,18 @@ class FieldSet(object):
                 data = f.rescale_and_set_minmax(data)
                 if signdt >= 0:
                     data = f.reshape(data)[2:, :]
-                    f.data = lib.concatenate([f.data[1:, :], data], axis=0)
+                    if lib is da:
+                        f.data = da.concatenate([f.data[1:, :], data], axis=0)
+                    else:
+                        f.data[:2, :] = f.data[1:, :]
+                        f.data[2, :] = data
                 else:
                     data = f.reshape(data)[0:1, :]
-                    f.data = lib.concatenate([data, f.data[:2, :]], axis=0)
+                    if lib is da:
+                        f.data = da.concatenate([data, f.data[:2, :]], axis=0)
+                    else: 
+                        f.data[1:, :] = f.data[:2, :]
+                        f.data[0, :] = data
                 g.load_chunk = np.where(g.load_chunk == 3, 0, g.load_chunk)
                 if isinstance(f.data, da.core.Array) and len(g.load_chunk) > 0:
                     if signdt >= 0:


### PR DESCRIPTION
In this PR, we manage in a better way the specific case of fields which are loaded in one single chunk (np.array instead of dask.array then)