### PR TITLE
allow multiple c_includes

### DIFF
--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -79,8 +79,8 @@ class Kernel(object):
         self.delete_cfiles = delete_cfiles
         self._cleanup_files = None
         self._cleanup_lib = None
-        self.c_include=c_include
-        
+        self.c_include = c_include
+
         # Derive meta information from pyfunc, if not given
         self.funcname = funcname or pyfunc.__name__
         if pyfunc is AdvectionRK4_3D:
@@ -451,7 +451,7 @@ class Kernel(object):
         return Kernel(self.fieldset, self.ptype, pyfunc=None,
                       funcname=funcname, funccode=self.funccode + kernel.funccode,
                       py_ast=func_ast, funcvars=self.funcvars + kernel.funcvars,
-                      c_include = self.c_include + kernel.c_include,
+                      c_include=self.c_include + kernel.c_include,
                       delete_cfiles=delete_cfiles)
 
     def __add__(self, kernel):

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -79,7 +79,8 @@ class Kernel(object):
         self.delete_cfiles = delete_cfiles
         self._cleanup_files = None
         self._cleanup_lib = None
-
+        self.c_include=c_include
+        
         # Derive meta information from pyfunc, if not given
         self.funcname = funcname or pyfunc.__name__
         if pyfunc is AdvectionRK4_3D:
@@ -450,6 +451,7 @@ class Kernel(object):
         return Kernel(self.fieldset, self.ptype, pyfunc=None,
                       funcname=funcname, funccode=self.funccode + kernel.funccode,
                       py_ast=func_ast, funcvars=self.funcvars + kernel.funcvars,
+                      c_include = self.c_include + kernel.c_include,
                       delete_cfiles=delete_cfiles)
 
     def __add__(self, kernel):


### PR DESCRIPTION
If one uses the following sequence, the C code liste into "c_include" will now be added to the final code generated by Parcels.
kernels = pset.Kernel(AdvectionRK4)
kernels += pset.Kernel(ckernel_something, c_include=c_include)

One can also add different c code with different kernels; they will be concatenated
