### PR TITLE
Remove scaling that reverses direction of w.

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -494,7 +494,8 @@ class FieldSet(object):
                |                                             |
                |                                             |
                |_________________V[k,j,i]____________________|
-            (For indexing details: https://mitgcm.readthedocs.io/en/latest/algorithm/algorithm.html#spatial-discretization-of-the-dynamical-equations)
+           For indexing details: https://mitgcm.readthedocs.io/en/latest/algorithm/algorithm.html#spatial-discretization-of-the-dynamical-equations
+           Note that vertical velocity (W) is assumed postive in the positive z direction (which is upward in MITgcm)
         """
         if 'creation_log' not in kwargs.keys():
             kwargs['creation_log'] = 'from_mitgcm'

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -503,8 +503,6 @@ class FieldSet(object):
         fieldset = cls.from_c_grid_dataset(filenames, variables, dimensions, mesh=mesh, indices=indices, time_periodic=time_periodic,
                                            allow_time_extrapolation=allow_time_extrapolation, tracer_interp_method=tracer_interp_method,
                                            chunksize=chunksize, gridindexingtype='mitgcm', **kwargs)
-        if hasattr(fieldset, 'W'):
-            fieldset.W.set_scaling_factor(-1.)
         return fieldset
 
     @classmethod


### PR DESCRIPTION
Fixes #945. When loading data from MITgcm, W is wrongly scaled by -1, to flip its direction. This PR removes that operation. 

I think the confusion arose from the way depth is defined: some models define it positively (e.g. POP and NEMO), with positively increasing Z from the surface. In MITgcm, Z is negative and decreases away from the surface towards the bottom. In that case W should not be flipped.