### PR TITLE
Change Particle-ID type from int (int32) to int64

### DIFF
--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -9,7 +9,7 @@ from parcels.tools.loggers import logger
 
 __all__ = ['ScipyParticle', 'JITParticle', 'Variable']
 
-indicators_64bit = [np.float64, np.int64, c_void_p]
+indicators_64bit = [np.float64, np.uint64, np.int64, c_void_p]
 
 
 class Variable(object):
@@ -178,7 +178,7 @@ class ScipyParticle(_Particle):
     yi = Variable('yi', dtype=np.int32, to_write=False)
     zi = Variable('zi', dtype=np.int32, to_write=False)
     ti = Variable('ti', dtype=np.int32, to_write=False, initial=-1)
-    id = Variable('id', dtype=np.int32)
+    id = Variable('id', dtype=np.int64)
     fileid = Variable('fileid', dtype=np.int32, initial=-1, to_write=False)
     dt = Variable('dt', dtype=np.float64, to_write=False)
     state = Variable('state', dtype=np.int32, initial=StateCode.Evaluate, to_write=False)

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -125,7 +125,6 @@ class ParticleFile(object):
         self.dataset.parcels_mesh = self.parcels_mesh
 
         # Create ID variable according to CF conventions
-        # self.id = self.dataset.createVariable("trajectory", "i4", coords, fill_value=-2**(31))  # minint32 fill_value
         self.id = self.dataset.createVariable("trajectory", "i8", coords, fill_value=-2**(63))  # minint64 fill_value
         self.id.long_name = "Unique identifier for each particle"
         self.id.cf_role = "trajectory_id"
@@ -253,8 +252,6 @@ class ParticleFile(object):
         """
 
         data = np.nan * np.zeros((self.maxid_written+1, time_steps))
-        # time_index = np.zeros(self.maxid_written+1, dtype=np.int32)
-        # t_ind_used = np.zeros(time_steps, dtype=np.int32)
         time_index = np.zeros(self.maxid_written+1, dtype=np.int64)
         t_ind_used = np.zeros(time_steps, dtype=np.int64)
 
@@ -268,7 +265,6 @@ class ParticleFile(object):
                                    '"parcels_convert_npydir_to_netcdf %s" to convert these to '
                                    'a NetCDF file yourself.\nTo avoid this error, make sure you '
                                    'close() your ParticleFile at the end of your script.' % self.tempwritedir)
-            # id_ind = np.array(data_dict["id"], dtype=np.int32)
             id_ind = np.array(data_dict["id"], dtype=np.int64)
             t_ind = time_index[id_ind] if 'once' not in file_list[0] else 0
             t_ind_used[t_ind] = 1

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -125,8 +125,8 @@ class ParticleFile(object):
         self.dataset.parcels_mesh = self.parcels_mesh
 
         # Create ID variable according to CF conventions
-        self.id = self.dataset.createVariable("trajectory", "i4", coords,
-                                              fill_value=-2**(31))  # maxint32 fill_value
+        # self.id = self.dataset.createVariable("trajectory", "i4", coords, fill_value=-2**(31))  # minint32 fill_value
+        self.id = self.dataset.createVariable("trajectory", "i8", coords, fill_value=-2**(63))  # minint64 fill_value
         self.id.long_name = "Unique identifier for each particle"
         self.id.cf_role = "trajectory_id"
 
@@ -253,8 +253,10 @@ class ParticleFile(object):
         """
 
         data = np.nan * np.zeros((self.maxid_written+1, time_steps))
-        time_index = np.zeros(self.maxid_written+1, dtype=int)
-        t_ind_used = np.zeros(time_steps, dtype=int)
+        # time_index = np.zeros(self.maxid_written+1, dtype=np.int32)
+        # t_ind_used = np.zeros(time_steps, dtype=np.int32)
+        time_index = np.zeros(self.maxid_written+1, dtype=np.int64)
+        t_ind_used = np.zeros(time_steps, dtype=np.int64)
 
         # loop over all files
         for npyfile in file_list:
@@ -266,7 +268,8 @@ class ParticleFile(object):
                                    '"parcels_convert_npydir_to_netcdf %s" to convert these to '
                                    'a NetCDF file yourself.\nTo avoid this error, make sure you '
                                    'close() your ParticleFile at the end of your script.' % self.tempwritedir)
-            id_ind = np.array(data_dict["id"], dtype=int)
+            # id_ind = np.array(data_dict["id"], dtype=np.int32)
+            id_ind = np.array(data_dict["id"], dtype=np.int64)
             t_ind = time_index[id_ind] if 'once' not in file_list[0] else 0
             t_ind_used[t_ind] = 1
             data[id_ind, t_ind] = data_dict[var]

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -539,12 +539,7 @@ class ParticleSet(object):
                     to_write = _to_write_particles(pd, time)
                 if np.any(to_write) > 0:
                     for var in pfile.var_names:
