### PR TITLE
Dynamic version info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 build/*
 docs/_build/*
 gh-pages/*
+lib/
+bin/
 
 *.so
 *.log

--- a/parcels/__init__.py
+++ b/parcels/__init__.py
@@ -1,5 +1,6 @@
-from ._version import version
-__version__ = version
+import subprocess
+import os
+__version__ = subprocess.check_output(['git', '-C', os.path.dirname(__file__), 'describe', '--tags']).decode('ascii').strip()
 
 from parcels.fieldset import *  # noqa
 from parcels.particle import *  # noqa


### PR DESCRIPTION
Previously, the version of parcels was set during `python setup.py install`, and not changed afterwards anymore. This is not correct when users change parcels through git. Here, we implement a more dynamic version number setting through the command
```
 git -C parcels describe --tags
```

This PR also adds `lib/` and `bin/` to gigignore, which are created when installing in the parcels directory