### PR TITLE
Refactoring random to ParcelsRandom class

### DIFF
--- a/parcels/__init__.py
+++ b/parcels/__init__.py
@@ -6,7 +6,7 @@ from parcels.particle import *  # noqa
 from parcels.particleset import *  # noqa
 from parcels.field import *  # noqa
 from parcels.kernel import *  # noqa
-import parcels.rng as random  # noqa
+import parcels.rng as ParcelsRandom  # noqa
 from parcels.particlefile import *  # noqa
 from parcels.kernels import *  # noqa
 from parcels.scripts import *  # noqa

--- a/parcels/codegenerator.py
+++ b/parcels/codegenerator.py
@@ -255,7 +255,7 @@ class IntrinsicTransformer(ast.NodeTransformer):
             node = StatusCodeNode(math, ccode='')
         elif node.id == 'math':
             node = MathNode(math, ccode='')
-        elif node.id == 'random':
+        elif node.id == 'ParcelsRandom':
             node = RandomNode(math, ccode='')
         elif node.id == 'print':
             node = PrintNode()

--- a/parcels/examples/example_brownian.py
+++ b/parcels/examples/example_brownian.py
@@ -8,7 +8,7 @@ from parcels import Field
 from parcels import FieldSet
 from parcels import JITParticle
 from parcels import ParticleSet
-from parcels import random
+from parcels import ParcelsRandom
 from parcels import ScipyParticle
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
@@ -32,11 +32,11 @@ def test_brownian_example(mode, mesh, npart=3000):
     fieldset.add_field(Field('Kh_meridional', kh_meridional, lon=0, lat=0, mesh=mesh))
 
     # Set random seed
-    random.seed(123456)
+    ParcelsRandom.seed(123456)
 
     runtime = delta(days=1)
 
-    random.seed(1234)
+    ParcelsRandom.seed(1234)
     pset = ParticleSet(fieldset=fieldset, pclass=ptype[mode],
                        lon=np.zeros(npart), lat=np.zeros(npart))
     pset.execute(pset.Kernel(DiffusionUniformKh),

--- a/parcels/examples/example_recursive_errorhandling.py
+++ b/parcels/examples/example_recursive_errorhandling.py
@@ -5,7 +5,7 @@ from parcels import ErrorCode
 from parcels import FieldSet
 from parcels import JITParticle
 from parcels import ParticleSet
-from parcels import random
+from parcels import ParcelsRandom
 from parcels import ScipyParticle
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
@@ -49,9 +49,9 @@ def test_recursive_errorhandling(mode, xdim=2, ydim=2):
     def Error_RandomiseLon(particle, fieldset, time):
         """Error handling kernel that draws a new longitude.
         Note that this new longitude can be smaller than fieldset.minlon"""
-        particle.lon = random.uniform(0., 1.)
+        particle.lon = ParcelsRandom.uniform(0., 1.)
 
-    random.seed(123456)
+    ParcelsRandom.seed(123456)
 
     # The .execute below is only run for one timestep. Yet the
     # recovery={ErrorCode.Error: Error_RandomiseLon} assures Parcels keeps

--- a/parcels/examples/tutorial_diffusion.ipynb
+++ b/parcels/examples/tutorial_diffusion.ipynb
@@ -61,7 +61,7 @@
     "An overview of numerical approximations for SDEs in a particle tracking setting can be found in [Gräwe (2011)](https://doi.org/10.1016/j.ocemod.2010.10.002).\n",
     "\n",
     "## The Wiener Increment\n",
-    "The Wiener increment should be a normally distributed random variable with zero mean and a standard deviation of $\\sqrt{dt}$. While such random numbers can be generated easily by Parcels (i.e. through `random.normalvariate(0, particle.dt)`), it is more efficient to draw random numbers from a uniform distribution with the same first and second moments. The central limit theorem ensures that the contribution from consecutive Wiener increments drawn from a uniform distribution quickly converges to a normal distribution, making a substitution with a uniform distribution valid for ensemble distributions. The discrete Wiener increment used by Parcels therefore reads $\\Delta W = \\sqrt{3\\Delta t } R[-1, 1]$. Wiener increments are drawn individually for each direction.\n",
+    "The Wiener increment should be a normally distributed random variable with zero mean and a standard deviation of $\\sqrt{dt}$. While such random numbers can be generated easily by Parcels (i.e. through `ParcelsRandom.normalvariate(0, particle.dt)`), it is more efficient to draw random numbers from a uniform distribution with the same first and second moments. The central limit theorem ensures that the contribution from consecutive Wiener increments drawn from a uniform distribution quickly converges to a normal distribution, making a substitution with a uniform distribution valid for ensemble distributions. The discrete Wiener increment used by Parcels therefore reads $\\Delta W = \\sqrt{3\\Delta t } R[-1, 1]$. Wiener increments are drawn individually for each direction.\n",
     "\n",
     "\n",
     "## Using Advection-Diffusion Kernels in Parcels\n",
@@ -97,7 +97,7 @@
     "import matplotlib.pyplot as plt\n",
     "import xarray as xr\n",
     "from datetime import timedelta\n",
-    "from parcels import rng as random\n",
+    "from parcels import ParcelsRandom\n",
     "from parcels import (FieldSet, ParticleSet, JITParticle,\n",
     "                     DiffusionUniformKh, AdvectionDiffusionM1, AdvectionDiffusionEM)"
    ]
