### PR TITLE
Including an option to pass cartopy features and coastline resolution.

### DIFF
--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -42,7 +42,7 @@ def plotparticles(particles, with_particles=True, show_time=None, field=None, do
 
     if field is None:
         spherical = True if particles.fieldset.U.grid.mesh == 'spherical' else False
-        plt, fig, ax, cartopy = create_parcelsfig_axis(spherical, land, projection)
+        plt, fig, ax, cartopy = create_parcelsfig_axis(spherical, land, projection, cartopy_features=kwargs.pop('cartopy_features', []))
         if plt is None:
             return  # creating axes was not possible
         ax.set_title('Particles' + parsetimestr(particles.fieldset.U.grid.time_origin, show_time))
@@ -75,7 +75,7 @@ def plotparticles(particles, with_particles=True, show_time=None, field=None, do
         depth_level = kwargs.pop('depth_level', 0)
         plt, fig, ax, cartopy = plotfield(field=field, animation=animation, show_time=show_time, domain=domain,
                                           projection=projection, land=land, vmin=vmin, vmax=vmax, savefile=None,
-                                          titlestr='Particles and ', depth_level=depth_level)
+                                          titlestr='Particles and ', depth_level=depth_level, **kwargs)
         if plt is None:
             return  # creating axes was not possible
 
@@ -128,7 +128,7 @@ def plotfield(field, show_time=None, domain=None, depth_level=0, projection=None
         logger.warning('Field.show() does not always correctly determine the domain for curvilinear grids. '
                        'Use plotting with caution and perhaps use domain argument as in the NEMO 3D tutorial')
 
-    plt, fig, ax, cartopy = create_parcelsfig_axis(spherical, land, projection=projection)
+    plt, fig, ax, cartopy = create_parcelsfig_axis(spherical, land, projection=projection, cartopy_features=kwargs.pop('cartopy_features', []))
     if plt is None:
         return None, None, None, None  # creating axes was not possible
 
@@ -258,7 +258,7 @@ def plotfield(field, show_time=None, domain=None, depth_level=0, projection=None
     return plt, fig, ax, cartopy
 
 
-def create_parcelsfig_axis(spherical, land=True, projection=None, central_longitude=0):
+def create_parcelsfig_axis(spherical, land=True, projection=None, central_longitude=0, cartopy_features=[]):
     try:
         import matplotlib.pyplot as plt
     except:
@@ -288,7 +288,12 @@ def create_parcelsfig_axis(spherical, land=True, projection=None, central_longit
         except:
             pass
 
-        if land:
+        for feature in cartopy_features:
+            ax.add_feature(feature)
+
+        if isinstance(land, str):
+            ax.coastlines(land)
+        elif land:
             ax.coastlines()
     else:
         cartopy = None


### PR DESCRIPTION
In some cases, the land with lower reasolution (default) covers the particle set making it impossible to visualize.

Including an option to pass cartopy features to plotparticles and create_parcelsfig_axis.
The parameter cartopy_features is a list of features to be added.
The coastline resolution can be defined setting the land variable as a string (e.g. '10m' or '50m').

Example:

```
import cartopy
import cartopy.feature as cfeature

land_50m = cfeature.NaturalEarthFeature('physical', 'land', '50m',
                                        edgecolor='face',
                                        facecolor=cfeature.COLORS['land'])

plotTrajectoriesFile('track_file.nc', mode='movie2d_notebook', land='50m', cartopy_features=[land_50m])
# or from a ParticleSet object pset
pset.show(field=fieldset.U, land='50m', cartopy_features=[land_50m])
```