### PR TITLE
Handle pass statement in kernels

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -692,6 +692,9 @@ class KernelGenerator(ast.NodeVisitor):
     def visit_Break(self, node):
         node.ccode = c.Statement("break")
 
+    def visit_Pass(self, node):
+        node.ccode = c.Statement("")
+
     def visit_FieldNode(self, node):
         """Record intrinsic fields used in kernel"""
         self.field_args[node.obj.ccode_name] = node.obj

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -130,6 +130,21 @@ def test_nested_if(fieldset, mode):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pass(fieldset, mode):
+    """Test pass commands"""
+    class TestParticle(ptype[mode]):
+        p = Variable('p', dtype=np.int32, initial=0)
+    pset = ParticleSet(fieldset, pclass=TestParticle, lon=0, lat=0)
+
+    def kernel(particle, fieldset, time):
+        particle.p = -1
+        pass
+
+    pset.execute(kernel, endtime=10, dt=1.)
+    assert np.allclose(pset[0].p, -1)
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_dt_as_variable_in_kernel(fieldset, mode):
     pset = ParticleSet(fieldset, pclass=ptype[mode], lon=0, lat=0)
 


### PR DESCRIPTION
A `pass` statement encountered in a kernel will generate an empty statement, instead of raising an error.