### PR TITLE
Fixing error message when FieldSet calendar is a cftime.datetime object

### DIFF
--- a/environment_py3_osx.yml
+++ b/environment_py3_osx.yml
@@ -25,7 +25,7 @@ dependencies:
   - six>=1.10.0
   - xarray>=0.10.8
   - dask>=2.0
-  - cftime
+  - cftime>=1.3.1
   - pytest
   - nbval
   - scikit-learn

--- a/environment_py3_win.yml
+++ b/environment_py3_win.yml
@@ -22,7 +22,7 @@ dependencies:
   - six>=1.10.0
   - xarray>=0.5.1
   - dask>=2.0
-  - cftime
+  - cftime>=1.3.1
   - ipykernel<5.0
   - pytest
   - nbval

--- a/environment_py3p6_linux.yml
+++ b/environment_py3p6_linux.yml
@@ -24,7 +24,7 @@ dependencies:
   - scipy>=0.16.0
   - six >=1.10.0
   - xarray>=0.10.8
-  - cftime
+  - cftime>=1.3.1
   - dask>=2.0
   - pytest
   - nbval

--- a/parcels/particlesets/baseparticleset.py
+++ b/parcels/particlesets/baseparticleset.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from datetime import timedelta as delta
 from os import path
 import time as time_module
+import cftime
 
 import progressbar
 
@@ -350,6 +351,8 @@ class BaseParticleSet(NDCluster):
             raise RuntimeError('endtime must be either a datetime or a double')
         if isinstance(endtime, datetime):
             endtime = np.datetime64(endtime)
+        elif isinstance(endtime, cftime.datetime):
+            endtime = self.time_origin.reltime(endtime)
         if isinstance(endtime, np.datetime64):
             if self.time_origin.calendar is None:
                 raise NotImplementedError('If fieldset.time_origin is not a date, execution endtime must be a double')

--- a/parcels/tools/converters.py
+++ b/parcels/tools/converters.py
@@ -53,9 +53,19 @@ class TimeConverter(object):
             return (time - self.time_origin) / np.timedelta64(1, 's')
         elif self.calendar in _get_cftime_calendars():
             if isinstance(time, (list, np.ndarray)):
-                return np.array([(t - self.time_origin).total_seconds() for t in time])
+                try:
+                    return np.array([(t - self.time_origin).total_seconds() for t in time])
+                except np.core._exceptions.UFuncTypeError:
+                    raise ValueError(f"Cannot subtract 'time' (a {type(time)} object) from "
+                                     f"a {self.calendar} calendar.\n"
+                                     f"Provide 'time' as a {type(self.time_origin)} object?")
             else:
-                return (time - self.time_origin).total_seconds()
+                try:
+                    return (time - self.time_origin).total_seconds()
+                except ValueError:
+                    raise ValueError(f"Cannot subtract 'time' (a {type(time)} object) from "
+                                     f"a {self.calendar} calendar.\n"
+                                     f"Provide 'time' as a {type(self.time_origin)} object?")
         elif self.calendar is None:
             return time - self.time_origin
         else:


### PR DESCRIPTION
This issue came up because GlobCurrentv3.0 has a 'julian' calendar, which means that all datetimes for the `ParticleSet` also need to be julian calendars. This is now better handled (requires `cftime>=1.3.1`)