@@ -224,7 +224,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO: Compiled random ==> /var/folders/_k/jcmdplbn0yj79g4k3g9f4nxr0000gn/T/parcels-501/parcels_random_90026758-b11d-438d-b43f-c207a0d92a19.so\n",
+      "INFO: Compiled ParcelsRandom ==> /var/folders/_k/jcmdplbn0yj79g4k3g9f4nxr0000gn/T/parcels-501/parcels_random_90026758-b11d-438d-b43f-c207a0d92a19.so\n",
       "INFO: Compiled JITParticleAdvectionDiffusionM1 ==> /var/folders/_k/jcmdplbn0yj79g4k3g9f4nxr0000gn/T/parcels-501/ed3fb56fbd4ce833c3c02d188a729819_0.so\n",
       "100% (0.3 of 0.3) |######################| Elapsed Time: 0:00:21 Time:  0:00:21\n"
      ]
@@ -235,7 +235,7 @@
     "testParticles = get_test_particles()\n",
     "output_file = testParticles.ParticleFile(name=\"M1_out.nc\",\n",
     "                                         outputdt=timedelta(seconds=dt))\n",
-    "random.seed(1636)  # Random seed for reproducibility\n",
+    "ParcelsRandom.seed(1636)  # Random seed for reproducibility\n",
     "testParticles.execute(AdvectionDiffusionM1,\n",
     "                      runtime=timedelta(seconds=0.3),\n",
     "                      dt=timedelta(seconds=dt),\n",
@@ -322,7 +322,7 @@
     "testParticles = get_test_particles()\n",
     "output_file = testParticles.ParticleFile(name=\"EM_out.nc\",\n",
     "                                         outputdt=timedelta(seconds=dt))\n",
-    "random.seed(1636)  # Random seed for reproducibility\n",
+    "ParcelsRandom.seed(1636)  # Random seed for reproducibility\n",
     "testParticles.execute(AdvectionDiffusionEM,\n",
     "                      runtime=timedelta(seconds=0.3),\n",
     "                      dt=timedelta(seconds=dt),\n",
@@ -402,7 +402,7 @@
     "testParticles = get_test_particles()\n",
     "output_file = testParticles.ParticleFile(name=\"Uniform_out.nc\",\n",
     "                                         outputdt=timedelta(seconds=dt))\n",
-    "random.seed(1636)  # Random seed for reproducibility\n",
+    "ParcelsRandom.seed(1636)  # Random seed for reproducibility\n",
     "testParticles.execute(DiffusionUniformKh,\n",
     "                      runtime=timedelta(seconds=0.3),\n",
     "                      dt=timedelta(seconds=dt),\n",
@@ -491,7 +491,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/parcels/kernels/advectiondiffusion.py
+++ b/parcels/kernels/advectiondiffusion.py
@@ -1,7 +1,7 @@
 """Collection of pre-built advection-diffusion kernels"""
 import math
 
