### PR TITLE
Treat NaN points as land in invdist interpolation

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -892,6 +892,7 @@ class Field(object):
             return val
         elif self.interp_method == 'linear_invdist_land_tracer':
             land = np.isclose(self.data[ti, yi:yi+2, xi:xi+2], 0.)
+            land |= np.isnan(self.data[ti, yi:yi+2, xi:xi+2])
             nb_land = np.sum(land)
             if nb_land == 4:
                 return 0
@@ -941,6 +942,7 @@ class Field(object):
             return (1-zeta) * f0 + zeta * f1
         elif self.interp_method == 'linear_invdist_land_tracer':
             land = np.isclose(self.data[ti, zi:zi+2, yi:yi+2, xi:xi+2], 0.)
+            land |= np.isnan(self.data[ti, zi:zi+2, yi:yi+2, xi:xi+2])
             nb_land = np.sum(land)
             if nb_land == 8:
                 return 0

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -81,7 +81,7 @@ static inline StatusCode spatial_interpolation_bilinear_invdist_land(double xsi,
   // count the number of surrounding land points (assume land is where the value is close to zero)
   for (i = 0; i < 2; i++) {
     for (j = 0; j < 2; j++) {
-      if (is_zero_flt(data[i][j])) {
+      if (is_zero_flt(data[i][j]) || isnan(data[i][j])) {
 	    land[i][j] = 1;
 	    nb_land++;
       }
@@ -181,7 +181,7 @@ static inline StatusCode spatial_interpolation_trilinear_invdist_land(double xsi
   for (i = 0; i < 2; i++) {
     for (j = 0; j < 2; j++) {
       for (k = 0; k < 2; k++) {  
-        if(is_zero_flt(data[i][j][k])) {
+        if(is_zero_flt(data[i][j][k]) || isnan(data[i][j][k])) {
 	      land[i][j][k] = 1;
 	      nb_land++;
         }


### PR DESCRIPTION
In addition to zeroes, it's pretty common for land points to be masked out, appearing as NaN within the dataset. This way we can avoid extra post-processing to make these files work with land-aware interpolation.

Hopefully I'm not mistaken in there being any use for this: I'm not sure why 0 was chosen in the first place, so maybe it doesn't make sense to do it this way.