### PR TITLE
Changing the dask chunk size warning to info

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1623,7 +1623,7 @@ class NetcdfFileBuffer(object):
             if 'array.chunk-size' in da_conf.config.keys():
                 chunk_cap = da_utils.parse_bytes(da_conf.config.get('array.chunk-size'))
             else:
-                logger.warning_once("Unable to locate chunking hints from dask, thus estimating the max. chunk size heuristically. Please consider defining the 'chunk-size' for 'array' in your local dask configuration file (see https://docs.dask.org).")
+                logger.info("Unable to locate chunking hints from dask, thus estimating the max. chunk size heuristically. Please consider defining the 'chunk-size' for 'array' in your local dask configuration file (see http://oceanparcels.org/faq.html#field_chunking_config and https://docs.dask.org).")
             if self._is_dimension_available('lat') and self._is_dimension_available('lon;'):
                 pDim = int(math.floor(math.sqrt(chunk_cap/np.dtype(np.float64).itemsize)))
                 init_chunk_dict[self.dimensions['lat']] = pDim

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1623,7 +1623,7 @@ class NetcdfFileBuffer(object):
             if 'array.chunk-size' in da_conf.config.keys():
                 chunk_cap = da_utils.parse_bytes(da_conf.config.get('array.chunk-size'))
             else:
-                logger.info("Unable to locate chunking hints from dask, thus estimating the max. chunk size heuristically. Please consider defining the 'chunk-size' for 'array' in your local dask configuration file (see http://oceanparcels.org/faq.html#field_chunking_config and https://docs.dask.org).")
+                logger.info_once("Unable to locate chunking hints from dask, thus estimating the max. chunk size heuristically. Please consider defining the 'chunk-size' for 'array' in your local dask configuration file (see http://oceanparcels.org/faq.html#field_chunking_config and https://docs.dask.org).")
             if self._is_dimension_available('lat') and self._is_dimension_available('lon;'):
                 pDim = int(math.floor(math.sqrt(chunk_cap/np.dtype(np.float64).itemsize)))
                 init_chunk_dict[self.dimensions['lat']] = pDim

--- a/parcels/tools/loggers.py
+++ b/parcels/tools/loggers.py
@@ -4,6 +4,7 @@ import logging
 __all__ = ['logger']
 
 warning_once_level = 25
+info_once_level = 26
 
 
 class DuplicateFilter(object):
@@ -14,7 +15,7 @@ class DuplicateFilter(object):
 
     def filter(self, record):
         rv = record.msg not in self.msgs
-        if record.levelno == warning_once_level:
+        if record.levelno in [warning_once_level, info_once_level]:
             self.msgs.add(record.msg)
         return rv
 
@@ -25,6 +26,12 @@ def warning_once(self, message, *args, **kws):
         self._log(warning_once_level, message, args, **kws)
 
 
+def info_once(self, message, *args, **kws):
+    """Custom logging level for info that need to be displayed only once"""
+    if self.isEnabledFor(info_once_level):
+        self._log(info_once_level, message, args, **kws)
+
+
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
 handler.setFormatter(logging.Formatter(fmt="%(levelname)s: %(message)s"))
@@ -32,6 +39,9 @@ logger.addHandler(handler)
 
 logging.addLevelName(warning_once_level, "WARNING")
 logging.Logger.warning_once = warning_once
+
+logging.addLevelName(info_once_level, "INFO")
+logging.Logger.info_once = info_once
 
 dup_filter = DuplicateFilter()
 logger.addFilter(dup_filter)


### PR DESCRIPTION
Since the warning about dask chunk-sizes may be somewhat worrying to users (See e.g. #733), I suggest to change it to an INFO statement. And also add the link to oceanparcels.org documentation