### PR TITLE
Throwing error for custom Variables with same name as built-in Variables

### DIFF
--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -24,9 +24,6 @@ class Variable(object):
     def __init__(self, name, dtype=np.float32, initial=0, to_write=True, _custom=True):
         if name == 'z':
             raise NotImplementedError("Custom Variable name 'z' is not allowed, as it is used for depth in ParticleFile")
-        if _custom and name in ['lon', 'lat', 'depth', 'time', 'xi', 'yi', 'zi', 'ti', 'id',
-                                'fileid', 'dt', 'state', '_next_dt']:
-            raise RuntimeError("Custom Variable name '%s' is not allowed, as it is also a built-in variable" % name)
         self.name = name
         self.dtype = dtype
         self.initial = initial
@@ -73,6 +70,13 @@ class ParticleType(object):
             if issubclass(cls, ScipyParticle):
                 # Add inherited particle variables
                 ptype = cls.getPType()
+                for v in self.variables:
+                    if v.name in [v.name for v in ptype.variables]:
+                        raise AttributeError(
+                            "Custom Variable name '%s' is not allowed, as it is also a built-in variable" % v.name)
+                    if v.name == 'z':
+                        raise AttributeError(
+                            "Custom Variable name 'z' is not allowed, as it is used for depth in ParticleFile")
                 self.variables = ptype.variables + self.variables
         # Sort variables with all the 64-bit first so that they are aligned for the JIT cptr
         self.variables = [v for v in self.variables if v.is64bit()] + \

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -21,9 +21,12 @@ class Variable(object):
              which will then be sampled at the location of the particle
     :param to_write: Boolean to control whether Variable is written to NetCDF file
     """
-    def __init__(self, name, dtype=np.float32, initial=0, to_write=True):
+    def __init__(self, name, dtype=np.float32, initial=0, to_write=True, _custom=True):
         if name == 'z':
             raise NotImplementedError("Custom Variable name 'z' is not allowed, as it is used for depth in ParticleFile")
+        if _custom and name in ['lon', 'lat', 'depth', 'time', 'xi', 'yi', 'zi', 'ti', 'id',
+                                'fileid', 'dt', 'state', '_next_dt']:
+            raise RuntimeError("Custom Variable name '%s' is not allowed, as it is also a built-in variable" % name)
         self.name = name
         self.dtype = dtype
         self.initial = initial
@@ -62,7 +65,6 @@ class ParticleType(object):
             raise TypeError("Class object required to derive ParticleType")
         if not issubclass(pclass, ScipyParticle):
             raise TypeError("Class object does not inherit from parcels.ScipyParticle")
-
         self.name = pclass.__name__
         self.uses_jit = issubclass(pclass, JITParticle)
         # Pick Variable objects out of __dict__.
@@ -166,19 +168,19 @@ class ScipyParticle(_Particle):
     Additional Variables can be added via the :Class Variable: objects
     """
 
-    lon = Variable('lon', dtype=np.float32)
-    lat = Variable('lat', dtype=np.float32)
-    depth = Variable('depth', dtype=np.float32)
-    time = Variable('time', dtype=np.float64)
-    xi = Variable('xi', dtype=np.int32, to_write=False)
-    yi = Variable('yi', dtype=np.int32, to_write=False)
-    zi = Variable('zi', dtype=np.int32, to_write=False)
-    ti = Variable('ti', dtype=np.int32, to_write=False, initial=-1)
-    id = Variable('id', dtype=np.int32)
-    fileid = Variable('fileid', dtype=np.int32, initial=-1, to_write=False)
-    dt = Variable('dt', dtype=np.float64, to_write=False)
-    state = Variable('state', dtype=np.int32, initial=ErrorCode.Evaluate, to_write=False)
-    next_dt = Variable('_next_dt', dtype=np.float64, initial=np.nan, to_write=False)
+    lon = Variable('lon', dtype=np.float32, _custom=False)
+    lat = Variable('lat', dtype=np.float32, _custom=False)
+    depth = Variable('depth', dtype=np.float32, _custom=False)
+    time = Variable('time', dtype=np.float64, _custom=False)
+    xi = Variable('xi', dtype=np.int32, to_write=False, _custom=False)
+    yi = Variable('yi', dtype=np.int32, to_write=False, _custom=False)
+    zi = Variable('zi', dtype=np.int32, to_write=False, _custom=False)
+    ti = Variable('ti', dtype=np.int32, to_write=False, initial=-1, _custom=False)
+    id = Variable('id', dtype=np.int32, _custom=False)
+    fileid = Variable('fileid', dtype=np.int32, initial=-1, to_write=False, _custom=False)
+    dt = Variable('dt', dtype=np.float64, to_write=False, _custom=False)
+    state = Variable('state', dtype=np.int32, initial=ErrorCode.Evaluate, to_write=False, _custom=False)
+    next_dt = Variable('_next_dt', dtype=np.float64, initial=np.nan, to_write=False, _custom=False)
 
     def __init__(self, lon, lat, pid, fieldset, depth=0., time=0., cptr=None):
 

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -21,9 +21,7 @@ class Variable(object):
              which will then be sampled at the location of the particle
     :param to_write: Boolean to control whether Variable is written to NetCDF file
     """
-    def __init__(self, name, dtype=np.float32, initial=0, to_write=True, _custom=True):
-        if name == 'z':
-            raise NotImplementedError("Custom Variable name 'z' is not allowed, as it is used for depth in ParticleFile")
+    def __init__(self, name, dtype=np.float32, initial=0, to_write=True):
         self.name = name
         self.dtype = dtype
         self.initial = initial
@@ -172,19 +170,19 @@ class ScipyParticle(_Particle):
     Additional Variables can be added via the :Class Variable: objects
     """
 