-                        # if type(getattr(pset_towrite[0], var)) in [np.uint64, np.int64, np.uint32]:
-                        #     data_dict[var] = np.array([np.int32(getattr(p, var)) for p in pset_towrite])
-                        # else:
-                        #     data_dict[var] = np.array([getattr(p, var) for p in pset_towrite])
                         data_dict[var] = pd[var][to_write]
-                    # pfile.maxid_written = max(pfile.maxid_written, np.max(data_dict['id']))
                     pfile.maxid_written = np.maximum(pfile.maxid_written, np.max(data_dict['id']))
 
                 pset_errs = (to_write & (pd['state'] != OperationCode.Delete)
@@ -559,8 +554,6 @@ class ParticleSet(object):
                 if len(pfile.var_names_once) > 0:
                     first_write = (_to_write_particles(pd, time) & np.isin(pd['id'], pfile.written_once, invert=True))
                     if np.any(first_write):
-                        # data_dict_once['id'] = pd['id'][first_write]
-                        # data_dict_once['id'] = np.array(pd['id'][first_write]).astype(dtype=np.int32)
                         data_dict_once['id'] = np.array(pd['id'][first_write]).astype(dtype=np.int64)
                         for var in pfile.var_names_once:
                             data_dict_once[var] = pd[var][first_write]

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -539,8 +539,13 @@ class ParticleSet(object):
                     to_write = _to_write_particles(pd, time)
                 if np.any(to_write) > 0:
                     for var in pfile.var_names:
+                        #if type(getattr(pset_towrite[0], var)) in [np.uint64, np.int64, np.uint32]:
+                        #    data_dict[var] = np.array([np.int32(getattr(p, var)) for p in pset_towrite])
+                        #else:
+                        #    data_dict[var] = np.array([getattr(p, var) for p in pset_towrite])
                         data_dict[var] = pd[var][to_write]
-                    pfile.maxid_written = max(pfile.maxid_written, np.max(data_dict['id']))
+                    #pfile.maxid_written = max(pfile.maxid_written, np.max(data_dict['id']))
+                    pfile.maxid_written = np.maximum(pfile.maxid_written, np.max(data_dict['id']))
 
                 pset_errs = (to_write & (pd['state'] != OperationCode.Delete)
                              & np.less(1e-3, np.abs(time - pd['time']), where=np.isfinite(pd['time'])))
@@ -552,10 +557,11 @@ class ParticleSet(object):
                     pfile.time_written.append(time)
 
                 if len(pfile.var_names_once) > 0:
-                    first_write = (_to_write_particles(pd, time)
-                                   & np.isin(pd['id'], pfile.written_once, invert=True))
+                    first_write = (_to_write_particles(pd, time) & np.isin(pd['id'], pfile.written_once, invert=True))
                     if np.any(first_write):
-                        data_dict_once['id'] = pd['id'][first_write]
+                        # data_dict_once['id'] = pd['id'][first_write]
+                        # data_dict_once['id'] = np.array(pd['id'][first_write]).astype(dtype=np.int32)
+                        data_dict_once['id'] = np.array(pd['id'][first_write]).astype(dtype=np.int64)
                         for var in pfile.var_names_once:
                             data_dict_once[var] = pd[var][first_write]
                         pfile.written_once.extend(pd['id'][first_write])

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -539,12 +539,12 @@ class ParticleSet(object):
                     to_write = _to_write_particles(pd, time)
                 if np.any(to_write) > 0:
                     for var in pfile.var_names:
-                        #if type(getattr(pset_towrite[0], var)) in [np.uint64, np.int64, np.uint32]:
-                        #    data_dict[var] = np.array([np.int32(getattr(p, var)) for p in pset_towrite])
-                        #else:
-                        #    data_dict[var] = np.array([getattr(p, var) for p in pset_towrite])
+                        # if type(getattr(pset_towrite[0], var)) in [np.uint64, np.int64, np.uint32]:
+                        #     data_dict[var] = np.array([np.int32(getattr(p, var)) for p in pset_towrite])
+                        # else:
+                        #     data_dict[var] = np.array([getattr(p, var) for p in pset_towrite])
                         data_dict[var] = pd[var][to_write]
-                    #pfile.maxid_written = max(pfile.maxid_written, np.max(data_dict['id']))
+                    # pfile.maxid_written = max(pfile.maxid_written, np.max(data_dict['id']))
                     pfile.maxid_written = np.maximum(pfile.maxid_written, np.max(data_dict['id']))
 
                 pset_errs = (to_write & (pd['state'] != OperationCode.Delete)


### PR DESCRIPTION
The idea in this pull request is to convert the Particle ID from a 32-bit to a 64-bit number (still: signed integer 64, i.e. 'long') to support the user of truely large particle sets.