### PR TITLE
Include Zenodo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ See [oceanparcels.org](http://oceanparcels.org/) for further information about [
 [![Build Status](https://github.com/oceanparcels/parcels/workflows/test-suite/badge.svg?branch=master)](https://github.com/OceanParcels/parcels/actions?query=workflow%3Atest-suite+branch%3Amaster)
 [![Anaconda-release](https://anaconda.org/conda-forge/parcels/badges/version.svg)](https://anaconda.org/conda-forge/parcels/)
 [![Anaconda-date](https://anaconda.org/conda-forge/parcels/badges/latest_release_date.svg)](https://anaconda.org/conda-forge/parcels/)
+[![Zenodo](https://zenodo.org/badge/DOI/10.5281/zenodo.823561.svg)](https://doi.org/10.5281/zenodo.823561)


### PR DESCRIPTION
This PR adds a Zenodo badge to the README. This is recommended by FAIR, and some journals also require software packages to be cited directly, alongside the papers that describe them. The badge links to the 'all versions' DOI on Zenodo, so that the latest version is loaded automatically.