### PR TITLE
warning if dt is modified during kernel returning SUCCESS

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -939,7 +939,8 @@ class LoopGenerator(object):
         part_loop = c.For("p = 0", "p < num_particles", "++p",
                           c.Block([sign_end_part, notstarted_continue, dt_pos, time_loop]))
         fbody = c.Block([c.Value("int", "p, sign_dt, sign_end_part"), c.Value("ErrorCode", "res"),
-                         c.Value("double", "__dt, __tol, __pdt"), c.Assign("__tol", "1.e-6"),
+                         c.Value("float", "__pdt"),
+                         c.Value("double", "__dt, __tol"), c.Assign("__tol", "1.e-6"),
                          sign_dt, particle_backup, part_loop])
         fdecl = c.FunctionDeclaration(c.Value("void", "particle_loop"), args)
         ccode += [str(c.FunctionBody(fdecl, fbody))]

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -827,7 +827,7 @@ class FieldSet(object):
                     data = f.reshape(data)[0:1, :]
                     if lib is da:
                         f.data = da.concatenate([data, f.data[:2, :]], axis=0)
-                    else: 
+                    else:
                         f.data[1:, :] = f.data[:2, :]
                         f.data[0, :] = data
                 g.load_chunk = np.where(g.load_chunk == 3, 0, g.load_chunk)

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -279,7 +279,6 @@ class Kernel(object):
                     res = self.pyfunc(p, pset.fieldset, p.time)
                     if (res is None or res == ErrorCode.Success) and not np.isclose(p.dt, pdt):
                         res = ErrorCode.Repeat
-                    p.update_next_dt()
                 except FieldOutOfBoundError as fse:
                     res = ErrorCode.ErrorOutOfBounds
                     p.exception = fse
@@ -294,7 +293,8 @@ class Kernel(object):
                 # Handle particle time and time loop
                 if res is None or res == ErrorCode.Success:
                     # Update time and repeat
-                    p.time += sign_dt * dt_pos
+                    p.time += p.dt
+                    p.update_next_dt()
                     dt_pos = min(abs(p.dt), abs(endtime - p.time))
                     if dt == 0:
                         break

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -278,11 +278,8 @@ class Kernel(object):
                     p.dt = pdt
                     res = self.pyfunc(p, pset.fieldset, p.time)
                     if (res is None or res == ErrorCode.Success) and not np.isclose(p.dt, pdt):
-                        next_time = p.time + sign_dt * dt_pos
-                        next_dt_pos = min(abs(p.dt), abs(endtime - next_time))
-                        if pdt < next_dt_pos:
-                            print('here', p.dt, pdt, next_dt_pos)
-                            res = ErrorCode.Repeat
+                        res = ErrorCode.Repeat
+                    p.update_next_dt()
                 except FieldOutOfBoundError as fse:
                     res = ErrorCode.ErrorOutOfBounds
                     p.exception = fse

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -274,8 +274,11 @@ class Kernel(object):
                 for var in ptype.variables:
                     p_var_back[var.name] = getattr(p, var.name)
                 try:
-                    p.dt = sign_dt * dt_pos
+                    pdt = sign_dt * dt_pos
+                    p.dt = pdt
                     res = self.pyfunc(p, pset.fieldset, p.time)
+                    if not np.isclose(p.dt, pdt):
+                        logger.warning('Particle.dt was modified in the kernel. This has spurious effects on the particle integration. You should return a REPEAT error if you modify the time step.')
                 except FieldOutOfBoundError as fse:
                     res = ErrorCode.ErrorOutOfBounds
                     p.exception = fse

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -275,10 +275,10 @@ class Kernel(object):
                 for var in ptype.variables:
                     p_var_back[var.name] = getattr(p, var.name)
                 try:
-                    pdt = sign_dt * dt_pos
-                    p.dt = pdt
+                    pdt_prekernels = sign_dt * dt_pos
+                    p.dt = pdt_prekernels
                     res = self.pyfunc(p, pset.fieldset, p.time)
-                    if (res is None or res == ErrorCode.Success) and not np.isclose(p.dt, pdt):
+                    if (res is None or res == ErrorCode.Success) and not np.isclose(p.dt, pdt_prekernels):
                         res = ErrorCode.Repeat
                 except FieldOutOfBoundError as fse:
                     res = ErrorCode.ErrorOutOfBounds

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -277,7 +277,7 @@ class Kernel(object):
                     pdt = sign_dt * dt_pos
                     p.dt = pdt
                     res = self.pyfunc(p, pset.fieldset, p.time)
-                    if not np.isclose(p.dt, pdt):
+                    if (res is None or res == ErrorCode.Success) and not np.isclose(p.dt, pdt):
                         logger.warning('Particle.dt was modified in the kernel. This has spurious effects on the particle integration. You should return a REPEAT error if you modify the time step.')
                 except FieldOutOfBoundError as fse:
                     res = ErrorCode.ErrorOutOfBounds

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -278,7 +278,11 @@ class Kernel(object):
                     p.dt = pdt
                     res = self.pyfunc(p, pset.fieldset, p.time)
                     if (res is None or res == ErrorCode.Success) and not np.isclose(p.dt, pdt):
