### PR TITLE
Move convert_pset_to_dict from ParticleFile to ParticleSet

### DIFF
--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -242,7 +242,7 @@ class ParticleFile(object):
         :param deleted_only: Flag to write only the deleted Particles
         """
 
-        data_dict, data_dict_once = pset.convert_pset_to_dict(self, time, deleted_only=deleted_only)
+        data_dict, data_dict_once = pset.to_dict(self, time, deleted_only=deleted_only)
         self.dump_dict_to_npy(data_dict, data_dict_once)
         self.dump_psetinfo_to_npy()
 

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -35,6 +35,16 @@ if MPI:
 __all__ = ['ParticleSet']
 
 
+def _to_write_particles(pd, time):
+    """We don't want to write a particle that is not started yet.
+    Particle will be written if particle.time is between time-dt/2 and time+dt/2
+    """
+    return (np.less_equal(time - np.abs(pd['dt']/2), pd['time'], where=np.isfinite(pd['time']))
+            & np.greater(time + np.abs(pd['dt']/2), pd['time'], where=np.isfinite(pd['time']))
+            & (np.isfinite(pd['id']))
+            & (np.isfinite(pd['time'])))
+
+
 class ParticleAccessor(object):
     def __init__(self, pset):
         self.pset = pset
@@ -502,6 +512,58 @@ class ParticleSet(object):
             if field.interp_method == 'cgrid_velocity':
                 return np.float64
         return np.float32
+
+    def convert_pset_to_dict(self, pfile, time, deleted_only=False):
+        """Convert all Particle data from one time step to a python dictionary.
+        :param pfile: ParticleFile object requesting the conversion
+        :param time: Time at which to write ParticleSet
+        :param deleted_only: Flag to write only the deleted Particles
+        returns two dictionaries: one for all variables to be written each outputdt,
+         and one for all variables to be written once
+        """
+        data_dict = {}
+        data_dict_once = {}
+
+        time = time.total_seconds() if isinstance(time, delta) else time
+
+        pd = self.particle_data
+
+        if pfile.lasttime_written != time and \
+           (pfile.write_ondelete is False or deleted_only is not False):
+            if pd['id'].size == 0:
+                logger.warning("ParticleSet is empty on writing as array at time %g" % time)
+            else:
+                if deleted_only is not False:
+                    to_write = deleted_only
+                else:
+                    to_write = _to_write_particles(pd, time)
+                if np.any(to_write) > 0:
+                    for var in pfile.var_names:
+                        data_dict[var] = pd[var][to_write]
+                    pfile.maxid_written = max(pfile.maxid_written, np.max(data_dict['id']))
+
+                pset_errs = (to_write & (pd['state'] != OperationCode.Delete)
+                             & np.less(1e-3, np.abs(time - pd['time']), where=np.isfinite(pd['time'])))
+                if np.count_nonzero(pset_errs) > 0:
+                    logger.warning_once(
+                        'time argument in pfile.write() is {}, but particles have time {}'.format(time, pd['time'][pset_errs]))
+
+                if time not in pfile.time_written:
+                    pfile.time_written.append(time)
+
+                if len(pfile.var_names_once) > 0:
+                    first_write = (_to_write_particles(pd, time)
+                                   & np.isin(pd['id'], pfile.written_once, invert=True))
+                    if np.any(first_write):
+                        data_dict_once['id'] = pd['id'][first_write]
+                        for var in pfile.var_names_once:
+                            data_dict_once[var] = pd[var][first_write]
+                        pfile.written_once.extend(pd['id'][first_write])
+
+            if deleted_only is False:
+                pfile.lasttime_written = time
+
+        return data_dict, data_dict_once
 
     @property
     def size(self):

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -513,7 +513,7 @@ class ParticleSet(object):
                 return np.float64
         return np.float32
 
-    def convert_pset_to_dict(self, pfile, time, deleted_only=False):
+    def to_dict(self, pfile, time, deleted_only=False):
         """Convert all Particle data from one time step to a python dictionary.
         :param pfile: ParticleFile object requesting the conversion
         :param time: Time at which to write ParticleSet


### PR DESCRIPTION
This pull request contains the minimal changes needed to move ParticleSet-implementation specific methods from the ParticleFile class to the ParticleSet class. This means moving the `convert_pset_to_dict` method and its supporting private function `_to_write_particles`. 