### PR TITLE
support specifying central longitude in 2d & 2dmovie trajectory plotting

### DIFF
--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -278,7 +278,10 @@ def create_parcelsfig_axis(spherical, land=True, projection=None, central_longit
         projection = cartopy.crs.PlateCarree(central_longitude) if projection is None else projection
         fig, ax = plt.subplots(1, 1, subplot_kw={'projection': projection})
         try:  # gridlines not supported for all projections
-            gl = ax.gridlines(crs=projection, draw_labels=True)
+            if isinstance(projection, cartopy.crs.PlateCarree) and central_longitude != 0:
+                gl = ax.gridlines(crs=cartopy.crs.PlateCarree(), draw_labels=True)  # central_lon=0 necessary for correct xlabels
+            else:
+                gl = ax.gridlines(crs=projection, draw_labels=True)
             gl.xlabels_top, gl.ylabels_right = (False, False)
             gl.xformatter = cartopy.mpl.gridliner.LONGITUDE_FORMATTER
             gl.yformatter = cartopy.mpl.gridliner.LATITUDE_FORMATTER

--- a/parcels/scripts/plottrajectoriesfile.py
+++ b/parcels/scripts/plottrajectoriesfile.py
@@ -89,7 +89,7 @@ def plotTrajectoriesFile(filename, mode='2d', tracerfile=None, tracerfield='P',
         cartopy_colorbar(cs, plt, fig, ax)
         ax.set_title('Particle histogram')
     elif mode in ('movie2d', 'movie2d_notebook'):
-        ax.set_xlim(np.nanmin((lon+central_longitude+180)%360 - 180), np.nanmax((lon+central_longitude+180)%360 - 180))
+        ax.set_xlim(np.nanmin((lon+central_longitude+180) % 360 - 180), np.nanmax((lon+central_longitude+180) % 360 - 180))
         ax.set_ylim(np.nanmin(lat), np.nanmax(lat))
         plottimes = np.unique(time)
         if not movie_forward:

--- a/parcels/scripts/plottrajectoriesfile.py
+++ b/parcels/scripts/plottrajectoriesfile.py
@@ -17,7 +17,7 @@ except:
 
 def plotTrajectoriesFile(filename, mode='2d', tracerfile=None, tracerfield='P',
                          tracerlon='x', tracerlat='y', recordedvar=None, movie_forward=True,
-                         bins=20, show_plt=True):
+                         bins=20, show_plt=True, central_longitude=0):
     """Quick and simple plotting of Parcels trajectories
 
     :param filename: Name of Parcels-generated NetCDF file with particle positions
@@ -58,7 +58,7 @@ def plotTrajectoriesFile(filename, mode='2d', tracerfile=None, tracerfield='P',
         titlestr = ' and ' + tracerfield
     else:
         spherical = False if mode == '3d' or mesh == 'flat' else True
-        plt, fig, ax, cartopy = create_parcelsfig_axis(spherical=spherical)
+        plt, fig, ax, cartopy = create_parcelsfig_axis(spherical=spherical, central_longitude=central_longitude)
         if plt is None:
             return  # creating axes was not possible
         titlestr = ''
@@ -88,7 +88,7 @@ def plotTrajectoriesFile(filename, mode='2d', tracerfile=None, tracerfield='P',
         cartopy_colorbar(cs, plt, fig, ax)
         ax.set_title('Particle histogram')
     elif mode in ('movie2d', 'movie2d_notebook'):
-        ax.set_xlim(np.nanmin(lon), np.nanmax(lon))
+        ax.set_xlim(np.nanmin((lon+central_longitude+180)%360 - 180), np.nanmax((lon+central_longitude+180)%360 - 180))
         ax.set_ylim(np.nanmin(lat), np.nanmax(lat))
         plottimes = np.unique(time)
         if not movie_forward:

--- a/parcels/scripts/plottrajectoriesfile.py
+++ b/parcels/scripts/plottrajectoriesfile.py
@@ -33,6 +33,7 @@ def plotTrajectoriesFile(filename, mode='2d', tracerfile=None, tracerfield='P',
     :param movie_forward: Boolean whether to show movie in forward or backward mode (default True)
     :param bins: Number of bins to use in `hist2d` mode. See also https://matplotlib.org/api/_as_gen/matplotlib.pyplot.hist2d.html
     :param show_plt: Boolean whether plot should directly be show (for py.test)
+    :param central_longitude: Degrees East at which to center the plot
     """
 
     environ["HDF5_USE_FILE_LOCKING"] = "FALSE"


### PR DESCRIPTION
Hi there!  I'm using Parcels for investigating flows in the North Pacific, and while the default plotting is almost perfect, I thought it could benefit from being able to specify a central longitude.  This is a pretty essential feature if you're interested in anything in the Pacific.  Some of your plotting already supports this, I just connected the functionality to plotTrajectoriesFile, and made a minor adjustment to create_parcelsfig_axis to generate the correct xlabels when utilizing its central_longitude parameter.

I would write a test, but I'm not really sure how to do that, since "correctness" kind of depends a graphical output.  Anyways, please let me know what else I need to do to make this mergeable, if you're interested in it.  Thanks for such a great library!

P.S. method signature of plotTrajectoriesFile is modified, so [this](https://oceanparcels.org/gh-pages/html/#module-scripts.plottrajectoriesfile) documentation page should change; I modified the docstring of the method, not sure if that automatically modifies the documentation.  If not, let me know where I can do that.