### PR TITLE
Use actual particle datatype for netcdf export

### DIFF
--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -221,7 +221,6 @@ class BaseParticleFile(ABC):
             self.z.units = "m"
             self.z.positive = "down"
 
-
         for vname, dtype in zip(self.var_names, self.var_dtypes):
             if vname not in self._reserved_var_names():
                 fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).max

--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -224,7 +224,7 @@ class BaseParticleFile(ABC):
 
         for vname, dtype in zip(self.var_names, self.var_dtypes):
             if vname not in self._reserved_var_names():
-                fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).min
+                fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).max
                 nc_dtype_fmt = dtype[0] + str(int(int(dtype[-2:])/8))
                 setattr(self, vname, self.dataset.createVariable(vname, nc_dtype_fmt, coords, fill_value=fill_value))
                 getattr(self, vname).long_name = ""
@@ -232,7 +232,7 @@ class BaseParticleFile(ABC):
                 getattr(self, vname).units = "unknown"
 
         for vname, dtype in zip(self.var_names_once, self.var_dtypes_once):
-            fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).min
+            fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).max
             nc_dtype_fmt = dtype[0] + str(int(int(dtype[-2:])/8))
             setattr(self, vname, self.dataset.createVariable(vname, nc_dtype_fmt, "traj", fill_value=fill_value))
             getattr(self, vname).long_name = ""

--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -100,10 +100,12 @@ class BaseParticleFile(ABC):
             for v in self.particleset.collection.ptype.variables:
                 if v.to_write == 'once':
                     self.var_names_once += [v.name]
-                    self.var_dtypes_once += [v.dtype.__name__[0] + str(int(int(v.dtype.__name__[-2:])/8))]
+                    self.var_dtypes_once += [v.dtype.__name__]
+                    # self.var_dtypes_once += [v.dtype.__name__[0] + str(int(int(v.dtype.__name__[-2:])/8))]
                 elif v.to_write is True:
                     self.var_names += [v.name]
-                    self.var_dtypes += [v.dtype.__name__[0] + str(int(int(v.dtype.__name__[-2:])/8))]
+                    self.var_dtypes += [v.dtype.__name__]
+                    # self.var_dtypes += [v.dtype.__name__[0] + str(int(int(v.dtype.__name__[-2:])/8))]
             if len(self.var_names_once) > 0:
                 self.written_once = []
                 self.file_list_once = []
@@ -222,15 +224,17 @@ class BaseParticleFile(ABC):
 
         for vname, dtype in zip(self.var_names, self.var_dtypes):
             if vname not in self._reserved_var_names():
-                fill_value = np.nan if dtype[0] == 'f' else -2**(8*int(dtype[-1])-1)
-                setattr(self, vname, self.dataset.createVariable(vname, dtype, coords, fill_value=fill_value))
+                fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).min
+                nc_dtype_fmt = dtype[0] + str(int(int(dtype[-2:])/8))
+                setattr(self, vname, self.dataset.createVariable(vname, nc_dtype_fmt, coords, fill_value=fill_value))
                 getattr(self, vname).long_name = ""
                 getattr(self, vname).standard_name = vname
                 getattr(self, vname).units = "unknown"
 
         for vname, dtype in zip(self.var_names_once, self.var_dtypes_once):
-            fill_value = np.nan if dtype[0] == 'f' else -2**(8*int(dtype[-1])-1)
-            setattr(self, vname, self.dataset.createVariable(vname, dtype, "traj", fill_value=fill_value))
+            fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).min
+            nc_dtype_fmt = dtype[0] + str(int(int(dtype[-2:])/8))
+            setattr(self, vname, self.dataset.createVariable(vname, nc_dtype_fmt, "traj", fill_value=fill_value))
             getattr(self, vname).long_name = ""
             getattr(self, vname).standard_name = vname
             getattr(self, vname).units = "unknown"

--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -98,11 +98,11 @@ class BaseParticleFile(ABC):
             self.var_names_once = []
             self.var_dtypes_once = []
             for v in self.particleset.collection.ptype.variables:
-                if v.to_write == 'once':
+                if v.to_write == 'once' and self.write_ondelete == False:
                     self.var_names_once += [v.name]
                     self.var_dtypes_once += [v.dtype.__name__]
                     # self.var_dtypes_once += [v.dtype.__name__[0] + str(int(int(v.dtype.__name__[-2:])/8))]
