### PR TITLE
Adding vonmisesvariate function

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -149,6 +149,7 @@ class RandomNode(IntrinsicNode):
                   'randint': 'parcels_randint',
                   'normalvariate': 'parcels_normalvariate',
                   'expovariate': 'parcels_expovariate',
+                  'vonmisesvariate': 'parcels_vonmisesvariate',
                   'seed': 'parcels_seed'}
 
     def __getattr__(self, attr):

--- a/parcels/include/random.h
+++ b/parcels/include/random.h
@@ -58,6 +58,50 @@ static inline float parcels_expovariate(float lamb)
   return (-log(1.0-u)/lamb);
 }
 
+static inline float parcels_vonmisesvariate(float mu, float kappa)
+/* Circular data distribution.                                              */
+/* Returns a float between 0 and 2*pi                                       */
+/* mu is the mean angle, expressed in radians between 0 and 2*pi, and       */
+/* kappa is the concentration parameter, which must be greater than or      */
+/* equal to zero.  If kappa is equal to zero, this distribution reduces     */
+/* to a uniform random angle over the range 0 to 2*pi.                      */
+/* Based upon an algorithm published in: Fisher, N.I.,                      */
+/* Statistical Analysis of Circular Data", Cambridge University Press, 1993.*/
+{
+  float u1, u2, u3, r, s, z, d, f, q, theta;
+
+  if (kappa <= 1e-6){
+    return (2.0 * M_PI * (float)rand()/(float)(RAND_MAX));
+  }
+
+  s = 0.5 / kappa;
+  r = s + sqrt(1.0 + s * s);
+
+  do {
+    u1 = (float)rand()/(float)(RAND_MAX);
+    z = cos(M_PI * u1);
+
+    d = z / (r + z);
+    u2 = (float)rand()/(float)(RAND_MAX);
+  }  while ( ( u2 >= (1.0 - d * d) ) && ( u2 > (1.0 - d) * exp(d) ) );
+
+  q = 1.0 / r;
+  f = (q + z) / (1.0 + q * z);
+  u3 = (float)rand()/(float)(RAND_MAX);
+
+  if (u3 > 0.5){
+    theta = mu + acos(f), 2*M_PI ;
+  }
+  else {
+    theta = mu - acos(f), 2*M_PI;
+  }
+  if (theta < 0){
+    theta = 2*M_PI+theta;
+  }
+
+  return theta;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/parcels/rng.py
+++ b/parcels/rng.py
@@ -10,7 +10,7 @@ from parcels.compiler import GNUCompiler
 from parcels.tools.loggers import logger
 
 
-__all__ = ['seed', 'random', 'uniform', 'randint', 'normalvariate', 'expovariate']
+__all__ = ['seed', 'random', 'uniform', 'randint', 'normalvariate', 'expovariate', 'vonmisesvariate']
 
 
 class Random(object):
@@ -45,8 +45,13 @@ extern float pcls_expovariate(float lamb){
   return parcels_expovariate(lamb);
 }
 """
+    fnct_vonmisesvariate = """
+extern float pcls_vonmisesvariate(float mu, float kappa){
+  return parcels_vonmisesvariate(mu, kappa);
+}
+"""
     ccode = stmt_import + fnct_seed
-    ccode += fnct_random + fnct_uniform + fnct_randint + fnct_normalvariate + fnct_expovariate
+    ccode += fnct_random + fnct_uniform + fnct_randint + fnct_normalvariate + fnct_expovariate + fnct_vonmisesvariate
     basename = path.join(get_cache_dir(), 'parcels_random_%s' % uuid.uuid4())
     src_file = "%s.c" % basename
     lib_file = "%s.so" % basename
@@ -112,3 +117,12 @@ def expovariate(lamb):
     rnd.argtype = c_float
     rnd.restype = c_float
     return rnd(c_float(lamb))
+
+
+def vonmisesvariate(mu, kappa):
+    """Returns a randome float of a Von Mises distribution
+    with mean angle mu and concentration parameter kappa"""
+    rnd = parcels_random.lib.pcls_vonmisesvariate
+    rnd.argtype = [c_float, c_float]
+    rnd.restype = c_float
+    return rnd(c_float(mu), c_float(kappa))

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -114,7 +114,7 @@ def test_randomexponential(mode, lambd, npart=1000):
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 @pytest.mark.parametrize('mu', [0.8*np.pi, np.pi])
 @pytest.mark.parametrize('kappa', [2, 4])
-def test_randomvonmises(mode, mu, kappa, npart=1000):
+def test_randomvonmises(mode, mu, kappa, npart=10000):
     fieldset = zeros_fieldset()
 
     # Parameters for random.vonmisesvariate
@@ -129,7 +129,6 @@ def test_randomvonmises(mode, mu, kappa, npart=1000):
     pset = ParticleSet(fieldset=fieldset, pclass=AngleParticle, lon=np.zeros(npart), lat=np.zeros(npart), depth=np.zeros(npart))
 
     def vonmises(particle, fieldset, time):
-        # Kernel for random exponential variable in depth direction
         particle.angle = random.vonmisesvariate(fieldset.mu, fieldset.kappa)
 
     pset.execute(vonmises, runtime=1, dt=1)
@@ -137,3 +136,6 @@ def test_randomvonmises(mode, mu, kappa, npart=1000):
     angles = np.array([p.angle for p in pset])
 
     assert np.allclose(np.mean(angles), mu, atol=.1)
+    scipy_mises = stats.vonmises.rvs(kappa, loc=mu, size=10000)
+    assert np.allclose(np.mean(angles), np.mean(scipy_mises), atol=.1)
+    assert np.allclose(np.std(angles), np.std(scipy_mises), atol=.1)


### PR DESCRIPTION
This PR adds a `vonmisesvariate` function to the parcels library of random functions. It follows @pierrick-giffard suggestion in #724 

@pierrick-giffard, could you check if this implementation works for you? And could you also propose another `assert` statement in the `test_diffusion.py` function to check if implementation of kappa is correct?