### PR TITLE
Remove explicit loops over particle state

### DIFF
--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -388,7 +388,7 @@ class Kernel(object):
         This deletion function is targetted to index-addressable, random-access array-collections.
         """
         # Indices marked for deletion.
-        bool_indices = np.array([p.state == OperationCode.Delete for p in pset])
+        bool_indices = pset.collection.state == OperationCode.Delete
         indices = np.where(bool_indices)[0]
         if len(indices) > 0 and output_file is not None:
             output_file.write(pset, endtime, deleted_only=bool_indices)
@@ -396,8 +396,7 @@ class Kernel(object):
 
     def execute(self, pset, endtime, dt, recovery=None, output_file=None, execute_once=False):
         """Execute this Kernel over a ParticleSet for several timesteps"""
-        for p in pset:
-            p.set_state(StateCode.Evaluate)
+        pset.collection.state[:] = StateCode.Evaluate
 
         if abs(dt) < 1e-6 and not execute_once:
             logger.warning_once("'dt' is too small, causing numerical accuracy limit problems. Please chose a higher 'dt' and rather scale the 'time' axis of the field accordingly. (related issue #762)")


### PR DESCRIPTION
The loops to test and set particle state were implemented using Python primitives, which are extremely slow for large particle counts. We can easily modify `remove_deleted_soa`, because we know the underlying collection supports array indexing. We should also be able to rely on `Collection.__getitem__` returning something with an array-like interface that we can use to set all particle states simultaneously: for SoA the array assignment is significantly faster, and it would be no slower for other collections.