### PR TITLE
Separate GitHub Actions workflows for unit and integration tests

### DIFF
--- a/.github/scripts/linux_integrationtest.sh
+++ b/.github/scripts/linux_integrationtest.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+export PATH="$HOME/miniconda/bin:$PATH"
+source activate parcels
+
+# Set up display to be able to plot in linux
+export DISPLAY=:99.0;
+sh -e /etc/init.d/xvfb start;
+sleep 3;
+
+parcels_get_examples examples/;
+pytest -v -s --nbval-lax -k "not documentation" examples/;

--- a/.github/scripts/linux_unittest.sh
+++ b/.github/scripts/linux_unittest.sh
@@ -7,5 +7,4 @@ export DISPLAY=:99.0;
 sh -e /etc/init.d/xvfb start;
 sleep 3;
 
-parcels_get_examples examples/;
-pytest -v -s --nbval-lax -k "not documentation" tests/ examples/;
+pytest -v -s tests/ ;

--- a/.github/scripts/osx_integrationtest.sh
+++ b/.github/scripts/osx_integrationtest.sh
@@ -1,0 +1,8 @@
+export PATH="$HOME/miniconda/bin:$PATH"
+source activate parcels
+
+export CONDA_BUILD_SYSROOT=/
+export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
+
+parcels_get_examples examples/;
+pytest -v -s --nbval-lax -k "not documentation" examples/;

--- a/.github/scripts/osx_unittest.sh
+++ b/.github/scripts/osx_unittest.sh
@@ -4,5 +4,4 @@ source activate parcels
 export CONDA_BUILD_SYSROOT=/
 export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
 
-parcels_get_examples examples/;
-pytest -v -s --nbval-lax -k "not documentation" tests/ examples/;
+pytest -v -s tests/;

--- a/.github/scripts/windows_integrationtest.bat
+++ b/.github/scripts/windows_integrationtest.bat
@@ -1,4 +1,4 @@
 SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
 call activate parcels
 parcels_get_examples examples/;
-pytest -v -s --nbval-lax -k "not documentation" tests/ examples/;
+pytest -v -s --nbval-lax -k "not documentation" examples/;

--- a/.github/scripts/windows_unittest.bat
+++ b/.github/scripts/windows_unittest.bat
@@ -1,4 +1,4 @@
 SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
 call activate parcels
 parcels_get_examples examples/;
-pytest -v -s --nbval-lax -k "not documentation" tests/ examples/;
+pytest -v -s --nbval-lax -k "not documentation" tests/;

--- a/.github/scripts/windows_unittest.bat
+++ b/.github/scripts/windows_unittest.bat
@@ -1,0 +1,3 @@
+SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+call activate parcels
+pytest -v -s tests/;

--- a/.github/scripts/windows_unittest.bat
+++ b/.github/scripts/windows_unittest.bat
@@ -1,4 +1,4 @@
 SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
 call activate parcels
 parcels_get_examples examples/;
-pytest -v -s --nbval-lax -k "not documentation" tests/;
+pytest -v -s --nbval-lax -k "not documentation" tests/

--- a/.github/scripts/windows_unittest.bat
+++ b/.github/scripts/windows_unittest.bat
@@ -1,4 +1,4 @@
 SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
 call activate parcels
 parcels_get_examples examples/;
-pytest -v -s tests/;
+pytest -v -s --nbval-lax -k "not documentation" tests/ examples/;

--- a/.github/scripts/windows_unittest.bat
+++ b/.github/scripts/windows_unittest.bat
@@ -1,4 +1,3 @@
 SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
 call activate parcels
-parcels_get_examples examples/;
-pytest -v -s --nbval-lax -k "not documentation" tests/
+pytest -v -s tests/

--- a/.github/scripts/windows_unittest.bat
+++ b/.github/scripts/windows_unittest.bat
@@ -1,3 +1,4 @@
 SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
 call activate parcels
