### PR TITLE
Bugfixes for 4D data access using field chunking

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -273,7 +273,7 @@ class Field(object):
             else:
                 raise RuntimeError('interp_method is a dictionary but %s is not in it' % variable[0])
 
-        with NetcdfFileBuffer(lonlat_filename, dimensions, indices, netcdf_engine, field_chunksize=False) as filebuffer:
+        with NetcdfFileBuffer(lonlat_filename, dimensions, indices, netcdf_engine, field_chunksize=False, lock_file=False) as filebuffer:
             lon, lat = filebuffer.read_lonlat
             indices = filebuffer.indices
             # Check if parcels_mesh has been explicitly set in file
@@ -281,7 +281,7 @@ class Field(object):
                 mesh = filebuffer.dataset.attrs['parcels_mesh']
 
         if 'depth' in dimensions:
-            with NetcdfFileBuffer(depth_filename, dimensions, indices, netcdf_engine, interp_method=interp_method, field_chunksize=False) as filebuffer:
+            with NetcdfFileBuffer(depth_filename, dimensions, indices, netcdf_engine, interp_method=interp_method, field_chunksize=False, lock_file=False) as filebuffer:
                 filebuffer.name = filebuffer.parse_name(variable[1])
                 depth = filebuffer.read_depth
                 data_full_zdim = filebuffer.data_full_zdim
@@ -309,8 +309,7 @@ class Field(object):
                 timeslices = []
                 dataFiles = []
                 for fname in data_filenames:
-                    with NetcdfFileBuffer(fname, dimensions, indices, netcdf_engine,
-                                          field_chunksize=False) as filebuffer:
+                    with NetcdfFileBuffer(fname, dimensions, indices, netcdf_engine, field_chunksize=False) as filebuffer:
                         ftime = filebuffer.time
                         timeslices.append(ftime)
                         dataFiles.append([fname] * len(ftime))
@@ -1543,7 +1542,7 @@ class NestedField(list):
 class NetcdfFileBuffer(object):
     """ Class that encapsulates and manages deferred access to file data. """
     def __init__(self, filename, dimensions, indices, netcdf_engine, timestamp=None,
-                 interp_method='linear', data_full_zdim=None, field_chunksize='auto', rechunk_callback_fields=None):
+                 interp_method='linear', data_full_zdim=None, field_chunksize='auto', rechunk_callback_fields=None, lock_file=True):
         self.filename = filename
         self.dimensions = dimensions  # Dict with dimension keys for file data
         self.indices = indices
@@ -1556,55 +1555,72 @@ class NetcdfFileBuffer(object):
         self.field_chunksize = field_chunksize
         self.chunk_mapping = None
         self.rechunk_callback_fields = rechunk_callback_fields
+        self.chunking_finalized = False
+        self.lock_file = lock_file
 
     def __enter__(self):
         if self.netcdf_engine == 'xarray':
             self.dataset = self.filename
             return self
+
         init_chunk_dict = self._get_initial_chunk_dictionary()
         try:
-            self.dataset = xr.open_dataset(str(self.filename), decode_cf=True, engine=self.netcdf_engine, chunks=init_chunk_dict)
+            # unfortunately we need to do if-else here, cause the lock-parameter is either False or a Lock-object (we we rather want to have auto-managed)
+            if self.lock_file:
+                self.dataset = xr.open_dataset(str(self.filename), decode_cf=True, engine=self.netcdf_engine, chunks=init_chunk_dict)
+            else:
+                self.dataset = xr.open_dataset(str(self.filename), decode_cf=True, engine=self.netcdf_engine, chunks=init_chunk_dict, lock=False)
             self.dataset['decoded'] = True
         except:
             logger.warning_once("File %s could not be decoded properly by xarray (version %s).\n         It will be opened with no decoding. Filling values might be wrongly parsed."
                                 % (self.filename, xr.__version__))
-            self.dataset = xr.open_dataset(str(self.filename), decode_cf=False, engine=self.netcdf_engine, chunks=init_chunk_dict)
+            if self.lock_file:
+                self.dataset = xr.open_dataset(str(self.filename), decode_cf=False, engine=self.netcdf_engine, chunks=init_chunk_dict)
+            else:
+                self.dataset = xr.open_dataset(str(self.filename), decode_cf=False, engine=self.netcdf_engine, chunks=init_chunk_dict, lock=False)
             self.dataset['decoded'] = False
