### PR TITLE
Fixing bug to clarify reason why IOError thrown in FieldSet creation

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -284,7 +284,7 @@ class FieldSet(object):
             paths = sorted(glob(str(paths)))
         if len(paths) == 0:
             notfound_paths = filenames[var] if isinstance(filenames, dict) and var in filenames else filenames
-            raise IOError("FieldSet files not found: %s" % str(notfound_paths))
+            raise IOError("FieldSet files not found for variable %s: %s" % (var, str(notfound_paths)))
         for fp in paths:
             if not path.exists(fp):
                 raise IOError("FieldSet file not found: %s" % str(fp))


### PR DESCRIPTION
This PR improves the `IOError` message thrown when files are not found in `FieldSet` creation, by also printing which Variable the Error relates to