### PR TITLE
Interaction periodic bc

### DIFF
--- a/parcels/interaction/neighborsearch/base.py
+++ b/parcels/interaction/neighborsearch/base.py
@@ -14,7 +14,7 @@ class BaseNeighborSearch(ABC):
     """
 
     def __init__(self, inter_dist_vert, inter_dist_horiz,
-                 max_depth=100000, zperiodic_bc_domain=None):
+                 max_depth=100000, periodic_domain_zonal=None):
         """Initialize neighbor search
 
         :param inter_dist_vert: interaction distance (vertical) in m
@@ -36,7 +36,7 @@ class BaseNeighborSearch(ABC):
         # Thus, this mask allows for particles do be deactivated without
         # needing to completely rebuild the tree.
         self._active_mask = None
-        self.zperiodic_bc_domain = zperiodic_bc_domain
+        self.periodic_domain_zonal = periodic_domain_zonal
 
     @abstractmethod
     def find_neighbors_by_coor(self, coor):
@@ -133,19 +133,19 @@ class BaseFlatNeighborSearch(BaseNeighborSearch):
         horiz_distance = np.sqrt(np.sum((
             self._values[1:, subset_idx] - coor[1:])**2,
             axis=0))
-        if self.zperiodic_bc_domain:
+        if self.periodic_domain_zonal:
             # If zonal periodic boundaries
-            coor[2, 0] -= self.zperiodic_bc_domain
+            coor[2, 0] -= self.periodic_domain_zonal
             # distance through Western boundary
             hd2 = np.sqrt(np.sum((
                 self._values[1:, subset_idx] - coor[1:])**2,
                 axis=0))
-            coor[2, 0] += 2*self.zperiodic_bc_domain
+            coor[2, 0] += 2*self.periodic_domain_zonal
             # distance through Eastern boundary
             hd3 = np.sqrt(np.sum((
                 self._values[1:, subset_idx] - coor[1:])**2,
                 axis=0))
-            coor[2, 0] -= self.zperiodic_bc_domain
+            coor[2, 0] -= self.periodic_domain_zonal
         else:
             hd2 = np.full(len(horiz_distance), np.inf)
             hd3 = np.full(len(horiz_distance), np.inf)
@@ -166,23 +166,23 @@ class BaseSphericalNeighborSearch(BaseNeighborSearch):
             self._values[2, subset_idx],
         )
 
-        if self.zperiodic_bc_domain:
+        if self.periodic_domain_zonal:
             # If zonal periodic boundaries
-            coor[2, 0] -= self.zperiodic_bc_domain
+            coor[2, 0] -= self.periodic_domain_zonal
             # distance through Western boundary
             hd2 = spherical_distance(
                 *coor,
                 self._values[0, subset_idx],
                 self._values[1, subset_idx],
                 self._values[2, subset_idx])[1]
-            coor[2, 0] += 2*self.zperiodic_bc_domain
+            coor[2, 0] += 2*self.periodic_domain_zonal
             # distance through Eastern boundary
             hd3 = spherical_distance(
                 *coor,
                 self._values[0, subset_idx],
                 self._values[1, subset_idx],
                 self._values[2, subset_idx])[1]
-            coor[2, 0] -= self.zperiodic_bc_domain
+            coor[2, 0] -= self.periodic_domain_zonal
         else:
             hd2 = np.full(len(horiz_distances), np.inf)
             hd3 = np.full(len(horiz_distances), np.inf)

--- a/parcels/particleset/particlesetsoa.py
+++ b/parcels/particleset/particlesetsoa.py
@@ -81,7 +81,7 @@ class ParticleSetSOA(BaseParticleSet):
     :param pid_orig: Optional list of (offsets for) the particle IDs
     :param partitions: List of cores on which to distribute the particles for MPI runs. Default: None, in which case particles
            are distributed automatically on the processors
-    :param zperiodic_bc_domain: Zonal domain size, used to apply zonally periodic boundaries for particle-particle
+    :param periodic_domain_zonal: Zonal domain size, used to apply zonally periodic boundaries for particle-particle
            interaction. If None, no zonally periodic boundaries are applied
 
     Other Variables can be initialised using further arguments (e.g. v=... for a Variable named 'v')
@@ -89,7 +89,7 @@ class ParticleSetSOA(BaseParticleSet):
 
     def __init__(self, fieldset=None, pclass=JITParticle, lon=None, lat=None,
                  depth=None, time=None, repeatdt=None, lonlatdepth_dtype=None,
-                 pid_orig=None, interaction_distance=None, zperiodic_bc_domain=None, **kwargs):
+                 pid_orig=None, interaction_distance=None, periodic_domain_zonal=None, **kwargs):
         super(ParticleSetSOA, self).__init__()
 
         # ==== first: create a new subclass of the pclass that includes the required variables ==== #
@@ -231,7 +231,7 @@ class ParticleSetSOA(BaseParticleSet):
             self._neighbor_tree = interaction_class(
                 inter_dist_vert=inter_dist_vert,
                 inter_dist_horiz=inter_dist_horiz,
-                zperiodic_bc_domain=zperiodic_bc_domain)
+                periodic_domain_zonal=periodic_domain_zonal)
         # End of neighbor search data structure initialization.
 
         if self.repeatdt:

--- a/tests/test_interaction_kernel.py
+++ b/tests/test_interaction_kernel.py
@@ -70,15 +70,15 @@ def test_simple_interaction_kernel(fieldset, mode):
 
 @pytest.mark.parametrize('mode', ['scipy'])
 @pytest.mark.parametrize('mesh', ['spherical', 'flat'])
-@pytest.mark.parametrize('zperiodic_bc_domain', [False, True])
-def test_zonal_periodic_distance(mode, mesh, zperiodic_bc_domain):
+@pytest.mark.parametrize('periodic_domain_zonal', [False, True])
+def test_zonal_periodic_distance(mode, mesh, periodic_domain_zonal):
     fset = fieldset(mesh=mesh)
     interaction_distance = 0.2 if mesh == 'flat' else 6371000*0.2*np.pi/180
     lons = [0.05, 0.4, 0.95]
     pset = ParticleSet(fset, pclass=ptype[mode], lon=lons, lat=[0.5]*len(lons),
-                       interaction_distance=interaction_distance, zperiodic_bc_domain=zperiodic_bc_domain)
+                       interaction_distance=interaction_distance, periodic_domain_zonal=periodic_domain_zonal)
     pset.execute(DoNothing, pyfunc_inter=DummyMoveNeighbor, endtime=1., dt=1.)
-    if zperiodic_bc_domain:
+    if periodic_domain_zonal:
         assert np.allclose([pset[0].lat, pset[2].lat], 0.6)
         assert np.allclose(pset[1].lat, 0.5)
     else:


### PR DESCRIPTION
After merging, it is possible to apply particle-particle interaction with periodic boundary conditions in the zonal direction. This means that the calculation of particle neighbours (i.e. to determine which particles are within the maximum interaction distance of a particle) in the particle-particle interaction, takes into account zonally periodic boundaries.
Meridional periodic boundaries are not implemented yet.