+
         for inds in self.indices.values():
             if type(inds) not in [list, range]:
                 raise RuntimeError('Indices for field subsetting need to be a list')
         return self
 
     def __exit__(self, type, value, traceback):
+        self.close()
+
+    def close(self):
         if self.netcdf_engine == 'xarray':
             pass
         else:
-            self.dataset.close()
-            self.dataset = None
+            if self.dataset is not None:
+                self.dataset.close()
+                self.dataset = None
+        self.chunking_finalized = False
+        self.chunk_mapping = None
 
     def _get_initial_chunk_dictionary(self):
         # ==== check-opening requested dataset to access metadata ==== #
         try:
-            self.dataset = xr.open_dataset(str(self.filename), decode_cf=True, engine=self.netcdf_engine, chunks={})
+            self.dataset = xr.open_dataset(str(self.filename), decode_cf=True, engine=self.netcdf_engine, chunks={}, lock=False)
             self.dataset['decoded'] = True
         except:
             logger.warning_once("File %s could not be decoded properly by xarray (version %s).\n         It will be opened with no decoding. Filling values might be wrongly parsed."
                                 % (self.filename, xr.__version__))
-            self.dataset = xr.open_dataset(str(self.filename), decode_cf=False, engine=self.netcdf_engine, chunks={})
+            self.dataset = xr.open_dataset(str(self.filename), decode_cf=False, engine=self.netcdf_engine, chunks={}, lock=False)
             self.dataset['decoded'] = False
         # ==== self.dataset temporarily available ==== #
         init_chunk_dict = {}
         if isinstance(self.field_chunksize, dict):
             init_chunk_dict = self.field_chunksize
-        elif isinstance(self.field_chunksize, tuple) and (len(self.dimensions) == self.field_chunksize):
+        elif isinstance(self.field_chunksize, tuple) and (len(self.dimensions) == len(self.field_chunksize)):
             chunk_index = 0
             if self._is_dimension_available('time'):
-                init_chunk_dict[self.dimensions['time']] = self.field_chunksize[chunk_index] if len(self.dimensions) > 2 else 1
+                init_chunk_dict[self.dimensions['time']] = self.field_chunksize[chunk_index] if (len(self.dimensions) > 2 and len(self.field_chunksize) > 2) else 1
                 chunk_index += 1 if len(self.dimensions) > 2 else 0
             else:
                 logger.warning_once(self._netcdf_DimNotFound_warning_message('time'))
             if self._is_dimension_available('depth'):
-                init_chunk_dict[self.dimensions['depth']] = self.field_chunksize[chunk_index] if len(self.dimensions) > 3 else 1
+                init_chunk_dict[self.dimensions['depth']] = self.field_chunksize[chunk_index] if (len(self.dimensions) > 3 and len(self.field_chunksize) > 3) else 1
                 chunk_index += 1 if len(self.dimensions) > 3 else 0
             else:
                 logger.warning_once(self._netcdf_DimNotFound_warning_message('depth'))
@@ -1613,7 +1629,7 @@ class NetcdfFileBuffer(object):
                 chunk_index += 1
             else:
                 logger.warning_once(self._netcdf_DimNotFound_warning_message('lat'))
-            if self._is_dimension_available('lom'):
+            if self._is_dimension_available('lon'):
                 init_chunk_dict[self.dimensions['lon']] = self.field_chunksize[chunk_index]
             else:
                 logger.warning_once(self._netcdf_DimNotFound_warning_message('lon'))
@@ -1644,7 +1660,67 @@ class NetcdfFileBuffer(object):
         return (dimension_name in self.dimensions and self.dimensions[dimension_name] in self.dataset.dims)
 
     def _netcdf_DimNotFound_warning_message(self, dimension_name):
