### PR TITLE
Adding explicit error message when indices is empty

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -271,8 +271,10 @@ class Field(object):
         netcdf_engine = kwargs.pop('netcdf_engine', 'netcdf4')
 
         indices = {} if indices is None else indices.copy()
-        for ind in indices.values():
-            assert np.min(ind) >= 0, \
+        for ind in indices:
+            if len(indices[ind]) == 0:
+                raise RuntimeError('Indices for %s can not be empty' % ind)
+            assert np.min(indices[ind]) >= 0, \
                 ('Negative indices are currently not allowed in Parcels. '
                  + 'This is related to the non-increasing dimension it could generate '
                  + 'if the domain goes from lon[-4] to lon[6] for example. '

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -190,6 +190,18 @@ def test_fieldset_from_file_subsets(indslon, indslat, tmpdir, filename='test_sub
     assert np.allclose(fieldsetsub.V.data, fieldsetfull.V.data[ixgrid])
 
 
+def test_empty_indices(tmpdir, filename='test_subsets'):
+    data, dimensions = generate_fieldset(100, 100)
+    filepath = tmpdir.join(filename)
+    FieldSet.from_data(data, dimensions).write(filepath)
+    error_thrown = False
+    try:
+        FieldSet.from_parcels(filepath, indices={'lon': []})
+    except RuntimeError:
+        error_thrown = True
+    assert error_thrown
+
+
 @pytest.mark.parametrize('calltype', ['from_data', 'from_nemo'])
 def test_illegal_dimensionsdict(calltype):
     error_thrown = False


### PR DESCRIPTION
As reported by @dlobelle, the error message when a user accidentally provided an empty list for indices was rather vague (`ValueError: zero-size array to reduction operation minimum which has no identity`)

With this PR, this error message has been made clearer