### PR TITLE
Changing the way the pytest fixtures are implemented

### DIFF
--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -17,19 +17,31 @@ gamma = 1/(86400. * 2.89)
 gamma_g = 1/(86400. * 28.9)
 
 
-@pytest.fixture
 def lon(xdim=200):
     return np.linspace(-170, 170, xdim, dtype=np.float32)
 
 
-@pytest.fixture
+@pytest.fixture(name="lon")
+def lon_fixture(xdim=200):
+    return lon(xdim=xdim)
+
+
 def lat(ydim=100):
     return np.linspace(-80, 80, ydim, dtype=np.float32)
 
 
-@pytest.fixture
+@pytest.fixture(name="lat")
+def lat_fixture(ydim=100):
+    return lat(ydim=ydim)
+
+
 def depth(zdim=2):
     return np.linspace(0, 30, zdim, dtype=np.float32)
+
+
+@pytest.fixture(name="depth")
+def depth_fixture(zdim=2):
+    return depth(zdim=zdim)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -17,7 +17,6 @@ def pclass(mode):
     return SampleParticle
 
 
-@pytest.fixture
 def k_sample_uv():
     def SampleUV(particle, fieldset, time):
         particle.u = fieldset.U[time, particle.depth, particle.lat, particle.lon]
@@ -25,14 +24,22 @@ def k_sample_uv():
     return SampleUV
 
 
-@pytest.fixture
+@pytest.fixture(name="k_sample_uv")
+def k_sample_uv_fixture():
+    return k_sample_uv()
+
+
 def k_sample_p():
     def SampleP(particle, fieldset, time):
         particle.p = fieldset.P[time, particle.depth, particle.lat, particle.lon]
     return SampleP
 
 
-@pytest.fixture
+@pytest.fixture(name="k_sample_p")
+def k_sample_P_fixture():
+    return k_sample_p()
+
+
 def fieldset(xdim=200, ydim=100):
     """ Standard fieldset spanning the earth's coordinates with U and V
         equivalent to longitude and latitude in deg.
@@ -46,7 +53,11 @@ def fieldset(xdim=200, ydim=100):
     return FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
 
 
-@pytest.fixture
+@pytest.fixture(name="fieldset")
+def fieldset_fixture(xdim=200, ydim=100):
+    return fieldset(xdim=xdim, ydim=ydim)
+
+
 def fieldset_geometric(xdim=200, ydim=100):
     """ Standard earth fieldset with U and V equivalent to lon/lat in m. """
     lon = np.linspace(-180, 180, xdim, dtype=np.float32)
@@ -62,7 +73,11 @@ def fieldset_geometric(xdim=200, ydim=100):
     return fieldset
 
 
-@pytest.fixture
+@pytest.fixture(name="fieldset_geometric")
+def fieldset_geometric_fixture(xdim=200, ydim=100):
+    return fieldset_geometric(xdim=xdim, ydim=ydim)
+
+
 def fieldset_geometric_polar(xdim=200, ydim=100):
     """ Standard earth fieldset with U and V equivalent to lon/lat in m
         and the inversion of the pole correction applied to U.
@@ -78,6 +93,11 @@ def fieldset_geometric_polar(xdim=200, ydim=100):
     data = {'U': U, 'V': V}
     dimensions = {'lon': lon, 'lat': lat}
     return FieldSet.from_data(data, dimensions, mesh='spherical', transpose=True)
+
+
+@pytest.fixture(name="fieldset_geometric_polar")
+def fieldset_geometric_polar_fixture(xdim=200, ydim=100):
+    return fieldset_geometric_polar(xdim=xdim, ydim=ydim)
 
 
 def test_fieldset_sample(fieldset, xdim=120, ydim=80):

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -14,7 +14,6 @@ def DoNothing(particle, fieldset, time):
     return ErrorCode.Success
 
 
-@pytest.fixture
 def fieldset(xdim=20, ydim=20):
     """ Standard unit mesh fieldset """
     lon = np.linspace(0., 1., xdim, dtype=np.float32)
