### PR TITLE
Raising an explicit error that abs() is not supported in JIT kernels

### DIFF
--- a/parcels/compilation/codegenerator.py
+++ b/parcels/compilation/codegenerator.py
@@ -290,6 +290,8 @@ class IntrinsicTransformer(ast.NodeTransformer):
             node = PrintNode()
         elif (node.id == 'pnum') or ('parcels_tmpvar' in node.id):
             raise NotImplementedError("Custom Kernels cannot contain string %s; please change your kernel" % node.id)
+        elif node.id == 'abs':
+            raise NotImplementedError("abs() does not work in JIT Kernels. Use math.fabs() instead")
         return node
 
     def visit_Attribute(self, node):

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -192,6 +192,22 @@ def test_parcels_tmpvar_in_kernel(pset_mode):
 
 
 @pytest.mark.parametrize('pset_mode', pset_modes)
+def test_abs(pset_mode):
+    """Tests for error thrown if using abs in kernel"""
+    error_thrown = False
+    pset = pset_type[pset_mode]['pset'](pclass=JITParticle, lon=0, lat=0)
+
+    def kernel_abs(particle, fieldset, time):
+        particle.lon = abs(3.1)  # noqa
+
+    try:
+        pset.execute(kernel_abs, endtime=1, dt=1.)
+    except NotImplementedError:
+        error_thrown = True
+    assert error_thrown
+
+
+@pytest.mark.parametrize('pset_mode', pset_modes)
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_if_withfield(fieldset, pset_mode, mode):
     """Test combination of if and Field sampling commands"""


### PR DESCRIPTION
As reported by @mikaelk in #1097, the `abs()`function defaults to integer abs in C (unlike in python), possibly creating confusion in JIT Kernels. For this reason, this PR implements throwing an error if a user uses `abs()` and suggest to use `math.fabs()` instead