### PR TITLE
'KeyError: 2' hotfix

### DIFF
--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -353,10 +353,12 @@ class Kernel(object):
             for p in error_particles:
                 if p.state == ErrorCode.Repeat:
                     p.state = ErrorCode.Success
-                else:
+                elif p.state in recovery_map:
                     recovery_kernel = recovery_map[p.state]
                     p.state = ErrorCode.Success
                     recovery_kernel(p, self.fieldset, p.time)
+                else:
+                    p.delete()
 
             # Remove all particles that signalled deletion
             remove_deleted(pset)

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -353,7 +353,7 @@ class Kernel(object):
             for p in error_particles:
                 if p.state == ErrorCode.Repeat:
                     p.state = ErrorCode.Success
-                elif p.state in recovery_map:
+                elif p.state in recovery_map:               # hotfix for #749, #737 and related issues
                     recovery_kernel = recovery_map[p.state]
                     p.state = ErrorCode.Success
                     recovery_kernel(p, self.fieldset, p.time)

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -358,6 +358,7 @@ class Kernel(object):
                     p.state = ErrorCode.Success
                     recovery_kernel(p, self.fieldset, p.time)
                 else:
+                    logger.warning_once('Deleting particle because of bug in #749 and #737')
                     p.delete()
 
             # Remove all particles that signalled deletion


### PR DESCRIPTION
only recover the particle errors that are listed in the combined recovery map, delete all particles that are unsuccessful and for whose errors there is no recovery specified.

Nature: hotfix

The error (until now tracked) only occurs when your simulation dynamically adds AND deletes particles during the execute() function. The actual errors source for this is still investigated, thus a better fix will be submitted separately in the future. This given fix is tested.