### PR TITLE
Fixing Dask ZeroDivisionError - DO NOT MERGE

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -2200,8 +2200,8 @@ class NetcdfFileBuffer(object):
                             self.rechunk_callback_fields()
                             self.chunking_finalized = True
                     else:
-                        # ==== I think this can be "pass" too ==== #
-                        data = data.rechunk(self.chunk_mapping)
+                        # # ==== I think this can be "pass" too ==== #
+                        # data = data.rechunk(self.chunk_mapping)
                         self.chunking_finalized = True
             else:
                 da_data = da.from_array(data, chunks=self.field_chunksize)


### PR DESCRIPTION
Some users experience a dask `ZeroDivisonError` in the latest master branch of Parcels. See e.g. https://github.com/OceanParcels/parcels/issues/889#issuecomment-666869317. 

By running `git-bisect`, we were able to pinpoint this bug to https://github.com/OceanParcels/parcels/commit/cbf9e287e3e5bcefd6c60821fddaf30425cb094c.

While removing the line `data = data.rechunk(self.chunk_mapping)` from field.py fixes this bug, it causes other unit tests to fail. Clearly, some further work is needed on the dask chunking