### PR TITLE
Chunkwise netcdf export

### DIFF
--- a/parcels/particlefile/particlefilesoa.py
+++ b/parcels/particlefile/particlefilesoa.py
@@ -151,7 +151,7 @@ class ParticleFileSOA(BaseParticleFile):
             # Find available memory to check if output file is too large
             avail_mem = psutil.virtual_memory()[1]
             req_mem   = len(self.id_present)*len(self.time_written)*8*1.2
-            avail_mem = req_mem/2
+            # avail_mem = req_mem/2 # ! HACK FOR TESTING !
 
             if req_mem > avail_mem:
                 # Read id_per_chunk ids at a time to keep memory use down

--- a/parcels/particlefile/particlefilesoa.py
+++ b/parcels/particlefile/particlefilesoa.py
@@ -142,6 +142,8 @@ class ParticleFileSOA(BaseParticleFile):
                 if len(self.var_names_once) > 0:
                     global_file_list_once += pset_info_local['file_list_once']
         self.maxid_written = global_maxid_written
+
+        # These steps seem to be quite expensive...
         self.time_written = np.unique(global_time_written)
         self.id_present = np.unique([pid for frame in global_id for pid in frame])
 
@@ -174,9 +176,8 @@ class ParticleFileSOA(BaseParticleFile):
                 data = self.read_from_npy(global_file_list, len(self.time_written), var, id_range)
                 if (var == self.var_names[0]) & (chunk == 0):
                     # !! unacceptable assumption !!
-                    # This step assumes that the first id is 0 and that the
-                    # number of time-steps in the first chunk == number of
-                    # time-steps across all chunks.
+                    # Assumes that the number of time-steps in the first chunk
+                    # == number of time-steps across all chunks.
                     self.open_netcdf_file((len(self.id_present), data.shape[1]))
 
                 varout = 'z' if var == 'depth' else var


### PR DESCRIPTION
Suggestion (WIP) for automatically 'chunking' netcdf export step if intermediate variables would exceed available system memory. Importantly, the code below currently assumes that the number of unique time steps in the first chunk == number of unique time steps for all chunks, which will often but not always be true. I am not currently sure how to calculate this cheaply.