### PR TITLE
Updating way ageing is implemented in tutorial_Argofloats

### DIFF
--- a/parcels/examples/tutorial_Argofloats.ipynb
+++ b/parcels/examples/tutorial_Argofloats.ipynb
@@ -62,7 +62,8 @@
     "            particle.cycle_phase = 0\n",
     "            particle.cycle_age = 0\n",
     "\n",
-    "    particle.cycle_age += particle.dt  # update cycle_age"
+    "    if particle.state == ErrorCode.Evaluate:\n",
+    "        particle.cycle_age += particle.dt  # update cycle_age"
    ]
   },
   {


### PR DESCRIPTION
Otherwise, age will be added twice when `particle.state == ErrorCode.Repeat`

This fixes #807