### PR TITLE
Renaming variable `p` in codegenerator to more specific `pnum`

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1036,7 +1036,7 @@ class Field(object):
 
     def ccode_eval(self, var, t, z, y, x):
         # Casting interp_methd to int as easier to pass on in C-code
-        return "temporal_interpolation(%s, %s, %s, %s, %s, &particles->xi[p*ngrid], &particles->yi[p*ngrid], &particles->zi[p*ngrid], &particles->ti[p*ngrid], &%s, %s)" \
+        return "temporal_interpolation(%s, %s, %s, %s, %s, &particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], &%s, %s)" \
             % (x, y, z, t, self.ccode_name, var, self.interp_method.upper())
 
     def ccode_convert(self, _, z, y, x):
@@ -1591,12 +1591,12 @@ class VectorField(object):
         if self.vector_type == '3D':
             return "temporal_interpolationUVW(%s, %s, %s, %s, %s, %s, %s, " \
                    % (x, y, z, t, U.ccode_name, V.ccode_name, W.ccode_name) + \
-                   "&particles->xi[p*ngrid], &particles->yi[p*ngrid], &particles->zi[p*ngrid], &particles->ti[p*ngrid], &%s, &%s, &%s, %s)" \
+                   "&particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], &%s, &%s, &%s, %s)" \
                    % (varU, varV, varW, U.interp_method.upper())
         else:
             return "temporal_interpolationUV(%s, %s, %s, %s, %s, %s, " \
                    % (x, y, z, t, U.ccode_name, V.ccode_name) + \
-                   "&particles->xi[p*ngrid], &particles->yi[p*ngrid], &particles->zi[p*ngrid], &particles->ti[p*ngrid], &%s, &%s, %s)" \
+                   "&particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], &%s, &%s, %s)" \
                    % (varU, varV, U.interp_method.upper())
 
 

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -167,11 +167,15 @@ def test_parcels_tmpvar_in_kernel(fieldset):
     def kernel_tmpvar(particle, fieldset, time):
         parcels_tmpvar0 = 0  # noqa
 
-    try:
-        pset.execute(kernel_tmpvar, endtime=1, dt=1.)
-    except NotImplementedError:
-        error_thrown = True
-    assert error_thrown
+    def kernel_pnum(particle, fieldset, time):
+        pnum = 0  # noqa
+
+    for kernel in [kernel_tmpvar, kernel_pnum]:
+        try:
+            pset.execute(kernel, endtime=1, dt=1.)
+        except NotImplementedError:
+            error_thrown = True
+        assert error_thrown
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])


### PR DESCRIPTION
This fixes the Issue that users can't use variable named `p` in their Custom Kernels (see also #741)