### PR TITLE
Fix bug with 0-dimensional time DataArray

### DIFF
--- a/parcels/fieldfilebuffer.py
+++ b/parcels/fieldfilebuffer.py
@@ -177,7 +177,7 @@ class NetcdfFileBuffer(_FileBuffer):
 
         time_da = self.dataset[self.dimensions['time']]
         convert_xarray_time_units(time_da, self.dimensions['time'])
-        time = np.array([time_da[self.dimensions['time']]]) if len(time_da.shape) == 0 else np.array(time_da[self.dimensions['time']])
+        time = np.array([time_da[self.dimensions['time']].data]) if len(time_da.shape) == 0 else np.array(time_da[self.dimensions['time']])
         if isinstance(time[0], datetime.datetime):
             raise NotImplementedError('Parcels currently only parses dates ranging from 1678 AD to 2262 AD, which are stored by xarray as np.datetime64. If you need a wider date range, please open an Issue on the parcels github page.')
         return time


### PR DESCRIPTION
Xarray `DataArray`s of time coordinates are casted into `np.datetime` arrays in `fieldfilebuffer.py`. Currently, if the shape of the `DataArray`s is 0, the `DataArray` object is put in a list and is subsequently casted into a `np.array`. This leads to errors. This PR fixes the issue, by extracting the `np.datetime` object from the `DataArray`, and casting this into a 1D `np.array` (with one entry).

This issue popped up when working with NEMO MOi data.