### PR TITLE
Set Variable write status after creation of ParticleSet

### DIFF
--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -171,7 +171,7 @@ class ParticleFile(object):
             self.lon.units = "degrees_east"
             self.lon.axis = "X"
 
-        if ('depth' in self.var_names):
+        if ('depth' in self.var_names) or ('z' in self.var_names):
             self.z = self.dataset.createVariable("z", lonlatdepth_precision, coords, fill_value=np.nan)
             self.z.long_name = ""
             self.z.standard_name = "depth"

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -157,23 +157,26 @@ class ParticleFile(object):
         else:
             lonlatdepth_precision = "f4"
 
-        self.lat = self.dataset.createVariable("lat", lonlatdepth_precision, coords, fill_value=np.nan)
-        self.lat.long_name = ""
-        self.lat.standard_name = "latitude"
-        self.lat.units = "degrees_north"
-        self.lat.axis = "Y"
+        if ('lat' in self.var_names):
+            self.lat = self.dataset.createVariable("lat", lonlatdepth_precision, coords, fill_value=np.nan)
+            self.lat.long_name = ""
+            self.lat.standard_name = "latitude"
+            self.lat.units = "degrees_north"
+            self.lat.axis = "Y"
 
-        self.lon = self.dataset.createVariable("lon", lonlatdepth_precision, coords, fill_value=np.nan)
-        self.lon.long_name = ""
-        self.lon.standard_name = "longitude"
-        self.lon.units = "degrees_east"
-        self.lon.axis = "X"
+        if ('lon' in self.var_names):
+            self.lon = self.dataset.createVariable("lon", lonlatdepth_precision, coords, fill_value=np.nan)
+            self.lon.long_name = ""
+            self.lon.standard_name = "longitude"
+            self.lon.units = "degrees_east"
+            self.lon.axis = "X"
 
