### PR TITLE
Fixing bug when concatenating kernels with ParcelsRandom functions in scipy

### DIFF
--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -37,6 +37,7 @@ from parcels.field import VectorField
 from parcels.grid import GridCode
 from parcels.kernels.advection import AdvectionRK4_3D
 from parcels.kernels.advection import AdvectionAnalytical
+import parcels.rng as ParcelsRandom  # noqa
 from parcels.tools.statuscodes import StateCode, OperationCode, ErrorCode
 from parcels.tools.statuscodes import recovery_map as recovery_base_map
 from parcels.tools.loggers import logger
@@ -116,6 +117,7 @@ class Kernel(object):
             try:
                 user_ctx = stack[-1][0].f_globals
                 user_ctx['math'] = globals()['math']
+                user_ctx['ParcelsRandom'] = globals()['ParcelsRandom']
                 user_ctx['random'] = globals()['random']
                 user_ctx['StateCode'] = globals()['StateCode']
                 user_ctx['OperationCode'] = globals()['OperationCode']

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -4,7 +4,6 @@ from parcels.kernels.EOSseawaterproperties import PressureFromLatDepth, PtempFro
 from parcels import ParcelsRandom
 import numpy as np
 import pytest
-import random as py_random
 from os import path
 import sys
 
@@ -265,11 +264,10 @@ def test_fieldset_access(fieldset, mode):
 
 
 def random_series(npart, rngfunc, rngargs, mode):
-    random = ParcelsRandom if mode == 'jit' else py_random
-    random.seed(1234)
-    func = getattr(random, rngfunc)
+    ParcelsRandom.seed(1234)
+    func = getattr(ParcelsRandom, rngfunc)
     series = [func(*rngargs) for _ in range(npart)]
-    random.seed(1234)  # Reset the RNG seed
+    ParcelsRandom.seed(1234)  # Reset the RNG seed
     return series
 
 
@@ -287,9 +285,8 @@ def test_random_float(mode, rngfunc, rngargs, npart=10):
                        lon=np.linspace(0., 1., npart),
                        lat=np.zeros(npart) + 0.5)
     series = random_series(npart, rngfunc, rngargs, mode)
-    rnglib = 'ParcelsRandom' if mode == 'jit' else 'random'
     kernel = expr_kernel('TestRandom_%s' % rngfunc, pset,
-                         '%s.%s(%s)' % (rnglib, rngfunc, ', '.join([str(a) for a in rngargs])))
+                         'ParcelsRandom.%s(%s)' % (rngfunc, ', '.join([str(a) for a in rngargs])))
     pset.execute(kernel, endtime=1., dt=1.)
     assert np.allclose(pset.p, series, atol=1e-9)
 

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -4,6 +4,7 @@ from parcels.kernels.EOSseawaterproperties import PressureFromLatDepth, PtempFro
 from parcels import ParcelsRandom
 import numpy as np
 import pytest
+import random as py_random
 from os import path
 import sys
 
@@ -264,10 +265,11 @@ def test_fieldset_access(fieldset, mode):
 
 
 def random_series(npart, rngfunc, rngargs, mode):
-    ParcelsRandom.seed(1234)
-    func = getattr(ParcelsRandom, rngfunc)
+    random = ParcelsRandom if mode == 'jit' else py_random
+    random.seed(1234)
+    func = getattr(random, rngfunc)
     series = [func(*rngargs) for _ in range(npart)]
-    ParcelsRandom.seed(1234)  # Reset the RNG seed
+    random.seed(1234)  # Reset the RNG seed
     return series
 
 
@@ -285,8 +287,9 @@ def test_random_float(mode, rngfunc, rngargs, npart=10):
                        lon=np.linspace(0., 1., npart),
                        lat=np.zeros(npart) + 0.5)
     series = random_series(npart, rngfunc, rngargs, mode)
+    rnglib = 'ParcelsRandom' if mode == 'jit' else 'random'
     kernel = expr_kernel('TestRandom_%s' % rngfunc, pset,
-                         'ParcelsRandom.%s(%s)' % (rngfunc, ', '.join([str(a) for a in rngargs])))
+                         '%s.%s(%s)' % (rnglib, rngfunc, ', '.join([str(a) for a in rngargs])))
     pset.execute(kernel, endtime=1., dt=1.)
     assert np.allclose(pset.p, series, atol=1e-9)
 


### PR DESCRIPTION
As reported by @daanreijnders, scipy breaks with an `Error: name 'ParcelsRandom' is not defined` when concatenating two kernels in which at least one call ParcelsRandom. This does not occur in JIT, only in Scipy. 

This PR will fix this bug