### PR TITLE
Add a method to pre-seed curvilinear indices using kdtree

### DIFF
--- a/environment_py3_osx.yml
+++ b/environment_py3_osx.yml
@@ -29,3 +29,4 @@ dependencies:
   - pytest
   - nbval
   - scikit-learn
+  - pykdtree

--- a/environment_py3_win.yml
+++ b/environment_py3_win.yml
@@ -26,3 +26,4 @@ dependencies:
   - ipykernel<5.0
   - pytest
   - nbval
+  - pykdtree

--- a/environment_py3p6_linux.yml
+++ b/environment_py3p6_linux.yml
@@ -29,3 +29,4 @@ dependencies:
   - pytest
   - nbval
   - scikit-learn
+  - pykdtree


### PR DESCRIPTION
This adds a dependency on the pykdtree library, which seems to be about ~10x faster than scipy's cKDTree (a drop-in replacement). The initial index search is only implemented for curvilinear grids, as the benefit may not be as pronounced vs. construction time for rectilinear grids.

Closes #947.