-        self.z = self.dataset.createVariable("z", lonlatdepth_precision, coords, fill_value=np.nan)
-        self.z.long_name = ""
-        self.z.standard_name = "depth"
-        self.z.units = "m"
-        self.z.positive = "down"
+        if ('depth' in self.var_names):
+            self.z = self.dataset.createVariable("z", lonlatdepth_precision, coords, fill_value=np.nan)
+            self.z.long_name = ""
+            self.z.standard_name = "depth"
+            self.z.units = "m"
+            self.z.positive = "down"
 
         for vname in self.var_names:
             if vname not in ['time', 'lat', 'lon', 'depth', 'id']:

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -819,6 +819,10 @@ def search_kernel(particle, fieldset, time):
         :param var: Name of the variable (string)
         :param status: Write status of the variable (True, False or 'once')
         """
+        var_changed = False
         for v in self.ptype.variables:
             if v.name == var:
                 v.to_write = write_status
+                var_changed = True
+        if not var_changed:
+            raise SyntaxError('Could not change the write status of %s, because it is not a Variable name' % var)

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -813,3 +813,12 @@ def search_kernel(particle, fieldset, time):
         """Wrapper method to initialise a :class:`parcels.particlefile.ParticleFile`
         object from the ParticleSet"""
         return ParticleFile(*args, particleset=self, **kwargs)
+
+    def set_variable_write_status(self, var, write_status):
+        """Method to set the write status of a Variable
+        :param var: Name of the variable (string)
+        :param status: Write status of the variable (True, False or 'once')
+        """
+        for v in self.ptype.variables:
+            if v.name == var:
+                v.to_write = write_status

--- a/tests/test_particle_file.py
+++ b/tests/test_particle_file.py
@@ -85,6 +85,10 @@ def test_pfile_set_towrite_False(fieldset, mode, tmpdir, npart=10):
     assert 'lat' not in ncfile.variables
     ncfile.close()
 
+    # For pytest purposes, we need to reset to original status
+    pset.set_variable_write_status('depth', True)
+    pset.set_variable_write_status('lat', True)
+
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pfile_array_remove_all_particles(fieldset, mode, tmpdir, npart=10):

--- a/tests/test_particle_file.py
+++ b/tests/test_particle_file.py
@@ -66,6 +66,27 @@ def test_pfile_array_remove_particles(fieldset, mode, tmpdir, npart=10):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pfile_set_towrite_False(fieldset, mode, tmpdir, npart=10):
+    filepath = tmpdir.join("pfile_set_towrite_False.nc")
+    pset = ParticleSet(fieldset, pclass=ptype[mode],
+                       lon=np.linspace(0, 1, npart),
+                       lat=0.5*np.ones(npart))
+    pset.set_variable_write_status('depth', False)
+    pset.set_variable_write_status('lat', False)
+    pfile = pset.ParticleFile(filepath, outputdt=1)
+
+    def Update_lon(particle, fieldset, time):
+        particle.lon += 0.1
+
+    pset.execute(Update_lon, runtime=10, output_file=pfile)
+    ncfile = close_and_compare_netcdffiles(filepath, pfile)
+    assert 'time' in ncfile.variables
+    assert 'depth' not in ncfile.variables
+    assert 'lat' not in ncfile.variables
+    ncfile.close()
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pfile_array_remove_all_particles(fieldset, mode, tmpdir, npart=10):
 
     filepath = tmpdir.join("pfile_array_remove_particles.nc")

--- a/tests/test_particle_file.py
+++ b/tests/test_particle_file.py
@@ -65,29 +65,29 @@ def test_pfile_array_remove_particles(fieldset, mode, tmpdir, npart=10):
     ncfile.close()
 
 
-@pytest.mark.parametrize('mode', ['scipy', 'jit'])
-def test_pfile_set_towrite_False(fieldset, mode, tmpdir, npart=10):
-    filepath = tmpdir.join("pfile_set_towrite_False.nc")
-    pset = ParticleSet(fieldset, pclass=ptype[mode],
-                       lon=np.linspace(0, 1, npart),
-                       lat=0.5*np.ones(npart))
-    pset.set_variable_write_status('depth', False)
-    pset.set_variable_write_status('lat', False)
-    pfile = pset.ParticleFile(filepath, outputdt=1)
-
-    def Update_lon(particle, fieldset, time):
-        particle.lon += 0.1
-
-    pset.execute(Update_lon, runtime=10, output_file=pfile)
-    ncfile = close_and_compare_netcdffiles(filepath, pfile)
-    assert 'time' in ncfile.variables
-    assert 'depth' not in ncfile.variables
-    assert 'lat' not in ncfile.variables
-    ncfile.close()
-
-    # For pytest purposes, we need to reset to original status
-    pset.set_variable_write_status('depth', True)
-    pset.set_variable_write_status('lat', True)
+# @pytest.mark.parametrize('mode', ['scipy', 'jit'])
+# def test_pfile_set_towrite_False(fieldset, mode, tmpdir, npart=10):
+#     filepath = tmpdir.join("pfile_set_towrite_False.nc")
+#     pset = ParticleSet(fieldset, pclass=ptype[mode],
+#                        lon=np.linspace(0, 1, npart),
+#                        lat=0.5*np.ones(npart))
+#     pset.set_variable_write_status('depth', False)
+#     pset.set_variable_write_status('lat', False)
+#     pfile = pset.ParticleFile(filepath, outputdt=1)
+#
+#     def Update_lon(particle, fieldset, time):
+#         particle.lon += 0.1
+#
+#     pset.execute(Update_lon, runtime=10, output_file=pfile)
+#     ncfile = close_and_compare_netcdffiles(filepath, pfile)
+#     assert 'time' in ncfile.variables
+#     assert 'depth' not in ncfile.variables
+#     assert 'lat' not in ncfile.variables
+#     ncfile.close()
+#
+#     # For pytest purposes, we need to reset to original status
+#     pset.set_variable_write_status('depth', True)
+#     pset.set_variable_write_status('lat', True)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])

--- a/tests/test_particle_file.py
+++ b/tests/test_particle_file.py
@@ -65,29 +65,29 @@ def test_pfile_array_remove_particles(fieldset, mode, tmpdir, npart=10):
     ncfile.close()
 
 
-# @pytest.mark.parametrize('mode', ['scipy', 'jit'])
-# def test_pfile_set_towrite_False(fieldset, mode, tmpdir, npart=10):
-#     filepath = tmpdir.join("pfile_set_towrite_False.nc")
-#     pset = ParticleSet(fieldset, pclass=ptype[mode],
-#                        lon=np.linspace(0, 1, npart),
-#                        lat=0.5*np.ones(npart))
-#     pset.set_variable_write_status('depth', False)
-#     pset.set_variable_write_status('lat', False)
-#     pfile = pset.ParticleFile(filepath, outputdt=1)
-#
-#     def Update_lon(particle, fieldset, time):
-#         particle.lon += 0.1
-#
-#     pset.execute(Update_lon, runtime=10, output_file=pfile)
-#     ncfile = close_and_compare_netcdffiles(filepath, pfile)
-#     assert 'time' in ncfile.variables
-#     assert 'depth' not in ncfile.variables
-#     assert 'lat' not in ncfile.variables
-#     ncfile.close()
-#
-#     # For pytest purposes, we need to reset to original status
-#     pset.set_variable_write_status('depth', True)
-#     pset.set_variable_write_status('lat', True)
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_pfile_set_towrite_False(fieldset, mode, tmpdir, npart=10):
+    filepath = tmpdir.join("pfile_set_towrite_False.nc")
+    pset = ParticleSet(fieldset, pclass=ptype[mode],
+                       lon=np.linspace(0, 1, npart),
+                       lat=0.5*np.ones(npart))
+    pset.set_variable_write_status('depth', False)
+    pset.set_variable_write_status('lat', False)
+    pfile = pset.ParticleFile(filepath, outputdt=1)
+
+    def Update_lon(particle, fieldset, time):
+        particle.lon += 0.1
+
+    pset.execute(Update_lon, runtime=10, output_file=pfile)
+    ncfile = close_and_compare_netcdffiles(filepath, pfile)
+    assert 'time' in ncfile.variables
+    assert 'depth' not in ncfile.variables
+    assert 'lat' not in ncfile.variables
+    ncfile.close()
+
+    # For pytest purposes, we need to reset to original status
+    pset.set_variable_write_status('depth', True)
+    pset.set_variable_write_status('lat', True)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])


### PR DESCRIPTION
This PR implements and tests a method to set the write-status of a Variable when ParticleSet has been created

Useful to change e.g. the write status of default Variables like 'depth'

This addresses #891