### PR TITLE
Updates to field.py and fieldset.py to include from_mom5 B-grid method

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -396,7 +396,7 @@ class Field(object):
             for tslice, fname in zip(grid.timeslices, data_filenames):
                 with NetcdfFileBuffer(fname, dimensions, indices, netcdf_engine,
                                       interp_method=interp_method, data_full_zdim=data_full_zdim,
-                                      creation_log = self.creation_log, field_chunksize=False) as filebuffer:
+                                      creation_log=kwargs.get("creation_log"), field_chunksize=False) as filebuffer:
                     # If Field.from_netcdf is called directly, it may not have a 'data' dimension
                     # In that case, assume that 'name' is the data dimension
                     filebuffer.name = filebuffer.parse_name(variable[1])
@@ -2177,7 +2177,7 @@ class NetcdfFileBuffer(object):
                 else:
                     data = lib.concatenate((data[ti, d0:d1-1, lat0:lat1, lon0:lon1],
                                            da.zeros((1, lat1-lat0, lon1-lon0))), axis=0)
-            elif self.indices['depth'][-1] == self.data_full_zdim-1 and data.shape[1] == self.data_full_zdim-1 and self.interp_method == 'bgrid_w_velocity' and self.creation_log != 'from_mom5':             
+            elif self.indices['depth'][-1] == self.data_full_zdim-1 and data.shape[1] == self.data_full_zdim-1 and self.interp_method == 'bgrid_w_velocity' and self.creation_log != 'from_mom5':
                 for dim in ['depth', 'lat', 'lon']:
                     if not isinstance(self.indices[dim], (list, range)):
                         raise NotImplementedError("For B grids, indices must be provided as a range")
@@ -2196,7 +2196,7 @@ class NetcdfFileBuffer(object):
                 else:
                     data = lib.concatenate((data[ti, d0:d1-1, lat0:lat1, lon0:lon1],
                                            da.zeros((1, lat1-lat0, lon1-lon0))), axis=0)
