### PR TITLE
bug-fix merging kernels with delete_cfiles argument

### DIFF
--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -375,7 +375,7 @@ class Kernel(object):
         func_ast = FunctionDef(name=funcname, args=self.py_ast.args,
                                body=self.py_ast.body + kernel.py_ast.body,
                                decorator_list=[], lineno=1, col_offset=0)
-        delete_cfiles = self.delete_cfiles or kernel.delete_cfiles
+        delete_cfiles = self.delete_cfiles and kernel.delete_cfiles
         return Kernel(self.fieldset, self.ptype, pyfunc=None,
                       funcname=funcname, funccode=self.funccode + kernel.funccode,
                       py_ast=func_ast, funcvars=self.funcvars + kernel.funcvars,

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -375,9 +375,11 @@ class Kernel(object):
         func_ast = FunctionDef(name=funcname, args=self.py_ast.args,
                                body=self.py_ast.body + kernel.py_ast.body,
                                decorator_list=[], lineno=1, col_offset=0)
+        delete_cfiles = self.delete_cfiles or kernel.delete_cfiles
         return Kernel(self.fieldset, self.ptype, pyfunc=None,
                       funcname=funcname, funccode=self.funccode + kernel.funccode,
-                      py_ast=func_ast, funcvars=self.funcvars + kernel.funcvars)
+                      py_ast=func_ast, funcvars=self.funcvars + kernel.funcvars,
+                      delete_cfiles=delete_cfiles)
 
     def __add__(self, kernel):
         if not isinstance(kernel, Kernel):


### PR DESCRIPTION
This PR fixes a bug that `delete_cfiles` keyword argument is maintained when merging Kernels and any of the Kernels has `delete_cfiles=False`