### PR TITLE
Extended netcdf export format dictionary to unsigned ints

### DIFF
--- a/parcels/particlefile/particlefileaos.py
+++ b/parcels/particlefile/particlefileaos.py
@@ -114,12 +114,14 @@ class ParticleFileAOS(BaseParticleFile):
                 return  # export only on threat 0
 
         # Create dictionary to translate datatypes and fill_values
-        self.fmt_map = {np.float32: 'f4', np.float64: 'f8',
-                        np.bool_: 'i1', np.int16: 'i2', np.int32: 'i4', np.int64: 'i8',
+        self.fmt_map = {np.float16: 'f2', np.float32: 'f4', np.float64: 'f8',
+                        np.bool_: 'i1', np.int8: 'i1', np.int16: 'i2',
+                        np.int32: 'i4', np.int64: 'i8', np.uint8: 'u1',
                         np.uint16: 'u2', np.uint32: 'u4', np.uint64: 'u8'}
-        self.fill_value_map = {np.float32: np.nan, np.float64: np.nan,
-                               np.bool_: np.iinfo(np.int8).max, np.int16: np.iinfo(np.int16).max,
-                               np.int32: np.iinfo(np.int32).max, np.int64: np.iinfo(np.int64).max,
+        self.fill_value_map = {np.float16: np.nan, np.float32: np.nan, np.float64: np.nan,
+                               np.bool_: np.iinfo(np.int8).max, np.int8: np.iinfo(np.int8).max,
+                               np.int16: np.iinfo(np.int16).max, np.int32: np.iinfo(np.int32).max,
+                               np.int64: np.iinfo(np.int64).max, np.uint8: np.iinfo(np.uint8).max,
                                np.uint16: np.iinfo(np.uint16).max, np.uint32: np.iinfo(np.uint32).max,
                                np.uint64: np.iinfo(np.uint64).max}
 

--- a/parcels/particlefile/particlefileaos.py
+++ b/parcels/particlefile/particlefileaos.py
@@ -115,10 +115,13 @@ class ParticleFileAOS(BaseParticleFile):
 
         # Create dictionary to translate datatypes and fill_values
         self.fmt_map = {np.float32: 'f4', np.float64: 'f8',
-                        np.bool_: 'i1', np.int16: 'i2', np.int32: 'i4', np.int64: 'i8'}
+                        np.bool_: 'i1', np.int16: 'i2', np.int32: 'i4', np.int64: 'i8',
+                        np.uint16: 'u2', np.uint32: 'u4', np.uint64: 'u8'}
         self.fill_value_map = {np.float32: np.nan, np.float64: np.nan,
                                np.bool_: np.iinfo(np.int8).max, np.int16: np.iinfo(np.int16).max,
-                               np.int32: np.iinfo(np.int32).max, np.int64: np.iinfo(np.int64).max}
+                               np.int32: np.iinfo(np.int32).max, np.int64: np.iinfo(np.int64).max,
+                               np.uint16: np.iinfo(np.uint16).max, np.uint32: np.iinfo(np.uint32).max,
+                               np.uint64: np.iinfo(np.uint64).max}
 
         # Retrieve all temporary writing directories and sort them in numerical order
         temp_names = sorted(glob(os.path.join("%s" % self.tempwritedir_base, "*")),

--- a/parcels/particlefile/particlefilesoa.py
+++ b/parcels/particlefile/particlefilesoa.py
@@ -116,10 +116,13 @@ class ParticleFileSOA(BaseParticleFile):
 
         # Create dictionary to translate datatypes and fill_values
         self.fmt_map = {np.float32: 'f4', np.float64: 'f8',
-                        np.bool_: 'i1', np.int16: 'i2', np.int32: 'i4', np.int64: 'i8'}
+                        np.bool_: 'i1', np.int16: 'i2', np.int32: 'i4', np.int64: 'i8',
+                        np.uint16: 'u2', np.uint32: 'u4', np.uint64: 'u8'}
         self.fill_value_map = {np.float32: np.nan, np.float64: np.nan,
                                np.bool_: np.iinfo(np.int8).max, np.int16: np.iinfo(np.int16).max,
-                               np.int32: np.iinfo(np.int32).max, np.int64: np.iinfo(np.int64).max}
+                               np.int32: np.iinfo(np.int32).max, np.int64: np.iinfo(np.int64).max,
+                               np.uint16: np.iinfo(np.uint16).max, np.uint32: np.iinfo(np.uint32).max,
+                               np.uint64: np.iinfo(np.uint64).max}
 
         # Retrieve all temporary writing directories and sort them in numerical order
         temp_names = sorted(glob(os.path.join("%s" % self.tempwritedir_base, "*")),

--- a/parcels/particlefile/particlefilesoa.py
+++ b/parcels/particlefile/particlefilesoa.py
@@ -115,12 +115,14 @@ class ParticleFileSOA(BaseParticleFile):
                 return  # export only on threat 0
 
         # Create dictionary to translate datatypes and fill_values
-        self.fmt_map = {np.float32: 'f4', np.float64: 'f8',
-                        np.bool_: 'i1', np.int16: 'i2', np.int32: 'i4', np.int64: 'i8',
+        self.fmt_map = {np.float16: 'f2', np.float32: 'f4', np.float64: 'f8',
+                        np.bool_: 'i1', np.int8: 'i1', np.int16: 'i2',
+                        np.int32: 'i4', np.int64: 'i8', np.uint8: 'u1',
                         np.uint16: 'u2', np.uint32: 'u4', np.uint64: 'u8'}
-        self.fill_value_map = {np.float32: np.nan, np.float64: np.nan,
-                               np.bool_: np.iinfo(np.int8).max, np.int16: np.iinfo(np.int16).max,
-                               np.int32: np.iinfo(np.int32).max, np.int64: np.iinfo(np.int64).max,
+        self.fill_value_map = {np.float16: np.nan, np.float32: np.nan, np.float64: np.nan,
+                               np.bool_: np.iinfo(np.int8).max, np.int8: np.iinfo(np.int8).max,
+                               np.int16: np.iinfo(np.int16).max, np.int32: np.iinfo(np.int32).max,
+                               np.int64: np.iinfo(np.int64).max, np.uint8: np.iinfo(np.uint8).max,
                                np.uint16: np.iinfo(np.uint16).max, np.uint32: np.iinfo(np.uint32).max,
                                np.uint64: np.iinfo(np.uint64).max}
 


### PR DESCRIPTION
The format dictionary we set up a while ago was missing unsigned integers + 8-bit integers, so I've just added those.