-    lon = Variable('lon', dtype=np.float32, _custom=False)
-    lat = Variable('lat', dtype=np.float32, _custom=False)
-    depth = Variable('depth', dtype=np.float32, _custom=False)
-    time = Variable('time', dtype=np.float64, _custom=False)
-    xi = Variable('xi', dtype=np.int32, to_write=False, _custom=False)
-    yi = Variable('yi', dtype=np.int32, to_write=False, _custom=False)
-    zi = Variable('zi', dtype=np.int32, to_write=False, _custom=False)
-    ti = Variable('ti', dtype=np.int32, to_write=False, initial=-1, _custom=False)
-    id = Variable('id', dtype=np.int32, _custom=False)
-    fileid = Variable('fileid', dtype=np.int32, initial=-1, to_write=False, _custom=False)
-    dt = Variable('dt', dtype=np.float64, to_write=False, _custom=False)
-    state = Variable('state', dtype=np.int32, initial=ErrorCode.Evaluate, to_write=False, _custom=False)
-    next_dt = Variable('_next_dt', dtype=np.float64, initial=np.nan, to_write=False, _custom=False)
+    lon = Variable('lon', dtype=np.float32)
+    lat = Variable('lat', dtype=np.float32)
+    depth = Variable('depth', dtype=np.float32)
+    time = Variable('time', dtype=np.float64)
+    xi = Variable('xi', dtype=np.int32, to_write=False)
+    yi = Variable('yi', dtype=np.int32, to_write=False)
+    zi = Variable('zi', dtype=np.int32, to_write=False)
+    ti = Variable('ti', dtype=np.int32, to_write=False, initial=-1)
+    id = Variable('id', dtype=np.int32)
+    fileid = Variable('fileid', dtype=np.int32, initial=-1, to_write=False)
+    dt = Variable('dt', dtype=np.float64, to_write=False)
+    state = Variable('state', dtype=np.int32, initial=ErrorCode.Evaluate, to_write=False)
+    next_dt = Variable('_next_dt', dtype=np.float64, initial=np.nan, to_write=False)
 
     def __init__(self, lon, lat, pid, fieldset, depth=0., time=0., cptr=None):
 

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -60,13 +60,13 @@ def test_variable_special_names(fieldset, mode):
     """Test that checks errors thrown for special names"""
     for vars in ['z', 'lon']:
         class TestParticle(ptype[mode]):
-            error_thrown = False
-            try:
-                tmp = Variable(vars, dtype=np.float32, initial=10.)
-            except RuntimeError:
-                error_thrown = True
-            assert error_thrown
-        ParticleSet(fieldset, pclass=TestParticle, lon=[0], lat=[0])
+            tmp = Variable(vars, dtype=np.float32, initial=10.)
+        error_thrown = False
+        try:
+            ParticleSet(fieldset, pclass=TestParticle, lon=[0], lat=[0])
+        except AttributeError:
+            error_thrown = True
+        assert error_thrown
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -58,14 +58,15 @@ def test_variable_unsupported_dtypes(fieldset, mode, type):
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_variable_special_names(fieldset, mode):
     """Test that checks errors thrown for special names"""
-    class TestParticle(ptype[mode]):
-        error_thrown = False
-        try:
-            z = Variable('z', dtype=np.float32, initial=10.)
-        except RuntimeError:
-            error_thrown = True
-        assert error_thrown
-    ParticleSet(fieldset, pclass=TestParticle, lon=[0], lat=[0])
+    for vars in ['z', 'lon']:
+        class TestParticle(ptype[mode]):
+            error_thrown = False
+            try:
+                tmp = Variable(vars, dtype=np.float32, initial=10.)
+            except RuntimeError:
+                error_thrown = True
+            assert error_thrown
+        ParticleSet(fieldset, pclass=TestParticle, lon=[0], lat=[0])
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])


### PR DESCRIPTION
Generating an error when users create a custom variable that has the same name as a built-in one

This fixes the Issue mentioned in https://github.com/OceanParcels/parcels/issues/846#issuecomment-638101903