-                        logger.warning('Particle.dt was modified in the kernel. This has spurious effects on the particle integration. You should return a REPEAT error if you modify the time step.')
+                        next_time = p.time + sign_dt * dt_pos
+                        next_dt_pos = min(abs(p.dt), abs(endtime - next_time))
+                        if pdt < next_dt_pos:
+                            print('here', p.dt, pdt, next_dt_pos)
+                            res = ErrorCode.Repeat
                 except FieldOutOfBoundError as fse:
                     res = ErrorCode.ErrorOutOfBounds
                     p.exception = fse

--- a/parcels/kernels/advection.py
+++ b/parcels/kernels/advection.py
@@ -96,7 +96,7 @@ def AdvectionRK45(particle, fieldset, time):
         particle.lon = lon_4th
         particle.lat = lat_4th
         if kappa <= math.fabs(particle.dt * tol[0] / 10):
-            particle.dt *= 2
+            particle.update_next_dt(particle.dt * 2)
     else:
         particle.dt /= 2
         return ErrorCode.Repeat

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -185,6 +185,7 @@ class ScipyParticle(_Particle):
         _Particle.lastID = max(_Particle.lastID, pid)
         type(self).dt.initial = None
         super(ScipyParticle, self).__init__()
+        self._next_dt = None
 
     def __repr__(self):
         time_string = 'not_yet_set' if self.time is None or np.isnan(self.time) else "{:f}".format(self.time)
@@ -202,6 +203,14 @@ class ScipyParticle(_Particle):
         cls.lon.dtype = dtype
         cls.lat.dtype = dtype
         cls.depth.dtype = dtype
+
+    def update_next_dt(self, next_dt=None):
+        if next_dt is None:
+            if self._next_dt is not None:
+                self.dt = self._next_dt
+                self._next_dt = None
+        else:
+            self._next_dt = next_dt
 
 
 class JITParticle(ScipyParticle):

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -232,7 +232,8 @@ class ParticleFile(object):
             if pset.size == 0:
                 logger.warning("ParticleSet is empty on writing as array at time %g" % time)
             else:
-                pset_towrite = [p for p in pset if p.dt * p.time <= p.dt * time and np.isfinite(p.id)]
+                tol = 1e-8
+                pset_towrite = [p for p in pset if p.dt * p.time < p.dt * time + tol and np.isfinite(p.id)]
                 if len(pset_towrite) > 0:
                     for var in self.var_names:
                         data_dict[var] = np.array([getattr(p, var) for p in pset_towrite])

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -295,7 +295,3 @@ def test_dt_modif_by_kernel(fieldset, mode, capfd):
         particle.dt = 2
 
     pset.execute(modif_dt, endtime=4., dt=1.)
-    if mode == 'jit':
-        out, err = capfd.readouterr()
-        err_msg = "Particle.dt was modified in the kernel. This has spurious effects on the particle integration. You should return a REPEAT error if you modify the time step.\n"
-        assert out[:50] == err_msg[:50]

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -288,10 +288,15 @@ def test_c_kernel(fieldset, mode, c_inc):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
-def test_dt_modif_by_kernel(fieldset, mode, capfd):
-    pset = ParticleSet(fieldset, pclass=ptype[mode], lon=[0.5], lat=[0])
+def test_dt_modif_by_kernel(fieldset, mode):
+    class TestParticle(ptype[mode]):
+        age = Variable('age', dtype=np.float32)
+    pset = ParticleSet(fieldset, pclass=TestParticle, lon=[0.5], lat=[0])
 
     def modif_dt(particle, fieldset, time):
+        particle.age += particle.dt
         particle.dt = 2
 
-    pset.execute(modif_dt, endtime=4., dt=1.)
+    endtime = 4
+    pset.execute(modif_dt, endtime=endtime, dt=1.)
+    assert np.isclose(pset[0].age, endtime)


### PR DESCRIPTION
This PR captures if a kernel has modified `particle.dt`.
This leads to problems in many situations:
* In our code, `particle.time` will be updated using the `dt` before the kernel call, ignoring the `dt`, which will be used at next kernel call (so one time step later)
* everything called after the `particle.dt` will then be executed with the wrong dt

-> There is no problem if after modifying dt, the kernel returns `REPEAT`, in which case, all variables are reset to their value before the kernel call (except dt) and the kernel is rerun


Problems:
* In current version of the PR, JIT particles call a warning for each occurence of p.dt modification. This can lead to a lot of prints
* the test does not capture the scipy particle warning. Nothing is really tested there
* Should JIT particle return a different error code in case of p.dt modifications, and a true warning_once be printed? There will be only one print, but the C loop will be broken all the time...

Solution? Why do we want to raise a warning? Why don't deleting the particle (or even killing the run?). Modifying dt during kernel execution is dangerous. Some users could use such operation correctly. But they could also do the same job without modifying the dt like this. It's better to completely disable such operation