### PR TITLE
Changing compute_on_defer unit test to use dask

### DIFF
--- a/parcels/tools/error.py
+++ b/parcels/tools/error.py
@@ -2,7 +2,7 @@
 
 
 __all__ = ['ErrorCode', 'FieldSamplingError', 'FieldOutOfBoundError', 'TimeExtrapolationError',
-           'KernelError', 'OutOfBoundsError', 'ThroughSurfaceError',
+           'KernelError', 'OutOfBoundsError', 'ThroughSurfaceError', 'OutOfTimeError',
            'recovery_map']
 
 


### PR DESCRIPTION
This PR addresses how `FieldSet.compute_on_defer` can best be combined with `dask` arrays, following the bug report at #741 