### PR TITLE
Removing the compiling and loading of random libs on import of Parcels

### DIFF
--- a/parcels/rng.py
+++ b/parcels/rng.py
@@ -70,6 +70,8 @@ extern float pcls_vonmisesvariate(float mu, float kappa){
         self.ccode += self.fnct_expovariate
         self.ccode += self.fnct_vonmisesvariate
         self._loaded = False
+        self.compile()
+        self.load_lib()
 
     def __del__(self):
         self.unload_lib()
@@ -123,16 +125,24 @@ extern float pcls_vonmisesvariate(float mu, float kappa){
         return self._lib
 
 
-_parcels_random_ccodeconverter = RandomC()
+_parcels_random_ccodeconverter = None
+
+
+def _assign_parcels_random_ccodeconverter():
+    global _parcels_random_ccodeconverter
+    if _parcels_random_ccodeconverter is None:
+        _parcels_random_ccodeconverter = RandomC()
 
 
 def seed(seed):
     """Sets the seed for parcels internal RNG"""
+    _assign_parcels_random_ccodeconverter()
     _parcels_random_ccodeconverter.lib.pcls_seed(c_int(seed))
 
 
 def random():
     """Returns a random float between 0. and 1."""
+    _assign_parcels_random_ccodeconverter()
     rnd = _parcels_random_ccodeconverter.lib.pcls_random
     rnd.argtype = []
     rnd.restype = c_float
@@ -141,6 +151,7 @@ def random():
 
 def uniform(low, high):
     """Returns a random float between `low` and `high`"""
+    _assign_parcels_random_ccodeconverter()
     rnd = _parcels_random_ccodeconverter.lib.pcls_uniform
     rnd.argtype = [c_float, c_float]
     rnd.restype = c_float
@@ -149,6 +160,7 @@ def uniform(low, high):
 
 def randint(low, high):
     """Returns a random int between `low` and `high`"""
+    _assign_parcels_random_ccodeconverter()
     rnd = _parcels_random_ccodeconverter.lib.pcls_randint
     rnd.argtype = [c_int, c_int]
     rnd.restype = c_int
@@ -157,6 +169,7 @@ def randint(low, high):
 
 def normalvariate(loc, scale):
     """Returns a random float on normal distribution with mean `loc` and width `scale`"""
+    _assign_parcels_random_ccodeconverter()
     rnd = _parcels_random_ccodeconverter.lib.pcls_normalvariate
     rnd.argtype = [c_float, c_float]
     rnd.restype = c_float
@@ -165,6 +178,7 @@ def normalvariate(loc, scale):
 
 def expovariate(lamb):
     """Returns a randome float of an exponential distribution with parameter lamb"""
+    _assign_parcels_random_ccodeconverter()
     rnd = _parcels_random_ccodeconverter.lib.pcls_expovariate
     rnd.argtype = c_float
     rnd.restype = c_float
@@ -174,6 +188,7 @@ def expovariate(lamb):
 def vonmisesvariate(mu, kappa):
     """Returns a randome float of a Von Mises distribution
     with mean angle mu and concentration parameter kappa"""
+    _assign_parcels_random_ccodeconverter()
     rnd = _parcels_random_ccodeconverter.lib.pcls_vonmisesvariate
     rnd.argtype = [c_float, c_float]
     rnd.restype = c_float

--- a/parcels/rng.py
+++ b/parcels/rng.py
@@ -70,8 +70,6 @@ extern float pcls_vonmisesvariate(float mu, float kappa){
         self.ccode += self.fnct_expovariate
         self.ccode += self.fnct_vonmisesvariate
         self._loaded = False
-        self.compile()
-        self.load_lib()
 
     def __del__(self):
         self.unload_lib()


### PR DESCRIPTION
Parcels compiles the random libraries on first import statement, even when those libraries are not necessary. This is not only confusing (and redundant), it can also lead to problems like in #1023. 

Here, I've simply removed the compiling and loading step from `rng.RandomC.__init__`, and the library then still is compiled when needed (and all unit tests still seem to pass). 

I'm wondering therefore whether this is a way to remove the on-import compilation, although I also remember that @CKehl mentioned this may cause a problem with MPI?