-            elif self.indices['depth'][-1] == self.data_full_zdim-1 and data.shape[1] == self.data_full_zdim-1 and self.interp_method == 'bgrid_w_velocity' and self.creation_log == 'from_mom5':          
+            elif self.indices['depth'][-1] == self.data_full_zdim-1 and data.shape[1] == self.data_full_zdim-1 and self.interp_method == 'bgrid_w_velocity' and self.creation_log == 'from_mom5':
                 for dim in ['depth', 'lat', 'lon']:
                     if not isinstance(self.indices[dim], (list, range)):
                         raise NotImplementedError("For B grids, indices must be provided as a range")

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -635,8 +635,8 @@ class FieldSet(object):
 
     @classmethod
     def from_mom5(cls, filenames, variables, dimensions, indices=None, mesh='spherical',
-                 allow_time_extrapolation=None, time_periodic=False,
-                 tracer_interp_method='bgrid_tracer', field_chunksize='auto', **kwargs):
+                  allow_time_extrapolation=None, time_periodic=False,
+                  tracer_interp_method='bgrid_tracer', field_chunksize='auto', **kwargs):
         """Initialises FieldSet object from NetCDF files of MOM5 fields.
 
         :param filenames: Dictionary mapping variables to file(s). The
@@ -689,11 +689,14 @@ class FieldSet(object):
 
         if 'creation_log' not in kwargs.keys():
             kwargs['creation_log'] = 'from_mom5'
-        fieldset = cls.from_b_grid_dataset(filenames, variables, dimensions, mesh=mesh, indices=indices, time_periodic=time_periodic, allow_time_extrapolation=allow_time_extrapolation, tracer_interp_method=tracer_interp_method, field_chunksize=field_chunksize, **kwargs)
+        fieldset = cls.from_b_grid_dataset(filenames, variables, dimensions, mesh=mesh, indices=indices, time_periodic=time_periodic,
+                                           allow_time_extrapolation=allow_time_extrapolation, tracer_interp_method=tracer_interp_method,
+                                           field_chunksize=field_chunksize, **kwargs)
         fieldset.W.set_scaling_factor(-1.)  # change the W direction
         logger.warning_once("Parcels assumes W is positive in direction of increasing depth. For MOM5 this is down. Scaling factor has been set to -1 for fieldset.W.")
+
         return fieldset
-    
+
     @classmethod
     def from_b_grid_dataset(cls, filenames, variables, dimensions, indices=None, mesh='spherical',
                             allow_time_extrapolation=None, time_periodic=False,

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -634,6 +634,67 @@ class FieldSet(object):
         return fieldset
 
     @classmethod
+    def from_mom5(cls, filenames, variables, dimensions, indices=None, mesh='spherical',
+                 allow_time_extrapolation=None, time_periodic=False,
+                 tracer_interp_method='bgrid_tracer', field_chunksize='auto', **kwargs):
+        """Initialises FieldSet object from NetCDF files of MOM5 fields.
+
+        :param filenames: Dictionary mapping variables to file(s). The
+               filepath may contain wildcards to indicate multiple files,
+               or be a list of file.
+               filenames can be a list [files], a dictionary {var:[files]},
+               a dictionary {dim:[files]} (if lon, lat, depth and/or data not stored in same files as data),
+               or a dictionary of dictionaries {var:{dim:[files]}}
+               time values are in filenames[data]
+        :param variables: Dictionary mapping variables to variable names in the netCDF file(s).
+        :param dimensions: Dictionary mapping data dimensions (lon,
+               lat, depth, time, data) to dimensions in the netCF file(s).
+               Note that dimensions can also be a dictionary of dictionaries if
+               dimension names are different for each variable.
+               Watch out: MOM5 is discretised on a B-grid:
+               U and V velocity nodes are not located as W velocity and T tracer nodes (see https://mom-ocean.github.io/assets/pdfs/MOM5_manual.pdf ).
+               U[k,j+1,i],V[k,j+1,i] ____________________U[k,j+1,i+1],V[k,j+1,i+1]
+               |                                         |
+               |      W[k:k+2,j+1,i+1],T[k,j+1,i+1]      |
+               |                                         |
+               U[k,j,i],V[k,j,i] ________________________U[k,j,i+1],V[k,j,i+1]
+               In 2D: U and V nodes are on the cell vertices and interpolated bilinearly as a A-grid.
+                      T node is at the cell centre and interpolated constant per cell as a C-grid.
+               In 3D: U and V nodes are at the middle of the cell vertical edges,
+                      They are interpolated bilinearly (independently of z) in the cell.
+                      W nodes are at the centre of the horizontal interfaces.
+                      They are interpolated linearly (as a function of z) in the cell.
+                      T node is at the cell centre, and constant per cell.
+        :param indices: Optional dictionary of indices for each dimension
+               to read from file(s), to allow for reading of subset of data.
+               Default is to read the full extent of each dimension.
+               Note that negative indices are not allowed.
+        :param fieldtype: Optional dictionary mapping fields to fieldtypes to be used for UnitConverter.
+               (either 'U', 'V', 'Kh_zonal', 'Kh_meridional' or None)
+        :param mesh: String indicating the type of mesh coordinates and
+               units used during velocity interpolation, see also https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_unitconverters.ipynb:
+
+               1. spherical (default): Lat and lon in degree, with a
+                  correction for zonal velocity U near the poles.
+               2. flat: No conversion, lat/lon are assumed to be in m.
+        :param allow_time_extrapolation: boolean whether to allow for extrapolation
+               (i.e. beyond the last available time snapshot)
+               Default is False if dimensions includes time, else True
+        :param time_periodic: To loop periodically over the time component of the Field. It is set to either False or the length of the period (either float in seconds or datetime.timedelta object). (Default: False)
+               This flag overrides the allow_time_interpolation and sets it to False
+        :param tracer_interp_method: Method for interpolation of tracer fields. It is recommended to use 'bgrid_tracer' (default)
+               Note that in the case of from_pop(), from_mom5() and from_bgrid(), the velocity fields are default to 'bgrid_velocity'
+        :param field_chunksize: size of the chunks in dask loading
+        """
+
+        if 'creation_log' not in kwargs.keys():
+            kwargs['creation_log'] = 'from_mom5'
+        fieldset = cls.from_b_grid_dataset(filenames, variables, dimensions, mesh=mesh, indices=indices, time_periodic=time_periodic, allow_time_extrapolation=allow_time_extrapolation, tracer_interp_method=tracer_interp_method, field_chunksize=field_chunksize, **kwargs)
+        fieldset.W.set_scaling_factor(-1.)  # change the W direction
+        logger.warning_once("Parcels assumes W is positive in direction of increasing depth. For MOM5 this is down. Scaling factor has been set to -1 for fieldset.W.")
+        return fieldset
+    
+    @classmethod
     def from_b_grid_dataset(cls, filenames, variables, dimensions, indices=None, mesh='spherical',
                             allow_time_extrapolation=None, time_periodic=False,
                             tracer_interp_method='bgrid_tracer', field_chunksize='auto', **kwargs):


### PR DESCRIPTION
The vertical dimension of MOM5 fields differs from other models in that the vertical velocity is defined at the base of the grid cell.  To overcome this the vertical fields should be indexed differently and the top layer of W has been repeated. This relates to issue #860. 