@@ -23,6 +22,11 @@ def fieldset(xdim=20, ydim=20):
     data = {'U': np.array(U, dtype=np.float32), 'V': np.array(V, dtype=np.float32)}
     dimensions = {'lat': lat, 'lon': lon}
     return FieldSet.from_data(data, dimensions, mesh='flat')
+
+
+@pytest.fixture(name="fieldset")
+def fieldset_fixture(xdim=20, ydim=20):
+    return fieldset(xdim=xdim, ydim=ydim)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -19,7 +19,6 @@ def expr_kernel(name, pset, expr):
                   funcvars=['particle'])
 
 
-@pytest.fixture
 def fieldset(xdim=20, ydim=20):
     """ Standard unit mesh fieldset """
     lon = np.linspace(0., 1., xdim, dtype=np.float32)
@@ -28,6 +27,11 @@ def fieldset(xdim=20, ydim=20):
     data = {'U': np.array(U, dtype=np.float32), 'V': np.array(V, dtype=np.float32)}
     dimensions = {'lat': lat, 'lon': lon}
     return FieldSet.from_data(data, dimensions, mesh='flat', transpose=True)
+
+
+@pytest.fixture(name="fieldset")
+def fieldset_fixture(xdim=20, ydim=20):
+    return fieldset(xdim=xdim, ydim=ydim)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/tests/test_particle_file.py
+++ b/tests/test_particle_file.py
@@ -11,7 +11,6 @@ import cftime
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 
 
-@pytest.fixture
 def fieldset(xdim=40, ydim=100):
     U = np.zeros((ydim, xdim), dtype=np.float32)
     V = np.zeros((ydim, xdim), dtype=np.float32)
@@ -21,6 +20,11 @@ def fieldset(xdim=40, ydim=100):
     data = {'U': np.array(U, dtype=np.float32), 'V': np.array(V, dtype=np.float32)}
     dimensions = {'lat': lat, 'lon': lon, 'depth': depth}
     return FieldSet.from_data(data, dimensions)
+
+
+@pytest.fixture(name="fieldset")
+def fieldset_ficture(xdim=40, ydim=100):
+    return fieldset(xdim=xdim, ydim=ydim)
 
 
 def close_and_compare_netcdffiles(filepath, ofile, assystemcall=False):

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -6,7 +6,6 @@ import pytest
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 
 
-@pytest.fixture
 def fieldset(xdim=40, ydim=100):
     U = np.zeros((ydim, xdim), dtype=np.float32)
     V = np.zeros((ydim, xdim), dtype=np.float32)
@@ -16,6 +15,11 @@ def fieldset(xdim=40, ydim=100):
     data = {'U': np.array(U, dtype=np.float32), 'V': np.array(V, dtype=np.float32)}
     dimensions = {'lat': lat, 'lon': lon, 'depth': depth}
     return FieldSet.from_data(data, dimensions)
+
+
+@pytest.fixture(name="fieldset")
+def fieldset_fixture(xdim=40, ydim=100):
+    return fieldset(xdim=xdim, ydim=ydim)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -7,13 +7,17 @@ from operator import attrgetter
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 
 
-@pytest.fixture
 def fieldset(xdim=100, ydim=100):
     data = {'U': np.zeros((ydim, xdim), dtype=np.float32),
             'V': np.zeros((ydim, xdim), dtype=np.float32)}
     dimensions = {'lon': np.linspace(0, 1, xdim, dtype=np.float32),
                   'lat': np.linspace(0, 1, ydim, dtype=np.float32)}
     return FieldSet.from_data(data, dimensions, mesh='flat')
+
+
+@pytest.fixture(name="fieldset")
+def fieldset_fixture(xdim=100, ydim=100):
+    return fieldset(xdim=xdim, ydim=ydim)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])


### PR DESCRIPTION
This facilitates easier debugging, as individual functions can now directly be called. 

See also https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly