### PR TITLE
Create a custom filter for the xarray decoding warnings

### DIFF
--- a/parcels/examples/tutorial_nemo_3D.ipynb
+++ b/parcels/examples/tutorial_nemo_3D.ipynb
@@ -45,20 +45,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING: File NemoNorthSeaORCA025-N006_data/coordinates.nc could not be decoded properly by xarray (version 0.16.0).\n",
-      "         It will be opened with no decoding. Filling values might be wrongly parsed.\n",
-      "WARNING: Casting lon data to np.float32\n",
-      "WARNING: Casting lat data to np.float32\n",
-      "INFO: Compiled JITParticleAdvectionRK4_3D ==> C:\\Users\\GEBRUI~1\\AppData\\Local\\Temp\\parcels-tmp\\e514525188ae4721eb60267f088fcccf_0.dll\n"
+      "INFO: Compiled ArrayJITParticleAdvectionRK4_3D ==> /var/folders/r2/8593q8z93kd7t4j9kbb_f7p00000gr/T/parcels-504/libe8f8d05e9f59db3883539a0a60266e35_0.so\n"
      ]
     }
    ],
    "source": [
     "from parcels import FieldSet, ParticleSet, JITParticle, AdvectionRK4_3D\n",
     "from glob import glob\n",
-    "import numpy as np\n",
     "from datetime import timedelta as delta\n",
-    "from os import path\n",
+    "\n",
+    "from parcels import logger, XarrayDecodedFilter\n",
+    "logger.addFilter(XarrayDecodedFilter())  # Add a filter for the xarray decoding warning\n",
     "\n",
     "data_path = 'NemoNorthSeaORCA025-N006_data/'\n",
     "ufiles = sorted(glob(data_path+'ORCA*U.nc'))\n",
@@ -86,7 +83,7 @@
     "                             depth=1)\n",
     "\n",
     "kernels = pset.Kernel(AdvectionRK4_3D)\n",
-    "pset.execute(kernels, runtime=delta(days=4), dt=delta(hours=6))\n"
+    "pset.execute(kernels, runtime=delta(days=4), dt=delta(hours=6))"
    ]
   },
   {
@@ -160,17 +157,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Casting time data to np.float64\n",
-      "WARNING: Casting depth data to np.float32\n",
-      "WARNING: Casting field data to np.float32\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "e1u = Field.from_netcdf(filenames=mesh_mask, variable='e1u', \n",
     "                        dimensions={'lon': 'glamu', 'lat': 'gphiu'},\n",

--- a/parcels/tools/loggers.py
+++ b/parcels/tools/loggers.py
@@ -1,7 +1,7 @@
 """Script to create a `logger` for Parcels"""
 import logging
 
-__all__ = ['logger']
+__all__ = ['logger', 'XarrayDecodedFilter']
 
 warning_once_level = 25
 info_once_level = 26
@@ -46,3 +46,9 @@ logging.Logger.info_once = info_once
 dup_filter = DuplicateFilter()
 logger.addFilter(dup_filter)
 logger.setLevel(10)
+
+
+class XarrayDecodedFilter(logging.Filter):
+    """Filters the warning_once from fieldfilebuffer when cf_decoding fails"""
+    def filter(self, record):
+        return 'Filling values might be wrongly parsed' not in record.getMessage()


### PR DESCRIPTION
This PR creates a custom filter for the `logging.warning_once` message below, since this warning is in some cases not relevant for new users
https://github.com/OceanParcels/parcels/blob/21f053b81a9ccdaa5d8ee4f7efd6f01639b83bfc/parcels/fieldfilebuffer.py#L44-L46

It can be triggered by 
```python
from parcels import logger, XarrayDecodedFilter
logger.addFilter(XarrayDecodedFilter())
```