-        return "Did not find {} in NetCDF dims. Please specifiy field_chunksize as dictionary for NetCDF dimension names, e.g.\n field_chunksize=\{ '{}': <number>, ... \}.".format(self.dimensions[dimension_name], self.dimensions[dimension_name])
+        display_name = dimension_name if (dimension_name not in self.dimensions) else self.dimensions[dimension_name]
+        return "Did not find {} in NetCDF dims. Please specifiy field_chunksize as dictionary for NetCDF dimension names, e.g.\n field_chunksize={{ '{}': <number>, ... }}.".format(display_name, display_name)
+
+    def _chunksize_to_chunkmap(self):
+        if self.field_chunksize in [False, 'auto', None]:
+            return
+        self.chunk_mapping = {}
+        if (isinstance(self.field_chunksize, tuple)):
+            for i in range(len(self.field_chunksize)):
+                self.chunk_mapping[i] = self.field_chunksize[i]
+        else:
+            dim_index = 0
+            if len(self.field_chunksize) == 2:
+                if self._is_dimension_available('time'):
+                    self.chunk_mapping[dim_index] = 1
+                    dim_index += 1
+                elif self._is_dimension_available('depth'):
+                    self.chunk_mapping[dim_index] = 1
+                    dim_index += 1
+                self.chunk_mapping[dim_index] = self.field_chunksize[self.dimensions['lat']]
+                dim_index += 1
+                self.chunk_mapping[dim_index] = self.field_chunksize[self.dimensions['lon']]
+                dim_index += 1
+            elif len(self.field_chunksize) >= 3:
+                if self._is_dimension_available('depth'):
+                    self.chunk_mapping[dim_index] = self.field_chunksize[self.dimensions['depth']]
+                    dim_index += 1
+                elif self._is_dimension_available('time'):
+                    self.chunk_mapping[dim_index] = 1
+                    dim_index += 1
+                self.chunk_mapping[dim_index] = self.field_chunksize[self.dimensions['lat']]
+                dim_index += 1
+                self.chunk_mapping[dim_index] = self.field_chunksize[self.dimensions['lon']]
+                dim_index += 1
+
+    def _chunkmap_to_chunksize(self):
+        self.field_chunksize = {}
+        chunk_map = self.chunk_mapping
+        if self._is_dimension_available('depth') and self._is_dimension_available('time'):
+            chunk_map[-1] = 1
+        if len(chunk_map) == 2:
+            self.field_chunksize[self.dimensions['lat']] = chunk_map[0]
+            self.field_chunksize[self.dimensions['lon']] = chunk_map[1]
+        elif len(chunk_map) == 3:
+            if self._is_dimension_available('depth'):
+                self.field_chunksize[self.dimensions['depth']] = chunk_map[0]
+            else:
+                self.field_chunksize[self.dimensions['time']] = chunk_map[0]
+            self.field_chunksize[self.dimensions['lat']] = chunk_map[1]
+            self.field_chunksize[self.dimensions['lon']] = chunk_map[2]
+        if len(chunk_map) >= 4:
+            self.field_chunksize[self.dimensions['time']] = 1
+            self.field_chunksize[self.dimensions['depth']] = chunk_map[0]
+            self.field_chunksize[self.dimensions['lat']] = chunk_map[1]
+            self.field_chunksize[self.dimensions['lon']] = chunk_map[2]
+            dim_index=3
+            for dim_name in self.dimensions:
+                if dim_name not in ['time', 'depth', 'lat', 'lon']:
+                    self.field_chunksize[self.dimensions[dim_name]] = chunk_map[dim_index]
+                    dim_index += 1
+
 
     def parse_name(self, name):
         if isinstance(name, list):
@@ -1722,15 +1798,7 @@ class NetcdfFileBuffer(object):
                 for i in range(len(self.field_chunksize)):
                     self.chunk_mapping[i] = self.field_chunksize[i]
             else:
-                dim_max_index = len(self.dimensions)-1
-                dim_index = 0
-                for dim_name in self.dimensions:
-                    coord_id = dim_max_index - dim_index
-                    if self.dimensions[dim_name] in self.field_chunksize:
-                        self.chunk_mapping[coord_id] = self.field_chunksize[self.dimensions[dim_name]]
-                    else:
-                        self.chunk_mapping[coord_id] = 1
-                    dim_index += 1
+                self._chunksize_to_chunkmap()
         data = self.dataset[self.name]
         ti = range(data.shape[0]) if self.ti is None else self.ti
         if len(data.shape) == 2:
@@ -1785,19 +1853,23 @@ class NetcdfFileBuffer(object):
             data = np.array(data)
         else:
             if isinstance(data, da.core.Array):
-                if self.field_chunksize == 'auto' and data.shape[-2:] == data.chunksize[-2:]:
-                    pass
-                elif self.field_chunksize == 'auto' and self.rechunk_callback_fields is not None:
+                if self.field_chunksize == 'auto' and data.shape[-2:] == data.chunksize[-2:] and not self.chunking_finalized:
+                    self.chunking_finalized = True
+                elif self.field_chunksize == 'auto' and self.rechunk_callback_fields is not None and not self.chunking_finalized:
                     data = data.rechunk(self.field_chunksize)
                     self.chunk_mapping = {}
                     chunkIndex = 0
                     for chunkDim in data.numblocks[1:]:
                         self.chunk_mapping[chunkIndex] = chunkDim
                         chunkIndex += 1
