### PR TITLE
Support sampling fields without applying conversion

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -365,7 +365,7 @@ class IntrinsicTransformer(ast.NodeTransformer):
            and node.func.attr == 'state':
             node = IntrinsicNode(node, "return DELETE")
 
-        if isinstance(node.func, FieldEvalCallNode):
+        elif isinstance(node.func, FieldEvalCallNode):
             # get a temporary value to assign result to
             tmp = self.get_tmp()
             # whether to convert

--- a/parcels/examples/tutorial_unitconverters.ipynb
+++ b/parcels/examples/tutorial_unitconverters.ipynb
@@ -161,6 +161,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that you can also interpolate the Field without a unit conversion, by using the `eval()` method and setting `applyConversion=False`, as below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(fieldset.V.eval(0, 0, 40, -5, applyConversion=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### UnitConverters for `mesh='flat'`"
    ]
   },
@@ -173,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -226,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -260,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -304,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -329,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -358,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -392,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Velocity fields on a spherical grid will automatically be converted to degrees when sampled within a kernel. This makes sense for advection, but we may want an interpolated sampling, without unit conversion. By calling `field.eval(..., applyConversion=False)` directly, we can get the desired behaviour. This works in both scipy and JIT modes.