### PR TITLE
Refactor C code for structured grid temporal interpolation

### DIFF
--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -222,7 +222,8 @@ static inline StatusCode spatial_interpolation_nearest2D(double xsi, double eta,
 }
 
 /* C grid interpolation routine for tracers on 2D grid */
-static inline StatusCode spatial_interpolation_tracer_c_grid_2D(float data[2][2], float *value)
+static inline StatusCode spatial_interpolation_tracer_c_grid_2D(double _xsi, double _eta,
+								float data[2][2], float *value)
 {
   *value = data[1][1];
   return SUCCESS;
@@ -241,7 +242,8 @@ static inline StatusCode spatial_interpolation_nearest3D(double xsi, double eta,
 }
 
 /* C grid interpolation routine for tracers on 3D grid */
-static inline StatusCode spatial_interpolation_tracer_c_grid_3D(float data[2][2][2], float *value)
+static inline StatusCode spatial_interpolation_tracer_c_grid_3D(double _xsi, double _eta, double _zeta,
+								float data[2][2][2], float *value)
 {
   *value = data[0][1][1];
   return SUCCESS;
@@ -459,131 +461,82 @@ static inline StatusCode temporal_interpolation_structured_grid(type_coord x, ty
   float data2D[2][2][2];
   float data3D[2][2][2][2];
 
+  // if we're in between time indices, and not at the end of the timeseries,
+  // we'll make sure to interpolate data between the two time values
+  // otherwise, we'll only use the data at the current time index
+  int tii = (ti[igrid] < grid->tdim-1 && time > grid->time[ti[igrid]]) ? 2 : 1;
 
-  if (ti[igrid] < grid->tdim-1 && time > grid->time[ti[igrid]]) {
-    float f0, f1;
-    double t0 = grid->time[ti[igrid]]; double t1 = grid->time[ti[igrid]+1];
-    /* Identify grid cell to sample through local linear search */
-    status = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], time, t0, t1, interp_method); CHECKSTATUS(status);
-    if (grid->zdim==1){
-      status = getCell2D(f, xi[igrid], yi[igrid], ti[igrid], data2D, 0); CHECKSTATUS(status);
-    } else{
-      status = getCell3D(f, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D, 0); CHECKSTATUS(status);
-    }
-    if ((interp_method == LINEAR) || (interp_method == CGRID_VELOCITY) || (interp_method == BGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)){
-      if ((interp_method == CGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)){ // interpolate w
-        if (gridindexingtype == NEMO){
-          xsi = 1;
-          eta = 1;
-        }
-        else if (gridindexingtype == MITGCM){
-          xsi = 0;
-          eta = 0;
-        }
-      }
-      else if (interp_method == BGRID_VELOCITY){
-          zeta = 0;
-      }
-      if (grid->zdim==1){
-        status = spatial_interpolation_bilinear(xsi, eta, data2D[0], &f0); CHECKSTATUS(status);
-        status = spatial_interpolation_bilinear(xsi, eta, data2D[1], &f1); CHECKSTATUS(status);
-      } else {
-        status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D[0], &f0); CHECKSTATUS(status);
-        status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D[1], &f1); CHECKSTATUS(status);
-      }
-    }
-    else if  (interp_method == NEAREST){
-      if (grid->zdim==1){
-        status = spatial_interpolation_nearest2D(xsi, eta, data2D[0], &f0); CHECKSTATUS(status);
-        status = spatial_interpolation_nearest2D(xsi, eta, data2D[1], &f1); CHECKSTATUS(status);
-      } else {
-        status = spatial_interpolation_nearest3D(xsi, eta, zeta, data3D[0], &f0); CHECKSTATUS(status);
-        status = spatial_interpolation_nearest3D(xsi, eta, zeta, data3D[1], &f1); CHECKSTATUS(status);
-      }
-    }
-    else if  ((interp_method == CGRID_TRACER) || (interp_method == BGRID_TRACER)){
-      if (grid->zdim==1){
-        status = spatial_interpolation_tracer_c_grid_2D(data2D[0], &f0); CHECKSTATUS(status);
-        status = spatial_interpolation_tracer_c_grid_2D(data2D[1], &f1); CHECKSTATUS(status);
-      } else {
-        status = spatial_interpolation_tracer_c_grid_3D(data3D[0], &f0); CHECKSTATUS(status);
-        status = spatial_interpolation_tracer_c_grid_3D(data3D[1], &f1); CHECKSTATUS(status);
-      }
-    }
-    else if (interp_method == LINEAR_INVDIST_LAND_TRACER){
-      if (grid->zdim==1){
-        status = spatial_interpolation_bilinear_invdist_land(xsi, eta, data2D[0], &f0); CHECKSTATUS(status);
-        status = spatial_interpolation_bilinear_invdist_land(xsi, eta, data2D[1], &f1); CHECKSTATUS(status);
-      } else {
-        status = spatial_interpolation_trilinear_invdist_land(xsi, eta, zeta, data3D[0], &f0); CHECKSTATUS(status);
-        status = spatial_interpolation_trilinear_invdist_land(xsi, eta, zeta, data3D[1], &f1); CHECKSTATUS(status);
-      }
-    }
-    else {
-        return ERROR;
-    }
-    *value = f0 + (f1 - f0) * (float)((time - t0) / (t1 - t0));
-    return SUCCESS;
+  float val[2] = {0.0f, 0.0f};
+  double t0 = grid->time[ti[igrid]];
+  // we set our second time bound and search time depending on the
+  // index critereon above
+  double t1 = (tii == 2) ? grid->time[ti[igrid]+1] : t0+1;
+  double tsrch = (tii == 2) ? time : t0;
+
+  status = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid],
+			  &xsi, &eta, &zeta, gcode, ti[igrid],
+			  tsrch, t0, t1, interp_method);
+  CHECKSTATUS(status);
+
+  if (grid->zdim == 1) {
+    // last param is a flag, which denotes that we only want the first timestep
+    // (rather than both)
+    status = getCell2D(f, xi[igrid], yi[igrid], ti[igrid], data2D, tii == 1); CHECKSTATUS(status);
   } else {
-    double t0 = grid->time[ti[igrid]];
-    status = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gcode, ti[igrid], t0, t0, t0+1, interp_method); CHECKSTATUS(status);
-    if (grid->zdim==1){
-      status = getCell2D(f, xi[igrid], yi[igrid], ti[igrid], data2D, 1); CHECKSTATUS(status);
-    } else{
-      status = getCell3D(f, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D, 1); CHECKSTATUS(status);
-    }
-    if ((interp_method == LINEAR) || (interp_method == CGRID_VELOCITY) || (interp_method == BGRID_VELOCITY) ||(interp_method == BGRID_W_VELOCITY)){
-      if ((interp_method == CGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)){ // interpolate w
-        if (gridindexingtype == NEMO){
-          xsi = 1;
-          eta = 1;
-        }
-        else if (gridindexingtype == MITGCM){
-          xsi = 0;
-          eta = 0;
-        }
-        if (grid->zdim==1)
-          return ERROR;
-      }
-      else if (interp_method == BGRID_VELOCITY){
-        zeta = 0;
-      }    
-      if (grid->zdim==1){
-        status = spatial_interpolation_bilinear(xsi, eta, data2D[0], value); CHECKSTATUS(status);
-      }
-      else{
-        status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D[0], value); CHECKSTATUS(status);
-      }
-    }
-    else if (interp_method == NEAREST){
-      if (grid->zdim==1){
-        status = spatial_interpolation_nearest2D(xsi, eta, data2D[0], value); CHECKSTATUS(status);
-      }
-      else {
-        status = spatial_interpolation_nearest3D(xsi, eta, zeta, data3D[0], value); CHECKSTATUS(status);
-      }
-    }
-    else if ((interp_method == CGRID_TRACER) || (interp_method == BGRID_TRACER)){
-      if (grid->zdim==1){
-        status = spatial_interpolation_tracer_c_grid_2D(data2D[0], value); CHECKSTATUS(status);
-      }
-      else {
-        status = spatial_interpolation_tracer_c_grid_3D(data3D[0], value); CHECKSTATUS(status);
-      }
-    }
-    else if (interp_method == LINEAR_INVDIST_LAND_TRACER){
-      if (grid->zdim==1){
-        status = spatial_interpolation_bilinear_invdist_land(xsi, eta, data2D[0], value); CHECKSTATUS(status);
-      }
-      else {
-        status = spatial_interpolation_trilinear_invdist_land(xsi, eta, zeta, data3D[0], value); CHECKSTATUS(status);
-      }
-    }
-    else {
-        return ERROR;    
-    }
-    return SUCCESS;
+    status = getCell3D(f, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D, tii == 1); CHECKSTATUS(status);
   }
