### PR TITLE
Implementing in-kernel computation field derivatives

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -888,9 +888,17 @@ class Field(object):
     def interpolator2D(self, ti, z, y, x, particle=None, derivative=None):
         (xsi, eta, _, xi, yi, _) = self.search_indices(x, y, z, particle=particle)
         if derivative in ['x', 'lon']:  # TODO implement curvilinear grid etc
-            return self.data[ti, yi, xi+1] - self.data[ti, yi, xi]
+            if self.grid.gtype in [GridCode.RectilinearSGrid, GridCode.RectilinearZGrid]:
+                dx = self.grid.lon[xi+1] - self.grid.lon[xi]
+            else:
+                raise NotImplementedError('Curvilinear grid derivatives not yet implemented')
+            return (self.data[ti, yi, xi+1] - self.data[ti, yi, xi]) / dx
         elif derivative in ['y', 'lat']:
-            return self.data[ti, yi+1, xi] - self.data[ti, yi, xi]
+            if self.grid.gtype in [GridCode.RectilinearSGrid, GridCode.RectilinearZGrid]:
+                dy = self.grid.lat[yi+1] - self.grid.lat[yi]
+            else:
+                raise NotImplementedError('Curvilinear grid derivatives not yet implemented')
+            return (self.data[ti, yi+1, xi] - self.data[ti, yi, xi]) / dy
         elif self.interp_method == 'nearest':
             xii = xi if xsi <= .5 else xi+1
             yii = yi if eta <= .5 else yi+1

--- a/parcels/include/index_search.h
+++ b/parcels/include/index_search.h
@@ -26,6 +26,11 @@ typedef enum
     NEMO = 0, MITGCM = 1, MOM5 = 2, POP = 3
   } GridIndexingType;
 
+typedef enum
+  {
+    NONE = 0, LON = 1, LAT = 2
+  } DerivativeDirection;
+
 typedef struct
 {
   int gtype;

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -427,8 +427,8 @@ def test_random_field(mode, k_sample_p, xdim=20, ydim=20, npart=100):
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])  # TODO: make test more complex (mesh=spherical etc)
 def test_field_derivative(mode):
-    dimensions = {'lon': np.linspace(0., 1., 2, dtype=np.float32),
-                  'lat': np.linspace(0., 1., 2, dtype=np.float32)}
+    dimensions = {'lon': np.linspace(0., 2., 2, dtype=np.float32),
+                  'lat': np.linspace(0., 3., 2, dtype=np.float32)}
     data = {'U': np.zeros((2, 2), dtype=np.float32),
             'V': np.zeros((2, 2), dtype=np.float32),
             'P': np.array([[0, 1], [2, 3]], dtype=np.float32)}
@@ -438,7 +438,7 @@ def test_field_derivative(mode):
         px = Variable('px')
         py = Variable('py')
 
-    pset = ParticleSet(fieldset, pclass=GradientSampler, lon=0.5, lat=0.5)
+    pset = ParticleSet(fieldset, pclass=GradientSampler, lon=1, lat=1.5)
 
     def gradient_sampling(particle, fieldset, time):
         particle.p = fieldset.P.eval(time, particle.depth, particle.lon, particle.lon)
@@ -446,9 +446,9 @@ def test_field_derivative(mode):
         particle.py = fieldset.P.eval(time, particle.depth, particle.lat, particle.lon, derivative='lat')
 
     pset.execute(gradient_sampling, dt=0.)
-    assert np.isclose(pset[0].p, 1.5)
-    assert np.isclose(pset[0].px, 1)
-    assert np.isclose(pset[0].py, 2)
+    assert np.isclose(pset[0].p, 7./6.)
+    assert np.isclose(pset[0].px, 0.5)
+    assert np.isclose(pset[0].py, 2./3.)
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])


### PR DESCRIPTION
This PR implements #970, to internally compute the derivatives of Fields. 

Proposed syntax is 
```python
field.eval(time, particle.depth, particle.lat, particle.lon, derivative='dir')
```
where `'dir'` can be any of `'lon'`, `'lat'`, `'depth'`, `'x'` (which is different from `'lon'` because it goes in the index-direction, which is not necessarily zonal for curvilinear grids), `'y'`, `'z'`, and perhaps even `'t'` and `'time'`

To-do list
- [x] implementation of the 'plumbing' (i.e. passing of derivative information to the field interpolation calls) in both scipy and JIT
- [ ] correct implementation in scipy of derivative for grids with non-unit mesh sizes, including also `mesh='spherical'`
- [ ] correct implementation in scipy of derivative for `x` and `y`, also for MITgcm and NEMO indexing convention
- [ ] correct implementation in scipy of derivative for `lon` and `lat`, also for curvilinear grids
- [ ] implementation in scipy of derivative for `depth` (and `z`) direction
- [ ] implementation in scipy of derivative for `time` (and `t`) direction
- [ ] implementation of all the above in JIT too

All these tasks on the list will require more unit tests, on more complicated `Fields`. @daanreijnders, can you help with these tasks, especially the implementations in scipy? I will then convert them to JIT where necessary 