-                elif v.to_write is True:
+                elif v.to_write is True or v.to_write == 'once':
                     self.var_names += [v.name]
                     self.var_dtypes += [v.dtype.__name__]
                     # self.var_dtypes += [v.dtype.__name__[0] + str(int(int(v.dtype.__name__[-2:])/8))]

--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -101,11 +101,9 @@ class BaseParticleFile(ABC):
                 if v.to_write == 'once' and self.write_ondelete == False:
                     self.var_names_once += [v.name]
                     self.var_dtypes_once += [v.dtype.__name__]
-                    # self.var_dtypes_once += [v.dtype.__name__[0] + str(int(int(v.dtype.__name__[-2:])/8))]
                 elif v.to_write is True or v.to_write == 'once':
                     self.var_names += [v.name]
                     self.var_dtypes += [v.dtype.__name__]
-                    # self.var_dtypes += [v.dtype.__name__[0] + str(int(int(v.dtype.__name__[-2:])/8))]
             if len(self.var_names_once) > 0:
                 self.written_once = []
                 self.file_list_once = []

--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -63,8 +63,10 @@ class BaseParticleFile(ABC):
     time_origin = None
     lonlatdepth_dtype = None
     var_names = None
+    var_dtypes = None
     file_list = None
     var_names_once = None
+    var_dtypes_once = None
     file_list_once = None
     maxid_written = -1
     tempwritedir_base = None
@@ -92,12 +94,16 @@ class BaseParticleFile(ABC):
             self.time_origin = self.particleset.time_origin
             self.lonlatdepth_dtype = self.particleset.collection.lonlatdepth_dtype
             self.var_names = []
+            self.var_dtypes = []
             self.var_names_once = []
+            self.var_dtypes_once = []
             for v in self.particleset.collection.ptype.variables:
                 if v.to_write == 'once':
                     self.var_names_once += [v.name]
+                    self.var_dtypes_once += [v.dtype.__name__[0] + str(int(int(v.dtype.__name__[-2:])/8))]
                 elif v.to_write is True:
                     self.var_names += [v.name]
+                    self.var_dtypes += [v.dtype.__name__[0] + str(int(int(v.dtype.__name__[-2:])/8))]
             if len(self.var_names_once) > 0:
                 self.written_once = []
                 self.file_list_once = []
@@ -213,15 +219,18 @@ class BaseParticleFile(ABC):
             self.z.units = "m"
             self.z.positive = "down"
 
-        for vname in self.var_names:
+
+        for vname, dtype in zip(self.var_names, self.var_dtypes):
             if vname not in self._reserved_var_names():
-                setattr(self, vname, self.dataset.createVariable(vname, "f4", coords, fill_value=np.nan))
+                fill_value = np.nan if dtype[0] == 'f' else -2**(8*int(dtype[-1])-1)
+                setattr(self, vname, self.dataset.createVariable(vname, dtype, coords, fill_value=fill_value))
                 getattr(self, vname).long_name = ""
                 getattr(self, vname).standard_name = vname
                 getattr(self, vname).units = "unknown"
 
-        for vname in self.var_names_once:
-            setattr(self, vname, self.dataset.createVariable(vname, "f4", "traj", fill_value=np.nan))
+        for vname, dtype in zip(self.var_names_once, self.var_dtypes_once):
+            fill_value = np.nan if dtype[0] == 'f' else -2**(8*int(dtype[-1])-1)
+            setattr(self, vname, self.dataset.createVariable(vname, dtype, "traj", fill_value=fill_value))
             getattr(self, vname).long_name = ""
             getattr(self, vname).standard_name = vname
             getattr(self, vname).units = "unknown"

--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -100,10 +100,10 @@ class BaseParticleFile(ABC):
             for v in self.particleset.collection.ptype.variables:
                 if v.to_write == 'once' and self.write_ondelete is False:
                     self.var_names_once += [v.name]
-                    self.var_dtypes_once += [v.dtype.__name__]
+                    self.var_dtypes_once += [v.dtype]
                 elif v.to_write is True or v.to_write == 'once':
                     self.var_names += [v.name]
-                    self.var_dtypes += [v.dtype.__name__]
+                    self.var_dtypes += [v.dtype]
             if len(self.var_names_once) > 0:
                 self.written_once = []
                 self.file_list_once = []
@@ -221,16 +221,16 @@ class BaseParticleFile(ABC):
 
         for vname, dtype in zip(self.var_names, self.var_dtypes):
             if vname not in self._reserved_var_names():
