### PR TITLE
Raising Error creating Field with np.ndarray data but deferred_load grid

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -86,6 +86,8 @@ class Field(object):
         self.data = data
         time_origin = TimeConverter(0) if time_origin is None else time_origin
         if grid:
+            if grid.defer_load and isinstance(data, np.ndarray):
+                raise ValueError('Cannot combine Grid from defer_loaded Field with np.ndarray data. please specify lon, lat, depth and time dimensions separately')
             self.grid = grid
         else:
             self.grid = Grid.create_grid(lon, lat, depth, time, time_origin=time_origin, mesh=mesh)

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -653,7 +653,8 @@ def test_fieldset_defer_loading_function(zdim, scale_fac, tmpdir, filename='test
     fieldset = FieldSet.from_parcels(filepath, field_chunksize=(1, 2, 2))
 
     # testing for combination of deferred-loaded and numpy Fields
-    fieldset.add_field(Field('numpyfield', np.zeros((10, zdim, 3, 3)), grid=fieldset.U.grid))
+    with pytest.raises(ValueError):
+        fieldset.add_field(Field('numpyfield', np.zeros((10, zdim, 3, 3)), grid=fieldset.U.grid))
 
     # testing for scaling factors
     fieldset.U.set_scaling_factor(scale_fac)


### PR DESCRIPTION
With the `dask` chunking, it is not a good idea to create a new `Field` with `np.ndarray` data and a `grid` that comes from a `deferred_array` `Field`. 

With this PR, this is now explicitly disallowed. Users should instead directly include `lon`, `lat`, `depth` and `time` dimensions for their new `Field`