### PR TITLE
Support curvilinear MITgcm-like indexing

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -12,7 +12,6 @@ from parcels.field import SummedField
 from parcels.field import VectorField
 from parcels.grid import Grid
 from parcels.gridset import GridSet
-from parcels.grid import GridCode
 from parcels.tools.converters import TimeConverter, convert_xarray_time_units
 from parcels.tools.statuscodes import TimeExtrapolationError
 from parcels.tools.loggers import logger

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -211,10 +211,6 @@ class FieldSet(object):
             if U.gridindexingtype not in ['nemo', 'mitgcm', 'mom5', 'pop']:
                 raise ValueError("Field.gridindexing has to be one of 'nemo', 'mitgcm', 'mom5' or 'pop'")
 
-            if U.gridindexingtype == 'mitgcm' and U.grid.gtype in [GridCode.CurvilinearZGrid, GridCode.CurvilinearZGrid]:
-                raise NotImplementedError('Curvilinear Grids are not implemented for mitgcm-style grid indexing.'
-                                          'If you have a use-case for this, please let us know by filing an Issue on github')
-
             if V.gridindexingtype != U.gridindexingtype or (W and W.gridindexingtype != U.gridindexingtype):
                 raise ValueError('Not all velocity Fields have the same gridindexingtype')
 

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -634,59 +634,8 @@ def test_popgrid(pset_mode, mode, vert_discretisation, deferred_load):
 @pytest.mark.parametrize('pset_mode', pset_modes)
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 @pytest.mark.parametrize('gridindexingtype', ['mitgcm', 'nemo'])
-def test_cgrid_indexing(pset_mode, mode, gridindexingtype):
-    xdim, ydim = 151, 201
-    a = b = 20000  # domain size
-    lon = np.linspace(-a / 2, a / 2, xdim, dtype=np.float32)
-    lat = np.linspace(-b / 2, b / 2, ydim, dtype=np.float32)
-    dx, dy = lon[2] - lon[1], lat[2] - lat[1]
-    omega = 2 * np.pi / delta(days=1).total_seconds()
-
-    index_signs = {'nemo': -1, 'mitgcm': 1}
-    isign = index_signs[gridindexingtype]
-
-    def calc_r_phi(ln, lt):
-        return np.sqrt(ln ** 2 + lt ** 2), np.arctan2(ln, lt)
-
-    def calculate_UVR(lat, lon, dx, dy, omega):
-        U = np.zeros((lat.size, lon.size), dtype=np.float32)
-        V = np.zeros((lat.size, lon.size), dtype=np.float32)
-        R = np.zeros((lat.size, lon.size), dtype=np.float32)
-        for i in range(lon.size):
-            for j in range(lat.size):
-                r, phi = calc_r_phi(lon[i], lat[j])
-                R[j, i] = r
-                r, phi = calc_r_phi(lon[i] + isign * dx / 2, lat[j])
-                V[j, i] = -omega * r * np.sin(phi)
-                r, phi = calc_r_phi(lon[i], lat[j] + isign * dy / 2)
-                U[j, i] = omega * r * np.cos(phi)
-        return U, V, R
-
-    U, V, R = calculate_UVR(lat, lon, dx, dy, omega)
-    data = {'U': U, 'V': V, 'R': R}
-    dimensions = {'lon': lon, 'lat': lat}
-    fieldset = FieldSet.from_data(data, dimensions, mesh='flat', gridindexingtype=gridindexingtype)
-    fieldset.U.interp_method = 'cgrid_velocity'
-    fieldset.V.interp_method = 'cgrid_velocity'
-
-    def UpdateR(particle, fieldset, time):
-        particle.radius = fieldset.R[time, particle.depth, particle.lat, particle.lon]
-
-    class MyParticle(ptype[mode]):
-        radius = Variable('radius', dtype=np.float32, initial=0.)
-        radius_start = Variable('radius_start', dtype=np.float32, initial=fieldset.R)
-
-    pset = pset_type[pset_mode]['pset'](fieldset, pclass=MyParticle, lon=0, lat=4e3, time=0)
-
-    pset.execute(pset.Kernel(UpdateR) + AdvectionRK4,
-                 runtime=delta(hours=14), dt=delta(minutes=5))
-    assert np.allclose(pset.radius, pset.radius_start, atol=10)
-
-
-@pytest.mark.parametrize('pset_mode', pset_modes)
-@pytest.mark.parametrize('mode', ['scipy', 'jit'])
-@pytest.mark.parametrize('gridindexingtype', ['mitgcm', 'nemo'])
-def test_cgrid_indexing_curvilinear(pset_mode, mode, gridindexingtype):
+@pytest.mark.parametrize('coordtype', ['rectilinear', 'curvilinear'])
+def test_cgrid_indexing(pset_mode, mode, gridindexingtype, coordtype):
     xdim, ydim = 151, 201
     a = b = 20000  # domain size
     lon = np.linspace(-a / 2, a / 2, xdim, dtype=np.float32)
@@ -704,27 +653,46 @@ def test_cgrid_indexing_curvilinear(pset_mode, mode, gridindexingtype):
         rotated = np.einsum('ji, mni -> jmn', rotmat, np.dstack([lons, lats]))
         return rotated[0], rotated[1]
 
-    alpha = 15*np.pi/180
-    lons, lats = rotate_coords(lon, lat, alpha)
+    if coordtype == 'rectilinear':
+        alpha = 0
+    elif coordtype == 'curvilinear':
+        alpha = 15*np.pi/180
+        lon, lat = rotate_coords(lon, lat, alpha)
 
     def calc_r_phi(ln, lt):
         return np.sqrt(ln ** 2 + lt ** 2), np.arctan2(ln, lt)
 
-    def calculate_UVR(lats, lons, dx, dy, omega, alpha):
-        U = np.zeros(lats.shape, dtype=np.float32)
-        V = np.zeros(lats.shape, dtype=np.float32)
-        R = np.zeros(lats.shape, dtype=np.float32)
-        for i in range(lats.shape[1]):
-            for j in range(lats.shape[0]):
-                r, phi = calc_r_phi(lons[j, i], lats[j, i])
-                R[j, i] = r
-                r, phi = calc_r_phi(lons[j, i] + isign * (dx / 2) * np.cos(alpha), lats[j, i] - isign * (dx / 2) * np.sin(alpha))
-                V[j, i] = np.sin(alpha) * (omega * r * np.cos(phi)) + np.cos(alpha) * (-omega * r * np.sin(phi))
-                r, phi = calc_r_phi(lons[j, i] + isign * (dy / 2) * np.sin(alpha), lats[j, i] + isign * (dy / 2) * np.cos(alpha))
-                U[j, i] = np.cos(alpha) * (omega * r * np.cos(phi)) - np.sin(alpha) * (-omega * r * np.sin(phi))
-        return U, V, R
+    if coordtype == 'rectilinear':
+        def calculate_UVR(lat, lon, dx, dy, omega, alpha):
+            U = np.zeros((lat.size, lon.size), dtype=np.float32)
+            V = np.zeros((lat.size, lon.size), dtype=np.float32)
+            R = np.zeros((lat.size, lon.size), dtype=np.float32)
+            for i in range(lon.size):
+                for j in range(lat.size):
+                    r, phi = calc_r_phi(lon[i], lat[j])
+                    R[j, i] = r
+                    r, phi = calc_r_phi(lon[i] + isign * dx / 2, lat[j])
+                    V[j, i] = -omega * r * np.sin(phi)
+                    r, phi = calc_r_phi(lon[i], lat[j] + isign * dy / 2)
+                    U[j, i] = omega * r * np.cos(phi)
+            return U, V, R
+    elif coordtype == 'curvilinear':
+        def calculate_UVR(lat, lon, dx, dy, omega, alpha):
+            U = np.zeros(lat.shape, dtype=np.float32)
+            V = np.zeros(lat.shape, dtype=np.float32)
+            R = np.zeros(lat.shape, dtype=np.float32)
+            for i in range(lat.shape[1]):
+                for j in range(lat.shape[0]):
+                    r, phi = calc_r_phi(lon[j, i], lat[j, i])
+                    R[j, i] = r
+                    r, phi = calc_r_phi(lon[j, i] + isign * (dx / 2) * np.cos(alpha), lat[j, i] - isign * (dx / 2) * np.sin(alpha))
+                    V[j, i] = np.sin(alpha) * (omega * r * np.cos(phi)) + np.cos(alpha) * (-omega * r * np.sin(phi))
+                    r, phi = calc_r_phi(lon[j, i] + isign * (dy / 2) * np.sin(alpha), lat[j, i] + isign * (dy / 2) * np.cos(alpha))
+                    U[j, i] = np.cos(alpha) * (omega * r * np.cos(phi)) - np.sin(alpha) * (-omega * r * np.sin(phi))
+            return U, V, R
 
