### PR TITLE
Fixing a bug in cartopy.quiver() when input not numpy.ndarray

### DIFF
--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -187,7 +187,7 @@ def plotfield(field, show_time=None, domain=None, depth_level=0, projection=None
         u = np.where(speed > 0., data[0]/speed, 0)
         v = np.where(speed > 0., data[1]/speed, 0)
         if cartopy:
-            cs = ax.quiver(x, y, u, v, speed, cmap=plt.cm.gist_ncar, clim=[vmin, vmax], scale=50, transform=cartopy.crs.PlateCarree())
+            cs = ax.quiver(np.asarray(x), np.asarray(y), np.asarray(u), np.asarray(v), speed, cmap=plt.cm.gist_ncar, clim=[vmin, vmax], scale=50, transform=cartopy.crs.PlateCarree())
         else:
             cs = ax.quiver(x, y, u, v, speed, cmap=plt.cm.gist_ncar, clim=[vmin, vmax], scale=50)
     else:


### PR DESCRIPTION
See also https://github.com/SciTools/cartopy/issues/1363 for the workaround that we implement here