### PR TITLE
delete_cfiles argument in Kernel initialisation

### DIFF
--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -61,6 +61,7 @@ class Kernel(object):
 
     :arg fieldset: FieldSet object providing the field information
     :arg ptype: PType object for the kernel particle
+    :param delete_cfiles: Boolean whether to delete the C-files after compilation in JIT mode (default is True)
 
     Note: A Kernel is either created from a compiled <function ...> object
     or the necessary information (funcname, funccode, funcvars) is provided.
@@ -69,10 +70,11 @@ class Kernel(object):
     """
 
     def __init__(self, fieldset, ptype, pyfunc=None, funcname=None,
-                 funccode=None, py_ast=None, funcvars=None, c_include=""):
+                 funccode=None, py_ast=None, funcvars=None, c_include="", delete_cfiles=False):
         self.fieldset = fieldset
         self.ptype = ptype
         self._lib = None
+        self.delete_cfiles = delete_cfiles
 
         # Derive meta information from pyfunc, if not given
         self.funcname = funcname or pyfunc.__name__
@@ -171,7 +173,7 @@ class Kernel(object):
             _ctypes.FreeLibrary(self._lib._handle) if platform == 'win32' else _ctypes.dlclose(self._lib._handle)
             del self._lib
             self._lib = None
-            if path.isfile(self.lib_file):
+            if path.isfile(self.lib_file) and self.delete_cfiles:
                 [remove(s) for s in [self.src_file, self.lib_file, self.log_file]]
 
     @property

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -70,7 +70,7 @@ class Kernel(object):
     """
 
     def __init__(self, fieldset, ptype, pyfunc=None, funcname=None,
-                 funccode=None, py_ast=None, funcvars=None, c_include="", delete_cfiles=False):
+                 funccode=None, py_ast=None, funcvars=None, c_include="", delete_cfiles=True):
         self.fieldset = fieldset
         self.ptype = ptype
         self._lib = None

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -599,10 +599,13 @@ class ParticleSet(object):
 
         return density
 
-    def Kernel(self, pyfunc, c_include=""):
+    def Kernel(self, pyfunc, c_include="", delete_cfiles=True):
         """Wrapper method to convert a `pyfunc` into a :class:`parcels.kernel.Kernel` object
-        based on `fieldset` and `ptype` of the ParticleSet"""
-        return Kernel(self.fieldset, self.ptype, pyfunc=pyfunc, c_include=c_include)
+        based on `fieldset` and `ptype` of the ParticleSet
+        :param delete_cfiles: Boolean whether to delete the C-files after compilation in JIT mode (default is True)
+        """
+        return Kernel(self.fieldset, self.ptype, pyfunc=pyfunc, c_include=c_include,
+                      delete_cfiles=delete_cfiles)
 
     def ParticleFile(self, *args, **kwargs):
         """Wrapper method to initialise a :class:`parcels.particlefile.ParticleFile`

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -1,3 +1,4 @@
+from os import path
 from parcels import (
     FieldSet, ParticleSet, ScipyParticle, JITParticle, ErrorCode, KernelError,
     OutOfBoundsError
@@ -262,3 +263,15 @@ def test_errorcode_repeat(fieldset, mode):
 
     pset = ParticleSet(fieldset, pclass=ptype[mode], lon=[0.], lat=[0.])
     pset.execute(pset.Kernel(simpleKernel), endtime=3., dt=1.)
+
+
+@pytest.mark.parametrize('delete_cfiles', [True, False])
+def test_execution_keep_cfiles(fieldset, delete_cfiles):
+    pset = ParticleSet(fieldset, pclass=JITParticle, lon=[0.], lat=[0.])
+    pset.execute(pset.Kernel(DoNothing, delete_cfiles=delete_cfiles), endtime=1., dt=1.)
+    cfile = pset.kernel.src_file
+    del pset.kernel
+    if delete_cfiles:
+        assert not path.exists(cfile)
+    else:
+        assert path.exists(cfile)


### PR DESCRIPTION
Adding an argument to `Kernel.__init__` to keep the C files after `Kernel` object is deleted

This aids debugging, as C-files are not removed anymore at end of python run and so can be more easily investigated if something goes wrong in JIT mode