+                    self._chunkmap_to_chunksize()
                     self.rechunk_callback_fields()
-                elif self.field_chunksize != 'auto':
+                    self.chunking_finalized = True
+                elif self.field_chunksize != 'auto' and not self.chunking_finalized:    # why ? why here ? why at every single data access, instead of fixing that size when you open the file ?!
                     data = data.rechunk(self.chunk_mapping)
+                    self.chunking_finalized = True
             else:
+                self.chunking_finalized = True
                 da_data = da.from_array(data, chunks=self.field_chunksize)
                 if self.field_chunksize == 'auto' and da_data.shape[-2:] == da_data.chunksize[-2:]:
                     data = np.array(data)
@@ -1808,6 +1880,9 @@ class NetcdfFileBuffer(object):
 
     @property
     def time(self):
+        return self.time_access()
+
+    def time_access(self):
         if self.timestamp is not None:
             return self.timestamp
 

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -232,7 +232,7 @@ class Field(object):
                 assert len(filenames) == len(timestamps), 'Outer dimension of timestamps should correspond to number of files.'
             elif isinstance(filenames, dict):
                 for k in filenames.keys():
-                    if k not in ['lat','lon','depth','time']:
+                    if k not in ['lat', 'lon', 'depth', 'time']:
                         assert(len(filenames[k]) == len(timestamps)), 'Outer dimension of timestamps should correspond to number of files.'
             else:
                 raise TypeError("Filenames type is inconsistent with manual timestamp provision."
@@ -1715,12 +1715,11 @@ class NetcdfFileBuffer(object):
             self.field_chunksize[self.dimensions['depth']] = chunk_map[0]
             self.field_chunksize[self.dimensions['lat']] = chunk_map[1]
             self.field_chunksize[self.dimensions['lon']] = chunk_map[2]
-            dim_index=3
+            dim_index = 3
             for dim_name in self.dimensions:
                 if dim_name not in ['time', 'depth', 'lat', 'lon']:
                     self.field_chunksize[self.dimensions[dim_name]] = chunk_map[dim_index]
                     dim_index += 1
-
 
     def parse_name(self, name):
         if isinstance(name, list):

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -783,7 +783,8 @@ class FieldSet(object):
                 for tind in f.loaded_time_indices:
                     for fb in f.filebuffers:
                         if fb is not None:
-                            fb.dataset.close()
+                            fb.close()
+                        fb=None
 
                     data = f.computeTimeChunk(data, tind)
                 data = f.rescale_and_set_minmax(data)
@@ -801,14 +802,14 @@ class FieldSet(object):
                 if signdt >= 0:
                     f.loaded_time_indices = [2]
                     if f.filebuffers[0] is not None:
-                        f.filebuffers[0].dataset.close()
+                        f.filebuffers[0].close()
                         f.filebuffers[0] = None
                     f.filebuffers[:2] = f.filebuffers[1:]
                     data = f.computeTimeChunk(data, 2)
                 else:
                     f.loaded_time_indices = [0]
                     if f.filebuffers[2] is not None:
-                        f.filebuffers[2].dataset.close()
+                        f.filebuffers[2].close()
                         f.filebuffers[2] = None
                     f.filebuffers[1:] = f.filebuffers[:2]
                     data = f.computeTimeChunk(data, 0)

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -784,7 +784,7 @@ class FieldSet(object):
                     for fb in f.filebuffers:
                         if fb is not None:
                             fb.close()
-                        fb=None
+                        fb = None
 
                     data = f.computeTimeChunk(data, tind)
                 data = f.rescale_and_set_minmax(data)


### PR DESCRIPTION
In issue #719 , we have adapted the data access in the NetcdfFileBuffer to actually make use of the lazy field evaluation to prevent loading all data per time step at once. We have thoroughly tested the procedure, but only for 2D+time (3D) data. For 3D+time (4D) data, this procedure was still buggy.

In this pull request, we resolve those issues with 4D data access. For testing, we used the Galapagos backward advection, as shown in van Sebille et al. 2019 "Basin-scale sources and pathways of microplastic that ends up in the Galápagos Archipelago" [code here](https://github.com/OceanParcels/GalapagosBasinPlastic), which is now running through successfully. Furthermore, we tested the process on the 3D NEMO data. in issue #731 , we will later use the fix to re-generate the MPI doc with the global reanalysis data for 3D fields. This run requires the bugfixes made here.