-                fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).max
-                nc_dtype_fmt = dtype[0] + str(int(int(dtype[-2:])/8))
+                fill_value = self.fill_value_map[dtype]
+                nc_dtype_fmt = self.fmt_map[dtype]
                 setattr(self, vname, self.dataset.createVariable(vname, nc_dtype_fmt, coords, fill_value=fill_value))
                 getattr(self, vname).long_name = ""
                 getattr(self, vname).standard_name = vname
                 getattr(self, vname).units = "unknown"
 
         for vname, dtype in zip(self.var_names_once, self.var_dtypes_once):
-            fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).max
-            nc_dtype_fmt = dtype[0] + str(int(int(dtype[-2:])/8))
+            fill_value = self.fill_value_map[dtype]
+            nc_dtype_fmt = self.fmt_map[dtype]
             setattr(self, vname, self.dataset.createVariable(vname, nc_dtype_fmt, "traj", fill_value=fill_value))
             getattr(self, vname).long_name = ""
             getattr(self, vname).standard_name = vname

--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -98,7 +98,7 @@ class BaseParticleFile(ABC):
             self.var_names_once = []
             self.var_dtypes_once = []
             for v in self.particleset.collection.ptype.variables:
-                if v.to_write == 'once' and self.write_ondelete == False:
+                if v.to_write == 'once' and self.write_ondelete is False:
                     self.var_names_once += [v.name]
                     self.var_dtypes_once += [v.dtype.__name__]
                 elif v.to_write is True or v.to_write == 'once':

--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -98,10 +98,10 @@ class BaseParticleFile(ABC):
             self.var_names_once = []
             self.var_dtypes_once = []
             for v in self.particleset.collection.ptype.variables:
-                if v.to_write == 'once' and self.write_ondelete is False:
+                if v.to_write == 'once':
                     self.var_names_once += [v.name]
                     self.var_dtypes_once += [v.dtype]
-                elif v.to_write is True or v.to_write == 'once':
+                elif v.to_write is True:
                     self.var_names += [v.name]
                     self.var_dtypes += [v.dtype]
             if len(self.var_names_once) > 0:

--- a/parcels/particlefile/particlefileaos.py
+++ b/parcels/particlefile/particlefileaos.py
@@ -117,7 +117,7 @@ class ParticleFileAOS(BaseParticleFile):
         self.fmt_map = {np.float32: 'f4', np.float64: 'f8',
                         np.bool_: 'i1', np.int16: 'i2', np.int32: 'i4', np.int64: 'i8'}
         self.fill_value_map = {np.float32: np.nan, np.float64: np.nan,
-                               np.bool_: np.iinfo(np.bool_).max, np.int16: np.iinfo(np.int16).max,
+                               np.bool_: np.iinfo(np.int8).max, np.int16: np.iinfo(np.int16).max,
                                np.int32: np.iinfo(np.int32).max, np.int64: np.iinfo(np.int64).max}
 
         # Retrieve all temporary writing directories and sort them in numerical order

--- a/parcels/particlefile/particlefilesoa.py
+++ b/parcels/particlefile/particlefilesoa.py
@@ -55,8 +55,9 @@ class ParticleFileSOA(BaseParticleFile):
         Attention:
         For ParticleSet structures other than SoA, and structures where ID != index, this has to be overridden.
         """
-        attributes = ['name', 'var_names', 'var_names_once', 'time_origin', 'lonlatdepth_dtype',
-                      'file_list', 'file_list_once', 'parcels_mesh', 'metadata']
+        attributes = ['name', 'var_names', 'var_dtypes', 'var_names_once', 'var_dtypes_once',
+                      'time_origin', 'lonlatdepth_dtype', 'file_list', 'file_list_once',
+                      'parcels_mesh', 'metadata']
         return attributes
 
     def read_from_npy(self, file_list, n_timesteps, var):

--- a/parcels/particlefile/particlefilesoa.py
+++ b/parcels/particlefile/particlefilesoa.py
@@ -72,7 +72,7 @@ class ParticleFileSOA(BaseParticleFile):
         :param var: name of the variable to read
         """
         max_timesteps = max(n_timesteps.values()) if n_timesteps.keys() else 0
-        fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).min
+        fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).max
         if dtype[0] == 'f':
             data = fill_value * np.zeros((len(n_timesteps), max_timesteps), dtype=dtype)
         else:

