### PR TITLE
Removing GitHub actions on push, keeping only on pull requests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,5 +1,5 @@
 name: test-suite
-on: [push, pull_request]
+on: pull_request
 jobs:
   test_macOS:
     name: Testing on macOS


### PR DESCRIPTION
Since otherwise events are twice triggered