-from parcels import rng as random
+import parcels.rng as ParcelsRandom
 
 
 __all__ = ['DiffusionUniformKh', 'AdvectionDiffusionM1', 'AdvectionRK4DiffusionM1',
@@ -28,8 +28,8 @@ def DiffusionUniformKh(particle, fieldset, time):
     doi.org/10.1007/s10236-012-0523-y for more information.
     """
     # Wiener increment with zero mean and std of sqrt(dt)
-    dWx = random.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
-    dWy = random.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
+    dWx = ParcelsRandom.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
+    dWy = ParcelsRandom.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
 
     bx = math.sqrt(2 * fieldset.Kh_zonal[time, particle.depth, particle.lat, particle.lon])
     by = math.sqrt(2 * fieldset.Kh_meridional[time, particle.depth, particle.lat, particle.lon])
@@ -61,8 +61,8 @@ def AdvectionDiffusionM1(particle, fieldset, time):
     doi.org/10.1007/s10236-012-0523-y for more information.
     """
     # Wiener increment with zero mean and std of sqrt(dt)
-    dWx = random.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
-    dWy = random.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
+    dWx = ParcelsRandom.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
+    dWy = ParcelsRandom.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
 
     Kxp1 = fieldset.Kh_zonal[time, particle.depth, particle.lat, particle.lon + fieldset.dres]
     Kxm1 = fieldset.Kh_zonal[time, particle.depth, particle.lat, particle.lon - fieldset.dres]
@@ -118,8 +118,8 @@ def AdvectionRK4DiffusionM1(particle, fieldset, time):
     (u4, v4) = fieldset.UV[time + particle.dt, particle.depth, lat3, lon3]
 
     # Wiener increment with zero mean and std of sqrt(dt)
-    dWx = random.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
-    dWy = random.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
+    dWx = ParcelsRandom.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
+    dWy = ParcelsRandom.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
 
     Kxp1 = fieldset.Kh_zonal[time, particle.depth, particle.lat, particle.lon + fieldset.dres]
     Kxm1 = fieldset.Kh_zonal[time, particle.depth, particle.lat, particle.lon - fieldset.dres]
@@ -155,8 +155,8 @@ def AdvectionDiffusionEM(particle, fieldset, time):
     doi.org/10.1007/s10236-012-0523-y for more information.
     """
     # Wiener increment with zero mean and std of sqrt(dt)
-    dWx = random.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
-    dWy = random.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
+    dWx = ParcelsRandom.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
+    dWy = ParcelsRandom.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
 
     Kxp1 = fieldset.Kh_zonal[time, particle.depth, particle.lat, particle.lon + fieldset.dres]
     Kxm1 = fieldset.Kh_zonal[time, particle.depth, particle.lat, particle.lon - fieldset.dres]
@@ -206,8 +206,8 @@ def AdvectionRK4DiffusionEM(particle, fieldset, time):
     (u4, v4) = fieldset.UV[time + particle.dt, particle.depth, lat3, lon3]
 
     # Wiener increment with zero mean and std of sqrt(dt)
-    dWx = random.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
-    dWy = random.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
+    dWx = ParcelsRandom.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
+    dWy = ParcelsRandom.uniform(-1., 1.) * math.sqrt(math.fabs(particle.dt) * 3)
 
     Kxp1 = fieldset.Kh_zonal[time, particle.depth, particle.lat, particle.lon + fieldset.dres]
     Kxm1 = fieldset.Kh_zonal[time, particle.depth, particle.lat, particle.lon - fieldset.dres]

--- a/parcels/rng.py
+++ b/parcels/rng.py
@@ -13,7 +13,7 @@ from parcels.tools.loggers import logger
 __all__ = ['seed', 'random', 'uniform', 'randint', 'normalvariate', 'expovariate', 'vonmisesvariate']
 
 
-class Random(object):
+class RandomC(object):
     stmt_import = """#include "parcels.h"\n\n"""
     fnct_seed = """
 extern void pcls_seed(int seed){
@@ -66,22 +66,22 @@ extern float pcls_vonmisesvariate(float mu, float kappa){
             with open(self.src_file, 'w') as f:
                 f.write(self.ccode)
             compiler.compile(self.src_file, self.lib_file, self.log_file)
-            logger.info("Compiled %s ==> %s" % ("random", self.lib_file))
+            logger.info("Compiled %s ==> %s" % ("ParcelsRandom", self.lib_file))
             self._lib = npct.load_library(self.lib_file, '.')
         return self._lib
 
 
-parcels_random = Random()
+_parcels_random_ccodeconverter = RandomC()
 
 
 def seed(seed):
     """Sets the seed for parcels internal RNG"""
-    parcels_random.lib.pcls_seed(c_int(seed))
+    _parcels_random_ccodeconverter.lib.pcls_seed(c_int(seed))
 
 
 def random():
     """Returns a random float between 0. and 1."""
-    rnd = parcels_random.lib.pcls_random
+    rnd = _parcels_random_ccodeconverter.lib.pcls_random
     rnd.argtype = []
     rnd.restype = c_float
     return rnd()
@@ -89,7 +89,7 @@ def random():
 
 def uniform(low, high):
     """Returns a random float between `low` and `high`"""
-    rnd = parcels_random.lib.pcls_uniform
+    rnd = _parcels_random_ccodeconverter.lib.pcls_uniform
     rnd.argtype = [c_float, c_float]
     rnd.restype = c_float
     return rnd(c_float(low), c_float(high))
@@ -97,7 +97,7 @@ def uniform(low, high):
 
 def randint(low, high):
     """Returns a random int between `low` and `high`"""
-    rnd = parcels_random.lib.pcls_randint
+    rnd = _parcels_random_ccodeconverter.lib.pcls_randint
     rnd.argtype = [c_int, c_int]
     rnd.restype = c_int
     return rnd(c_int(low), c_int(high))
@@ -105,7 +105,7 @@ def randint(low, high):
 
 def normalvariate(loc, scale):
     """Returns a random float on normal distribution with mean `loc` and width `scale`"""
-    rnd = parcels_random.lib.pcls_normalvariate
+    rnd = _parcels_random_ccodeconverter.lib.pcls_normalvariate
     rnd.argtype = [c_float, c_float]
     rnd.restype = c_float
     return rnd(c_float(loc), c_float(scale))
@@ -113,7 +113,7 @@ def normalvariate(loc, scale):
 
 def expovariate(lamb):
     """Returns a randome float of an exponential distribution with parameter lamb"""
-    rnd = parcels_random.lib.pcls_expovariate
+    rnd = _parcels_random_ccodeconverter.lib.pcls_expovariate
     rnd.argtype = c_float
     rnd.restype = c_float
     return rnd(c_float(lamb))
@@ -122,7 +122,7 @@ def expovariate(lamb):
 def vonmisesvariate(mu, kappa):
     """Returns a randome float of a Von Mises distribution
     with mean angle mu and concentration parameter kappa"""
-    rnd = parcels_random.lib.pcls_vonmisesvariate
+    rnd = _parcels_random_ccodeconverter.lib.pcls_vonmisesvariate
     rnd.argtype = [c_float, c_float]
     rnd.restype = c_float
     return rnd(c_float(mu), c_float(kappa))

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -2,7 +2,7 @@ from parcels import (FieldSet, Field, RectilinearZGrid, ParticleSet, JITParticle
                      DiffusionUniformKh, AdvectionDiffusionM1, AdvectionRK4DiffusionM1,
                      AdvectionDiffusionEM, AdvectionRK4DiffusionEM, ScipyParticle,
                      Variable)
-from parcels import rng as random
+from parcels import ParcelsRandom
 from datetime import timedelta as delta
 import numpy as np
 import pytest
@@ -37,7 +37,7 @@ def test_fieldKh_Brownian(mesh, mode, xdim=200, ydim=100, kh_zonal=100, kh_merid
     npart = 1000
     runtime = delta(days=1)
 
-    random.seed(1234)
+    ParcelsRandom.seed(1234)
     pset = ParticleSet(fieldset=fieldset, pclass=ptype[mode],
                        lon=np.zeros(npart), lat=np.zeros(npart))
     pset.execute(pset.Kernel(DiffusionUniformKh),
@@ -80,7 +80,7 @@ def test_fieldKh_SpatiallyVaryingDiffusion(mesh, mode, kernel, xdim=200, ydim=10
     npart = 100
     runtime = delta(days=1)
 
-    random.seed(1636)
+    ParcelsRandom.seed(1636)
     pset = ParticleSet(fieldset=fieldset, pclass=ptype[mode],
                        lon=np.zeros(npart), lat=np.zeros(npart))
     pset.execute(pset.Kernel(kernel),
@@ -103,13 +103,13 @@ def test_randomexponential(mode, lambd, npart=1000):
     fieldset.lambd = lambd
 
     # Set random seed
-    random.seed(1234)
+    ParcelsRandom.seed(1234)
 
     pset = ParticleSet(fieldset=fieldset, pclass=ptype[mode], lon=np.zeros(npart), lat=np.zeros(npart), depth=np.zeros(npart))
 
     def vertical_randomexponential(particle, fieldset, time):
         # Kernel for random exponential variable in depth direction
-        particle.depth = random.expovariate(fieldset.lambd)
+        particle.depth = ParcelsRandom.expovariate(fieldset.lambd)
 
     pset.execute(vertical_randomexponential, runtime=1, dt=1)
 
@@ -129,14 +129,14 @@ def test_randomvonmises(mode, mu, kappa, npart=10000):
     fieldset.kappa = kappa
 
     # Set random seed
-    random.seed(1234)
+    ParcelsRandom.seed(1234)
 
     class AngleParticle(ptype[mode]):
         angle = Variable('angle')
     pset = ParticleSet(fieldset=fieldset, pclass=AngleParticle, lon=np.zeros(npart), lat=np.zeros(npart), depth=np.zeros(npart))
 
     def vonmises(particle, fieldset, time):
-        particle.angle = random.vonmisesvariate(fieldset.mu, fieldset.kappa)
+        particle.angle = ParcelsRandom.vonmisesvariate(fieldset.mu, fieldset.kappa)
 
     pset.execute(vonmises, runtime=1, dt=1)
 

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -1,7 +1,7 @@
 from parcels import FieldSet, ParticleSet, ScipyParticle, JITParticle, Kernel, Variable, StateCode
 from parcels.kernels.TEOSseawaterdensity import PolyTEOS10_bsq
 from parcels.kernels.EOSseawaterproperties import PressureFromLatDepth, PtempFromTemp, TempFromPtemp, UNESCODensity
-from parcels import random as parcels_random
+from parcels import ParcelsRandom
 import numpy as np
 import pytest
 import random as py_random
@@ -265,7 +265,7 @@ def test_fieldset_access(fieldset, mode):
 
 
 def random_series(npart, rngfunc, rngargs, mode):
-    random = parcels_random if mode == 'jit' else py_random
+    random = ParcelsRandom if mode == 'jit' else py_random
     random.seed(1234)
     func = getattr(random, rngfunc)
     series = [func(*rngargs) for _ in range(npart)]
@@ -287,8 +287,9 @@ def test_random_float(mode, rngfunc, rngargs, npart=10):
                        lon=np.linspace(0., 1., npart),
                        lat=np.zeros(npart) + 0.5)
     series = random_series(npart, rngfunc, rngargs, mode)
+    rnglib = 'ParcelsRandom' if mode == 'jit' else 'random'
     kernel = expr_kernel('TestRandom_%s' % rngfunc, pset,
-                         'random.%s(%s)' % (rngfunc, ', '.join([str(a) for a in rngargs])))
+                         '%s.%s(%s)' % (rnglib, rngfunc, ', '.join([str(a) for a in rngargs])))
     pset.execute(kernel, endtime=1., dt=1.)
     assert np.allclose(pset.p, series, atol=1e-9)
 


### PR DESCRIPTION
This implements #873. Note that this renaming of the random function is not backward-compatibel; users can choose two ways to adapt their code

1. Change 
    ```diff
    - from parcels import random
    + from parcels import ParcelsRandom as random
    ```

2. Change 
    ```diff
    - from parcels import random
    + from parcels import ParcelsRandom
    ``` 
    and rename all calls to `random` functions to `ParcelsRandom`