--- a/parcels/particlefile/particlefilesoa.py
+++ b/parcels/particlefile/particlefilesoa.py
@@ -60,7 +60,7 @@ class ParticleFileSOA(BaseParticleFile):
                       'parcels_mesh', 'metadata']
         return attributes
 
-    def read_from_npy(self, file_list, n_timesteps, var):
+    def read_from_npy(self, file_list, n_timesteps, var, dtype):
         """
         Read NPY-files for one variable using a loop over all files.
 
@@ -72,7 +72,11 @@ class ParticleFileSOA(BaseParticleFile):
         :param var: name of the variable to read
         """
         max_timesteps = max(n_timesteps.values()) if n_timesteps.keys() else 0
-        data = np.nan * np.zeros((len(n_timesteps), max_timesteps))
+        fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).min
+        if dtype[0] == 'f':
+            data = fill_value * np.zeros((len(n_timesteps), max_timesteps), dtype=dtype)
+        else:
+            data = fill_value * np.ones((len(n_timesteps), max_timesteps), dtype=dtype)
         time_index = np.zeros(len(n_timesteps))
         id_index = {}
         count = 0
@@ -138,8 +142,8 @@ class ParticleFileSOA(BaseParticleFile):
                 if len(self.var_names_once) > 0:
                     global_file_list_once += pset_info_local['file_list_once']
 
-        for var in self.var_names:
-            data = self.read_from_npy(global_file_list, n_timesteps, var)
+        for var, dtype in zip(self.var_names, self.var_dtypes):
+            data = self.read_from_npy(global_file_list, n_timesteps, var, dtype)
             if var == self.var_names[0]:
                 self.open_netcdf_file(data.shape)
             varout = 'z' if var == 'depth' else var
@@ -150,6 +154,6 @@ class ParticleFileSOA(BaseParticleFile):
             for i in n_timesteps:
                 n_timesteps_once[i] = 1
             for var in self.var_names_once:
-                getattr(self, var)[:] = self.read_from_npy(global_file_list_once, n_timesteps_once, var)
+                getattr(self, var)[:] = self.read_from_npy(global_file_list_once, n_timesteps_once, var, dtype)
 
         self.close_netcdf_file()

--- a/parcels/particlefile/particlefilesoa.py
+++ b/parcels/particlefile/particlefilesoa.py
@@ -72,11 +72,8 @@ class ParticleFileSOA(BaseParticleFile):
         :param var: name of the variable to read
         """
         max_timesteps = max(n_timesteps.values()) if n_timesteps.keys() else 0
-        fill_value = np.nan if dtype[0] == 'f' else np.iinfo(np.dtype(dtype)).max
-        if dtype[0] == 'f':
-            data = fill_value * np.zeros((len(n_timesteps), max_timesteps), dtype=dtype)
-        else:
-            data = fill_value * np.ones((len(n_timesteps), max_timesteps), dtype=dtype)
+        fill_value = self.fill_value_map[dtype]
+        data = fill_value * np.ones((len(n_timesteps), max_timesteps), dtype=dtype)
         time_index = np.zeros(len(n_timesteps))
         id_index = {}
         count = 0
@@ -116,6 +113,13 @@ class ParticleFileSOA(BaseParticleFile):
             MPI.COMM_WORLD.Barrier()
             if MPI.COMM_WORLD.Get_rank() > 0:
                 return  # export only on threat 0
+
+        # Create dictionary to translate datatypes and fill_values
+        self.fmt_map = {np.float32: 'f4', np.float64: 'f8',
+                        np.bool_: 'i1', np.int16: 'i2', np.int32: 'i4', np.int64: 'i8'}
+        self.fill_value_map = {np.float32: np.nan, np.float64: np.nan,
+                               np.bool_: np.iinfo(np.int8).max, np.int16: np.iinfo(np.int16).max,
+                               np.int32: np.iinfo(np.int32).max, np.int64: np.iinfo(np.int64).max}
 
         # Retrieve all temporary writing directories and sort them in numerical order
         temp_names = sorted(glob(os.path.join("%s" % self.tempwritedir_base, "*")),


### PR DESCRIPTION
At present, during conversion to netcdf format, all variables are converted to float32, resulting in a loss of information in certain cases. This PR ensures that the correct dtype is used during netcdf export (and sets the fill value to the minimum possible value for ints).