-    U, V, R = calculate_UVR(lats, lons, dx, dy, omega, alpha)
+    U, V, R = calculate_UVR(lat, lon, dx, dy, omega, alpha)
+
     data = {'U': U, 'V': V, 'R': R}
     dimensions = {'lon': lon, 'lat': lat}
     fieldset = FieldSet.from_data(data, dimensions, mesh='flat', gridindexingtype=gridindexingtype)

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -681,7 +681,8 @@ def test_cgrid_indexing(pset_mode, mode, gridindexingtype):
     pset.execute(pset.Kernel(UpdateR) + AdvectionRK4,
                  runtime=delta(hours=14), dt=delta(minutes=5))
     assert np.allclose(pset.radius, pset.radius_start, atol=10)
-    
+
+
 @pytest.mark.parametrize('pset_mode', pset_modes)
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 @pytest.mark.parametrize('gridindexingtype', ['mitgcm', 'nemo'])
@@ -695,17 +696,17 @@ def test_cgrid_indexing_curvilinear(pset_mode, mode, gridindexingtype):
 
     index_signs = {'nemo': -1, 'mitgcm': 1}
     isign = index_signs[gridindexingtype]
-    
+
     def rotate_coords(lon, lat, alpha=0):
-        rotmat = np.array([[np.cos(alpha),  np.sin(alpha)],
+        rotmat = np.array([[np.cos(alpha), np.sin(alpha)],
                            [-np.sin(alpha), np.cos(alpha)]])
         lons, lats = np.meshgrid(lon, lat)
         rotated = np.einsum('ji, mni -> jmn', rotmat, np.dstack([lons, lats]))
         return rotated[0], rotated[1]
-    
+
     alpha = 15*np.pi/180
     lons, lats = rotate_coords(lon, lat, alpha)
-    
+
     def calc_r_phi(ln, lt):
         return np.sqrt(ln ** 2 + lt ** 2), np.arctan2(ln, lt)
 
@@ -715,11 +716,11 @@ def test_cgrid_indexing_curvilinear(pset_mode, mode, gridindexingtype):
         R = np.zeros(lats.shape, dtype=np.float32)
         for i in range(lats.shape[1]):
             for j in range(lats.shape[0]):
-                r, phi = calc_r_phi(lons[j,i], lats[j,i])
+                r, phi = calc_r_phi(lons[j, i], lats[j, i])
                 R[j, i] = r
-                r, phi = calc_r_phi(lons[j,i] + isign * (dx / 2) * np.cos(alpha), lats[j,i] - isign * (dx / 2) * np.sin(alpha))
+                r, phi = calc_r_phi(lons[j, i] + isign * (dx / 2) * np.cos(alpha), lats[j, i] - isign * (dx / 2) * np.sin(alpha))
                 V[j, i] = np.sin(alpha) * (omega * r * np.cos(phi)) + np.cos(alpha) * (-omega * r * np.sin(phi))
-                r, phi = calc_r_phi(lons[j,i] + isign * (dy / 2) * np.sin(alpha), lats[j,i] + isign * (dy / 2) * np.cos(alpha))
+                r, phi = calc_r_phi(lons[j, i] + isign * (dy / 2) * np.sin(alpha), lats[j, i] + isign * (dy / 2) * np.cos(alpha))
                 U[j, i] = np.cos(alpha) * (omega * r * np.cos(phi)) - np.sin(alpha) * (-omega * r * np.sin(phi))
         return U, V, R
 


### PR DESCRIPTION
Currently, MITgcm/ROMS-like indexing is only supported for rectilinear grids, although the code may already be able to work with curvilinear grids too. In this PR we:
- [x] Turn off the error that checks whether `gridindexingtype = 'mitgcm'`
- [x] Add a unit test for curvilinear MITgcm-like indexing.