### PR TITLE
Fix multigrid segfault errors under UNIX

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -923,7 +923,7 @@ class Field(object):
 
     def ccode_eval(self, var, t, z, y, x):
         # Casting interp_methd to int as easier to pass on in C-code
-        return "temporal_interpolation(%s, %s, %s, %s, %s, &particles->xi[p], &particles->yi[p], &particles->zi[p], &particles->ti[p], &%s, %s)" \
+        return "temporal_interpolation(%s, %s, %s, %s, %s, &particles->xi[p*ngrid], &particles->yi[p*ngrid], &particles->zi[p*ngrid], &particles->ti[p*ngrid], &%s, %s)" \
             % (x, y, z, t, self.ccode_name, var, self.interp_method.upper())
 
     def ccode_convert(self, _, z, y, x):

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -219,7 +219,7 @@ class Kernel(object):
     def execute_jit(self, pset, endtime, dt):
         """Invokes JIT engine to perform the core update loop"""
         if len(pset) > 0 and pset.particle_data['xi'].ndim == 2:
-            assert pset.fieldset.gridset.size == pset.particle_data['xi'].shape[0], \
+            assert pset.fieldset.gridset.size == pset.particle_data['xi'].shape[1], \
                 'FieldSet has different number of grids than Particle.xi. Have you added Fields after creating the ParticleSet?'
 
         for g in pset.fieldset.gridset.grids:

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -221,7 +221,7 @@ class ParticleSet(object):
         initialised = set()
         for v in self.ptype.variables:
             if v.name in ['xi', 'yi', 'zi', 'ti']:
-                self.particle_data[v.name] = np.empty((fieldset.gridset.size, len(lon)), dtype=v.dtype)
+                self.particle_data[v.name] = np.empty((len(lon), fieldset.gridset.size), dtype=v.dtype)
             else:
                 self.particle_data[v.name] = np.empty(len(lon), dtype=v.dtype)
 
@@ -498,7 +498,7 @@ class ParticleSet(object):
     def remove_booleanvector(self, indices):
         """Method to remove particles from the ParticleSet, based on an array of booleans"""
         for d in self.particle_data:
-            self.particle_data[d] = self.particle_data[d][..., ~indices]
+            self.particle_data[d] = self.particle_data[d][~indices, ...]
 
     def execute(self, pyfunc=AdvectionRK4, endtime=None, runtime=None, dt=1.,
                 moviedt=None, recovery=None, output_file=None, movie_background_field=None,

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -1,4 +1,4 @@
-from ctypes import cast, Structure, POINTER
+from ctypes import Structure, POINTER
 import time as time_module
 from datetime import date
 from datetime import datetime

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -299,9 +299,9 @@ class ParticleSet(object):
             _fields_ = [(v.name, POINTER(np.ctypeslib.as_ctypes_type(v.dtype))) for v in self.ptype.variables]
 
         def cdata_for(v):
-            cdata_array = np.ctypeslib.as_ctypes(self.particle_data[v.name])
-            # cast to bare pointer
-            return cast(cdata_array, POINTER(np.ctypeslib.as_ctypes_type(v.dtype)))
+            data_flat = self.particle_data[v.name].view()
+            data_flat.shape = -1
+            return np.ctypeslib.as_ctypes(data_flat)
 
         cdata = [cdata_for(v) for v in self.ptype.variables]
         cstruct = CParticles(*cdata)

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -431,19 +431,21 @@ def test_sampling_multigrids_non_vectorfield(mode):
         particle.sample_var += fieldset.B[time, fieldset.sample_depth, particle.lat, particle.lon]
 
     kernels = pset.Kernel(AdvectionRK4) + pset.Kernel(test_sample)
+    kernels = pset.Kernel(AdvectionRK4)
     pset.execute(kernels, runtime=10, dt=1)
     assert np.allclose(pset.sample_var, 10.0)
-    print(pset.xi)
-    print(pset.yi)
-    assert len(pset.xi.shape) == 2
-    assert pset.xi.shape[0] == len(pset.lon)
-    assert pset.xi.shape[1] == len(fieldset.get_fields())
-    assert np.all((pset.xi >= 0) & (pset.xi[fieldset.B.grid.igrid] < xdim * 4))
-    assert np.all((pset.xi >= 0) & (pset.xi[0] < xdim))
-    assert pset.yi.shape[0] == len(pset.lon)
-    assert pset.yi.shape[1] == len(fieldset.get_fields())
-    assert np.all((pset.yi >= 0) & (pset.yi[fieldset.B.grid.igrid] < ydim * 3))
-    assert np.all((pset.yi >= 0) & (pset.yi[0] < ydim))
+    if mode == 'jit':
+        print(pset.xi)
+        print(pset.yi)
+        assert len(pset.xi.shape) == 2
+        assert pset.xi.shape[0] == len(pset.lon)
+        assert pset.xi.shape[1] == len(fieldset.get_fields())
+        assert np.all((pset.xi >= 0) & (pset.xi[fieldset.B.grid.igrid] < xdim * 4))
+        assert np.all((pset.xi >= 0) & (pset.xi[0] < xdim))
+        assert pset.yi.shape[0] == len(pset.lon)
+        assert pset.yi.shape[1] == len(fieldset.get_fields())
+        assert np.all((pset.yi >= 0) & (pset.yi[fieldset.B.grid.igrid] < ydim * 3))
+        assert np.all((pset.yi >= 0) & (pset.yi[0] < ydim))
 
 
 @pytest.mark.parametrize('mode', ['jit', 'scipy'])

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -452,16 +452,16 @@ def test_sampling_multigrids_non_vectorfield_from_file(mode, npart, tmpdir, chs,
     assert np.allclose(pset.sample_var, 10.0)
     if mode == 'jit':
         assert len(pset.xi.shape) == 2
-        assert pset.xi.shape[1] == len(pset.lon)
-        assert pset.xi.shape[0] == fieldset.gridset.size
+        assert pset.xi.shape[0] == len(pset.lon)
+        assert pset.xi.shape[1] == fieldset.gridset.size
         assert np.all(pset.xi >= 0)
-        assert np.all(pset.xi[fieldset.B.igrid, :] < xdim * 4)
-        assert np.all(pset.xi[0, :] < xdim)
-        assert pset.yi.shape[1] == len(pset.lon)
-        assert pset.yi.shape[0] == fieldset.gridset.size
+        assert np.all(pset.xi[:, fieldset.B.igrid] < xdim * 4)
+        assert np.all(pset.xi[:, 0] < xdim)
+        assert pset.yi.shape[0] == len(pset.lon)
+        assert pset.yi.shape[1] == fieldset.gridset.size
         assert np.all(pset.yi >= 0)
-        assert np.all(pset.yi[fieldset.B.igrid, :] < ydim * 3)
-        assert np.all(pset.yi[0, :] < ydim)
+        assert np.all(pset.yi[:, fieldset.B.igrid] < ydim * 3)
+        assert np.all(pset.yi[:, 0] < ydim)
 
 
 @pytest.mark.parametrize('mode', ['jit', 'scipy'])
@@ -496,16 +496,16 @@ def test_sampling_multigrids_non_vectorfield(mode, npart):
     assert np.allclose(pset.sample_var, 10.0)
     if mode == 'jit':
         assert len(pset.xi.shape) == 2
-        assert pset.xi.shape[1] == len(pset.lon)
-        assert pset.xi.shape[0] == fieldset.gridset.size
+        assert pset.xi.shape[0] == len(pset.lon)
+        assert pset.xi.shape[1] == fieldset.gridset.size
         assert np.all(pset.xi >= 0)
-        assert np.all(pset.xi[fieldset.B.igrid, :] < xdim * 4)
-        assert np.all(pset.xi[0, :] < xdim)
-        assert pset.yi.shape[1] == len(pset.lon)
-        assert pset.yi.shape[0] == fieldset.gridset.size
+        assert np.all(pset.xi[:, fieldset.B.igrid] < xdim * 4)
+        assert np.all(pset.xi[:, 0] < xdim)
+        assert pset.yi.shape[0] == len(pset.lon)
+        assert pset.yi.shape[1] == fieldset.gridset.size
         assert np.all(pset.yi >= 0)
-        assert np.all(pset.yi[fieldset.B.igrid, :] < ydim * 3)
-        assert np.all(pset.yi[0, :] < ydim)
+        assert np.all(pset.yi[:, fieldset.B.igrid] < ydim * 3)
+        assert np.all(pset.yi[:, 0] < ydim)
 
 
 @pytest.mark.parametrize('mode', ['jit', 'scipy'])

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -405,6 +405,48 @@ def test_sampling_out_of_bounds_time(mode, allow_time_extrapolation, k_sample_p,
 
 
 @pytest.mark.parametrize('mode', ['jit', 'scipy'])
+def test_sampling_multigrids_non_vectorfield(mode):
+    xdim, ydim = 100, 200
+    U = Field('U', np.zeros((ydim, xdim), dtype=np.float32),
+              lon=np.linspace(0., 1., xdim, dtype=np.float32),
+              lat=np.linspace(0., 1., ydim, dtype=np.float32))
+    V = Field('V', np.zeros((ydim, xdim), dtype=np.float32),
+              lon=np.linspace(0., 1., xdim, dtype=np.float32),
+              lat=np.linspace(0., 1., ydim, dtype=np.float32))
+    B = Field('B', np.ones((3*ydim, 4*xdim), dtype=np.float32),
+              lon=np.linspace(0., 1., 4*xdim, dtype=np.float32),
+              lat=np.linspace(0., 1., 3*ydim, dtype=np.float32))
+    fieldset = FieldSet(U, V)
+    fieldset.add_field(B, 'B')
+    fieldset.add_constant('sample_depth', 2.5)
+    assert fieldset.U.grid is fieldset.V.grid
+    assert fieldset.U.grid is not fieldset.B.grid
+
+    class TestParticle(ptype[mode]):
+        sample_var = Variable('sample_var', initial=0.)
+
+    pset = ParticleSet.from_line(fieldset, pclass=TestParticle, start=[0.3, 0.3], finish=[0.7, 0.7], size=10)
+
+    def test_sample(particle, fieldset, time):
+        particle.sample_var += fieldset.B[time, fieldset.sample_depth, particle.lat, particle.lon]
+
+    kernels = pset.Kernel(AdvectionRK4) + pset.Kernel(test_sample)
+    pset.execute(kernels, runtime=10, dt=1)
+    assert np.allclose(pset.sample_var, 10.0)
+    print(pset.xi)
+    print(pset.yi)
+    assert len(pset.xi.shape) == 2
+    assert pset.xi.shape[0] == len(pset.lon)
+    assert pset.xi.shape[1] == len(fieldset.get_fields())
+    assert np.all((pset.xi >= 0) & (pset.xi[fieldset.B.grid.igrid] < xdim * 4))
+    assert np.all((pset.xi >= 0) & (pset.xi[0] < xdim))
+    assert pset.yi.shape[0] == len(pset.lon)
+    assert pset.yi.shape[1] == len(fieldset.get_fields())
+    assert np.all((pset.yi >= 0) & (pset.yi[fieldset.B.grid.igrid] < ydim * 3))
+    assert np.all((pset.yi >= 0) & (pset.yi[0] < ydim))
+
+
+@pytest.mark.parametrize('mode', ['jit', 'scipy'])
 @pytest.mark.parametrize('ugridfactor', [1, 10])
 def test_sampling_multiple_grid_sizes(mode, ugridfactor):
     xdim, ydim = 10, 20

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -406,6 +406,66 @@ def test_sampling_out_of_bounds_time(mode, allow_time_extrapolation, k_sample_p,
 
 @pytest.mark.parametrize('mode', ['jit', 'scipy'])
 @pytest.mark.parametrize('npart', [1, 10])
+@pytest.mark.parametrize('chs', [False, 'auto', (10, 10)])
+def test_sampling_multigrids_non_vectorfield_from_file(mode, npart, tmpdir, chs, filename='test_subsets'):
+    xdim, ydim = 100, 200
+    filepath = tmpdir.join(filename)
+    U = Field('U', np.zeros((ydim, xdim), dtype=np.float32),
+              lon=np.linspace(0., 1., xdim, dtype=np.float32),
+              lat=np.linspace(0., 1., ydim, dtype=np.float32))
+    V = Field('V', np.zeros((ydim, xdim), dtype=np.float32),
+              lon=np.linspace(0., 1., xdim, dtype=np.float32),
+              lat=np.linspace(0., 1., ydim, dtype=np.float32))
+    B = Field('B', np.ones((3*ydim, 4*xdim), dtype=np.float32),
+              lon=np.linspace(0., 1., 4*xdim, dtype=np.float32),
+              lat=np.linspace(0., 1., 3*ydim, dtype=np.float32))
+    fieldset = FieldSet(U, V)
+    fieldset.add_field(B, 'B')
+    fieldset.write(filepath)
+    fieldset = None
+
+    ufiles = [filepath+'U.nc', ] * 4
+    vfiles = [filepath+'V.nc', ] * 4
+    bfiles = [filepath+'B.nc', ] * 4
+    timestamps = np.arange(0, 4, 1) * 86400.0
+    timestamps = np.expand_dims(timestamps, 1)
+    files = {'U': ufiles, 'V': vfiles, 'B': bfiles}
+    variables = {'U': 'vozocrtx', 'V': 'vomecrty', 'B': 'B'}
+    dimensions = {'lon': 'nav_lon', 'lat': 'nav_lat'}
+    fieldset = FieldSet.from_netcdf(files, variables, dimensions, timestamps=timestamps, allow_time_extrapolation=True,
+                                    field_chunksize=chs)
+
+    fieldset.add_constant('sample_depth', 2.5)
+    assert fieldset.U.grid is fieldset.V.grid
+    assert fieldset.U.grid is not fieldset.B.grid
+
+    class TestParticle(ptype[mode]):
+        sample_var = Variable('sample_var', initial=0.)
+
+    pset = ParticleSet.from_line(fieldset, pclass=TestParticle, start=[0.3, 0.3], finish=[0.7, 0.7], size=npart)
+
+    def test_sample(particle, fieldset, time):
+        particle.sample_var += fieldset.B[time, fieldset.sample_depth, particle.lat, particle.lon]
+
+    kernels = pset.Kernel(AdvectionRK4) + pset.Kernel(test_sample)
+    pset.execute(kernels, runtime=10, dt=1)
+    assert np.allclose(pset.sample_var, 10.0)
+    if mode == 'jit':
+        assert len(pset.xi.shape) == 2
+        assert pset.xi.shape[1] == len(pset.lon)
+        assert pset.xi.shape[0] == fieldset.gridset.size
+        assert np.all(pset.xi >= 0)
+        assert np.all(pset.xi[fieldset.B.igrid, :] < xdim * 4)
+        assert np.all(pset.xi[0, :] < xdim)
+        assert pset.yi.shape[1] == len(pset.lon)
+        assert pset.yi.shape[0] == fieldset.gridset.size
+        assert np.all(pset.yi >= 0)
+        assert np.all(pset.yi[fieldset.B.igrid, :] < ydim * 3)
+        assert np.all(pset.yi[0, :] < ydim)
+
+
+@pytest.mark.parametrize('mode', ['jit', 'scipy'])
+@pytest.mark.parametrize('npart', [1, 10])
 def test_sampling_multigrids_non_vectorfield(mode, npart):
     xdim, ydim = 100, 200
     U = Field('U', np.zeros((ydim, xdim), dtype=np.float32),


### PR DESCRIPTION
In our longer running test case, we found out that the field sampling of multigrids still leads to errors (specifically there: Segmentation Faults and ctypes errors, such as:
```
tests/test_grids.py:584: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/var/scratch/test_env/lib/python3.7/site-packages/parcels-2.1.5.dev192+g74c9143.d20200402-py3.7.egg/parcels/particleset.py:640: in execute
    self.kernel.execute(self, endtime=time, dt=dt, recovery=recovery, output_file=output_file)
/var/scratch/test_env/lib/python3.7/site-packages/parcels-2.1.5.dev192+g74c9143.d20200402-py3.7.egg/parcels/kernel.py:409: in execute
    self.execute_jit(pset, endtime, dt)
/var/scratch/test_env/lib/python3.7/site-packages/parcels-2.1.5.dev192+g74c9143.d20200402-py3.7.egg/parcels/kernel.py:253: in execute_jit
    particle_data = byref(pset.ctypes_struct)
/var/scratch/test_env/lib/python3.7/site-packages/parcels-2.1.5.dev192+g74c9143.d20200402-py3.7.egg/parcels/particleset.py:306: in ctypes_struct
    cdata = [cdata_for(v) for v in self.ptype.variables]
/var/scratch/test_env/lib/python3.7/site-packages/parcels-2.1.5.dev192+g74c9143.d20200402-py3.7.egg/parcels/particleset.py:306: in <listcomp>
    cdata = [cdata_for(v) for v in self.ptype.variables]
/var/scratch/test_env/lib/python3.7/site-packages/parcels-2.1.5.dev192+g74c9143.d20200402-py3.7.egg/parcels/particleset.py:302: in cdata_for
    cdata_array = np.ctypeslib.as_ctypes(self.particle_data[v.name])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
obj = array([[1, 2, 0],
       [0, 2, 0],
       [0, 0, 0],
       [0, 0, 0]], dtype=int32)
    def as_ctypes(obj):
        """Create and return a ctypes object from a numpy array.  Actually
        anything that exposes the __array_interface__ is accepted."""
        ai = obj.__array_interface__
        if ai["strides"]:
>           raise TypeError("strided arrays not supported")
E           TypeError: strided arrays not supported
/var/scratch/bin-x86_64/anaconda/envs/OpenParcels_MPI/lib/python3.7/site-packages/numpy/ctypeslib.py:531: TypeError
```

based on that, we created an new, expanded test in `tests/test_fieldset_sampling.py` that resembles the error occurence better, called `test_sampling_multigrids_non_vectorfield()`.

specifically, in the custom test kernel, the sampling of the 'B' field fails.
