### PR TITLE
Bugfix: Using correct library to create empty DeferredArray and error for dask.expand_dims()

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -487,8 +487,12 @@ class Field(object):
         if self.grid.xdim == 1 or self.grid.ydim == 1:
             data = lib.squeeze(data)  # First remove all length-1 dimensions in data, so that we can add them below
         if self.grid.xdim == 1 and len(data.shape) < 4:
+            if lib == da:
+                raise NotImplementedError('Length-one dimensions with field chunking not implemented, as dask does not have an `expand_dims` method')
             data = lib.expand_dims(data, axis=-1)
         if self.grid.ydim == 1 and len(data.shape) < 4:
+            raise NotImplementedError(
+                'Length-one dimensions with field chunking not implemented, as dask does not have an `expand_dims` method')
             data = lib.expand_dims(data, axis=-2)
         if self.grid.tdim == 1:
             if len(data.shape) < 4:

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -491,8 +491,8 @@ class Field(object):
                 raise NotImplementedError('Length-one dimensions with field chunking not implemented, as dask does not have an `expand_dims` method')
             data = lib.expand_dims(data, axis=-1)
         if self.grid.ydim == 1 and len(data.shape) < 4:
-            raise NotImplementedError(
-                'Length-one dimensions with field chunking not implemented, as dask does not have an `expand_dims` method')
+            if lib == da:
+                raise NotImplementedError('Length-one dimensions with field chunking not implemented, as dask does not have an `expand_dims` method')
             data = lib.expand_dims(data, axis=-2)
         if self.grid.tdim == 1:
             if len(data.shape) < 4:

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -922,7 +922,8 @@ class FieldSet(object):
                         for i in range(len(f.data)):
                             del f.data[i, :]
 
-                data = da.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
+                lib = np if f.field_chunksize in [False, None] else da
+                data = lib.empty((g.tdim, g.zdim, g.ydim-2*g.meridional_halo, g.xdim-2*g.zonal_halo), dtype=np.float32)
                 f.loaded_time_indices = range(3)
                 for tind in f.loaded_time_indices:
                     for fb in f.filebuffers:


### PR DESCRIPTION
Fixing a small bug where DeferredArrays were always created as dask, even if field_chunksize was set to False or None

This then later caused problems in field.reshape() because `dask` does not have a method `expand_dims`. We therefore now throw a `NotImplementedError`