+parcels_get_examples examples/;
 pytest -v -s tests/;

--- a/.github/workflows/ci-workflow-integrationtests.yml
+++ b/.github/workflows/ci-workflow-integrationtests.yml
@@ -1,0 +1,49 @@
+name: integration-tests
+on:
+  pull_request:
+    types: [review_requested, ready_for_review]
+jobs:
+  test_macOS:
+    name: Integration testing on macOS python latest
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Test OSX
+        env:
+          OS_NAME: osx
+          PY_VERSION: 3
+          MINICONDA_NAME: Miniconda3-latest-MacOSX-x86_64.sh
+        run: |
+          ./.github/scripts/linux_install.sh
+          ./.github/scripts/osx_integrationtest.sh
+        shell: bash
+  test_linux:
+    name: Integration testing on Linux Python 3.6
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Test linux
+        env:
+          OS_NAME: linux
+          PY_VERSION: 3
+          MINICONDA_NAME: Miniconda3-latest-Linux-x86_64.sh
+        run: |
+          ./.github/scripts/linux_install.sh
+          ./.github/scripts/linux_integrationtest.sh
+        shell: bash
+  test_windows:
+    name: Integration testing on Windows python latest
+    runs-on: windows-2016
+    steps:
+      - uses: actions/checkout@master
+      - name: Test Windows
+        env:
+          OS_NAME: win
+          PY_VERSION: 3
+          PYTHON_ARCH: 64
+          PYTHON: C:\Miniconda36-x64
+        run: |
+          ./.github/scripts/install_miniconda.ps1
+          ./.github/scripts/windows_install.bat
+          ./.github/scripts/windows_integrationtest.bat
+        shell: powershell

--- a/.github/workflows/ci-workflow-unittests.yml
+++ b/.github/workflows/ci-workflow-unittests.yml
@@ -1,5 +1,6 @@
-name: test-suite
-on: pull_request
+name: unit-tests
+on:
+  pull_request:
 jobs:
   pep8-linter:
     name: Testing PEP8 linter
@@ -14,7 +15,7 @@ jobs:
           python -m flake8 tests/
         shell: bash
   test_macOS:
-    name: Testing on macOS python latest
+    name: Unittesting on macOS python latest
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@master
@@ -25,10 +26,10 @@ jobs:
           MINICONDA_NAME: Miniconda3-latest-MacOSX-x86_64.sh
         run: |
           ./.github/scripts/linux_install.sh
-          ./.github/scripts/osx_test.sh
+          ./.github/scripts/osx_unittest.sh
         shell: bash
   test_linux:
-    name: Testing on Linux Python 3.6
+    name: Unittesting on Linux Python 3.6
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -39,10 +40,10 @@ jobs:
           MINICONDA_NAME: Miniconda3-latest-Linux-x86_64.sh
         run: |
           ./.github/scripts/linux_install.sh
-          ./.github/scripts/linux_test.sh
+          ./.github/scripts/linux_unittest.sh
         shell: bash
   test_windows:
-    name: Testing on Windows python latest
+    name: Unittesting on Windows python latest
     runs-on: windows-2016
     steps:
       - uses: actions/checkout@master
@@ -55,5 +56,5 @@ jobs:
         run: |
           ./.github/scripts/install_miniconda.ps1
           ./.github/scripts/windows_install.bat
-          ./.github/scripts/windows_test.bat
+          ./.github/scripts/windows_unittest.bat
         shell: powershell


### PR DESCRIPTION
Because the GitHub Actions workflow is taking an hour on each commit now, @CKehl and I discussed whether we could make testing more efficient by separating the GitHub Actions into a unittesting workflow (triggered on every commit to a PR) and a integration testing workflow that is only triggered for Pull Requests that are ready for review

Before merging, it would then also be good to

- [ ] Move some of the longer-running/larger test scripts in `tests/` to `examples/` so they are run on the integration test workflow