### PR TITLE
Adding a check for unimplemented keyword arguments

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -177,6 +177,8 @@ class Field(object):
         self.nchunks = []
         self.chunk_set = False
         self.filebuffers = [None] * 3
+        if len(kwargs) > 0:
+            raise SyntaxError('Field received an unexpected keyword argument "%s"' % list(kwargs.keys())[0])
 
     @classmethod
     def get_dim_filenames(cls, filenames, dim):

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -45,11 +45,11 @@ def test_fieldset_from_data(xdim, ydim):
 def test_fieldset_extra_syntax():
     """ Simple test for fieldset initialisation from data. """
     data, dimensions = generate_fieldset(10, 10)
-    failed=False
+    failed = False
     try:
         FieldSet.from_data(data, dimensions, unknown_keyword=5)
     except SyntaxError:
-        failed=True
+        failed = True
     assert failed
 
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -42,6 +42,17 @@ def test_fieldset_from_data(xdim, ydim):
     assert np.allclose(fieldset.V.data[0, :], data['V'], rtol=1e-12)
 
 
+def test_fieldset_extra_syntax():
+    """ Simple test for fieldset initialisation from data. """
+    data, dimensions = generate_fieldset(10, 10)
+    failed=False
+    try:
+        FieldSet.from_data(data, dimensions, unknown_keyword=5)
+    except SyntaxError:
+        failed=True
+    assert failed
+
+
 @pytest.mark.parametrize('ttype', ['float', 'datetime64'])
 @pytest.mark.parametrize('tdim', [1, 20])
 def test_fieldset_from_data_timedims(ttype, tdim):


### PR DESCRIPTION
Especially with the new `fieldset_chunksize`, it can be expected that users make mistakes in naming of this argument (e.g. `fieldset_chunksizes`, `fieldset_chunk_size`, `chunksize`), so here we implement a check on whether there are any keywords left that have not been parsed and are thus not implemented( so unexpected)