### PR TITLE
Fixing bug in ParticleSet partitions check for maximum particle position

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -184,7 +184,7 @@ class ParticleSet(object):
                         else:
                             partitions = None
                         partitions = mpi_comm.bcast(partitions, root=0)
-                    elif np.max(partitions >= mpi_rank):
+                    elif np.max(partitions) >= mpi_size:
                         raise RuntimeError('Particle partitions must vary between 0 and the number of mpi procs')
                     lon = lon[partitions == mpi_rank]
                     lat = lat[partitions == mpi_rank]


### PR DESCRIPTION
This fixes issue #850, where the maximum in partitions is compared to mpi_rank instead of mpi_size.