### PR TITLE
Kernel support for math.nan and NotEq operator

### DIFF
--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -152,7 +152,7 @@ class ConstNode(IntrinsicNode):
 
 
 class MathNode(IntrinsicNode):
-    symbol_map = {'pi': 'M_PI', 'e': 'M_E'}
+    symbol_map = {'pi': 'M_PI', 'e': 'M_E', 'nan': 'NAN'}
 
     def __getattr__(self, attr):
         if hasattr(math, attr):
@@ -703,6 +703,9 @@ class KernelGenerator(ast.NodeVisitor):
 
     def visit_Eq(self, node):
         node.ccode = "=="
+
+    def visit_NotEq(self, node):
+        node.ccode = "!="
 
     def visit_Lt(self, node):
         node.ccode = "<"

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -79,10 +79,12 @@ def test_expression_float(mode, name, expr, result, npart=10):
     ('And', 'True and False', False),
     ('Or', 'True or False', True),
     ('Equal', '5 == 5', True),
+    ('NotEqual', '3 != 4', True),
     ('Lesser', '5 < 3', False),
     ('LesserEq', '3 <= 5', True),
     ('Greater', '4 > 2', True),
     ('GreaterEq', '2 >= 4', False),
+    ('CheckNaN', 'math.nan != math.nan', True),
 ])
 def test_expression_bool(mode, name, expr, result, npart=10):
     """ Test basic arithmetic expressions """


### PR DESCRIPTION
Somewhat surprisingly, we did not yet support the NotEq (`!=`) operator in Kernels. With this PR, that is now fixed. 

Also, there was no easy way to include a nan into a Kernel. Now, Kernels support `math.nan`