### PR TITLE
Use .data in Field from xarray

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -450,7 +450,7 @@ class Field(object):
                This flag overrides the allow_time_interpolation and sets it to False
         """
 
-        data = da.values
+        data = da.data
         interp_method = kwargs.pop('interp_method', 'linear')
 
         time = da[dimensions['time']].values if 'time' in dimensions else np.array([0])


### PR DESCRIPTION
Using `.values` to extract the data from an xarray dataset when creating a field forcing loading of all the data. This doesn't take advantage of xarray datasets with deferred data. Indeed, the rest of Field is aware of dask arrays, so we can load them in directly by using `.data` instead.