+
+  // define a helper macro that will select the appropriate interpolation method
+  // depending on whether we need 2D or 3D
+#define INTERP(fn_2d, fn_3d)						\
+  do {									\
+    if (grid->zdim == 1) {						\
+      for (int i = 0; i < tii; i++) {					\
+	status = fn_2d(xsi, eta, data2D[i], &val[i]);			\
+	CHECKSTATUS(status);						\
+      }									\
+    } else {								\
+      for (int i = 0; i < tii; i++) {					\
+	status = fn_3d(xsi, eta, zeta, data3D[i], &val[i]);		\
+	CHECKSTATUS(status);						\
+      }									\
+    }									\
+  } while (0)
+
+  if ((interp_method == LINEAR) || (interp_method == CGRID_VELOCITY) ||
+      (interp_method == BGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)) {
+    // adjust the normalised coordinate for flux-based interpolation methods
+    if ((interp_method == CGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)) {
+      if (gridindexingtype == NEMO) {
+	// velocity is on the northeast of a tracer cell
+	xsi = 1;
+	eta = 1;
+      } else if (gridindexingtype == MITGCM) {
+	// velocity is on the southwest of a tracer cell
+	xsi = 0;
+	eta = 0;
+      }
+    } else if (interp_method == BGRID_VELOCITY) {
+      zeta = 0;
+    }
+
+    INTERP(spatial_interpolation_bilinear, spatial_interpolation_trilinear);
+  } else if (interp_method == NEAREST) {
+    INTERP(spatial_interpolation_nearest2D, spatial_interpolation_nearest3D);
+  } else if ((interp_method == CGRID_TRACER) || (interp_method == BGRID_TRACER)) {
+    INTERP(spatial_interpolation_tracer_c_grid_2D, spatial_interpolation_tracer_c_grid_3D);
+  } else if (interp_method == LINEAR_INVDIST_LAND_TRACER) {
+    INTERP(spatial_interpolation_bilinear_invdist_land, spatial_interpolation_trilinear_invdist_land);
+  } else {
+    return ERROR;
+  }
+
+  // tsrch = t0 in the case where val[1] isn't populated, so this
+  // gives the right interpolation in either case
+  *value = val[0] + (val[1] - val[0]) * (float)((tsrch - t0) / (t1 - t0));
+
+  return SUCCESS;
+#undef INTERP
 }
 
 static double dist(double lon1, double lon2, double lat1, double lat2, int sphere_mesh, double lat)

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -488,19 +488,19 @@ static inline StatusCode temporal_interpolation_structured_grid(type_coord x, ty
 
   // define a helper macro that will select the appropriate interpolation method
   // depending on whether we need 2D or 3D
-#define INTERP(fn_2d, fn_3d)						\
-  do {									\
-    if (grid->zdim == 1) {						\
-      for (int i = 0; i < tii; i++) {					\
-	status = fn_2d(xsi, eta, data2D[i], &val[i]);			\
-	CHECKSTATUS(status);						\
-      }									\
-    } else {								\
-      for (int i = 0; i < tii; i++) {					\
-	status = fn_3d(xsi, eta, zeta, data3D[i], &val[i]);		\
-	CHECKSTATUS(status);						\
-      }									\
-    }									\
+#define INTERP(fn_2d, fn_3d)                                            \
+  do {                                                                  \
+    if (grid->zdim == 1) {                                              \
+      for (int i = 0; i < tii; i++) {                                   \
+        status = fn_2d(xsi, eta, data2D[i], &val[i]);                   \
+        CHECKSTATUS(status);                                            \
+      }                                                                 \
+    } else {                                                            \
+      for (int i = 0; i < tii; i++) {                                   \
+        status = fn_3d(xsi, eta, zeta, data3D[i], &val[i]);             \
+        CHECKSTATUS(status);                                            \
+      }                                                                 \
+    }                                                                   \
   } while (0)
 
   if ((interp_method == LINEAR) || (interp_method == CGRID_VELOCITY) ||
@@ -508,13 +508,13 @@ static inline StatusCode temporal_interpolation_structured_grid(type_coord x, ty
     // adjust the normalised coordinate for flux-based interpolation methods
     if ((interp_method == CGRID_VELOCITY) || (interp_method == BGRID_W_VELOCITY)) {
       if (gridindexingtype == NEMO) {
-	// velocity is on the northeast of a tracer cell
-	xsi = 1;
-	eta = 1;
+        // velocity is on the northeast of a tracer cell
+        xsi = 1;
+        eta = 1;
       } else if (gridindexingtype == MITGCM) {
-	// velocity is on the southwest of a tracer cell
-	xsi = 0;
-	eta = 0;
+        // velocity is on the southwest of a tracer cell
+        xsi = 0;
+        eta = 0;
       }
     } else if (interp_method == BGRID_VELOCITY) {
       zeta = 0;


### PR DESCRIPTION
There's a lot of code duplication in the structured grid temporal function which hides the actual intent.

This was also hiding a behavioural difference where interpolation on a 2D field with `CGRID_VELOCITY` would cause an error only if the interpolation time exactly coincides with the time grid. The new behaviour is to not raise the error, regardless of the interpolation time.

I've factored out the logic to handle interpolation at 1/2 time points into `tii`, and wrapped it, along with the separate handling of 2D and 3D interpolation into a single macro called `INTERP`.