### PR TITLE
compress temporary *.npy files with gzip to give *.npy.gz files

### DIFF
--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -5,7 +5,7 @@ import shutil
 import string
 from abc import ABC
 from abc import abstractmethod
-import gzip 
+import gzip
 
 import numpy as np
 

--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -5,6 +5,7 @@ import shutil
 import string
 from abc import ABC
 from abc import abstractmethod
+import gzip 
 
 import numpy as np
 
@@ -235,14 +236,14 @@ class BaseParticleFile(ABC):
             os.makedirs(self.tempwritedir)
 
         if len(data_dict) > 0:
-            tmpfilename = os.path.join(self.tempwritedir, str(len(self.file_list)) + ".npy")
-            with open(tmpfilename, 'wb') as f:
+            tmpfilename = os.path.join(self.tempwritedir, str(len(self.file_list)) + ".npy.gz")
+            with gzip.open(tmpfilename, 'wb') as f:
                 np.save(f, data_dict)
             self.file_list.append(tmpfilename)
 
         if len(data_dict_once) > 0:
-            tmpfilename = os.path.join(self.tempwritedir, str(len(self.file_list)) + '_once.npy')
-            with open(tmpfilename, 'wb') as f:
+            tmpfilename = os.path.join(self.tempwritedir, str(len(self.file_list)) + '_once.npy.gz')
+            with gzip.open(tmpfilename, 'wb') as f:
                 np.save(f, data_dict_once)
             self.file_list_once.append(tmpfilename)
 

--- a/parcels/particlefile/particlefileaos.py
+++ b/parcels/particlefile/particlefileaos.py
@@ -86,7 +86,7 @@ class ParticleFileAOS(BaseParticleFile):
         # loop over all files
         for npyfile in file_list:
             try:
-                with gzip.open(npyfile,'b') as f:
+                with gzip.open(npyfile, 'b') as f:
                     data_dict = np.load(f, allow_pickle=True).item()
             except NameError:
                 raise RuntimeError('Cannot combine npy files into netcdf file because your ParticleFile is '
@@ -140,7 +140,7 @@ class ParticleFileAOS(BaseParticleFile):
             if os.path.exists(tempwritedir):
                 pset_info_local = np.load(os.path.join(tempwritedir, 'pset_info.npy'), allow_pickle=True).item()
                 for npyfile in pset_info_local['file_list']:
-                    with gzip.open(npyfile,'b') as f:
+                    with gzip.open(npyfile, 'b') as f:
                         tmp_dict = np.load(f, allow_pickle=True).item()
                     for i in tmp_dict['id']:
                         if i in n_timesteps:

--- a/parcels/particlefile/particlefileaos.py
+++ b/parcels/particlefile/particlefileaos.py
@@ -3,6 +3,7 @@ import os
 from glob import glob
 import numpy as np
 import xarray as xr
+import gzip
 
 try:
     from mpi4py import MPI
@@ -85,7 +86,8 @@ class ParticleFileAOS(BaseParticleFile):
         # loop over all files
         for npyfile in file_list:
             try:
-                data_dict = np.load(npyfile, allow_pickle=True).item()
+                with gzip.open(npyfile,'b') as f:
+                    data_dict = np.load(f, allow_pickle=True).item()
             except NameError:
                 raise RuntimeError('Cannot combine npy files into netcdf file because your ParticleFile is '
                                    'still open on interpreter shutdown.\nYou can use '
@@ -138,7 +140,8 @@ class ParticleFileAOS(BaseParticleFile):
             if os.path.exists(tempwritedir):
                 pset_info_local = np.load(os.path.join(tempwritedir, 'pset_info.npy'), allow_pickle=True).item()
                 for npyfile in pset_info_local['file_list']:
-                    tmp_dict = np.load(npyfile, allow_pickle=True).item()
+                    with gzip.open(npyfile,'b') as f:
+                        tmp_dict = np.load(f, allow_pickle=True).item()
                     for i in tmp_dict['id']:
                         if i in n_timesteps:
                             n_timesteps[i] += 1

--- a/parcels/particlefile/particlefileaos.py
+++ b/parcels/particlefile/particlefileaos.py
@@ -86,7 +86,7 @@ class ParticleFileAOS(BaseParticleFile):
         # loop over all files
         for npyfile in file_list:
             try:
-                with gzip.open(npyfile, 'b') as f:
+                with gzip.open(npyfile, 'rb') as f:
                     data_dict = np.load(f, allow_pickle=True).item()
             except NameError:
                 raise RuntimeError('Cannot combine npy files into netcdf file because your ParticleFile is '
@@ -140,7 +140,7 @@ class ParticleFileAOS(BaseParticleFile):
             if os.path.exists(tempwritedir):
                 pset_info_local = np.load(os.path.join(tempwritedir, 'pset_info.npy'), allow_pickle=True).item()
                 for npyfile in pset_info_local['file_list']:
-                    with gzip.open(npyfile, 'b') as f:
+                    with gzip.open(npyfile, 'rb') as f:
                         tmp_dict = np.load(f, allow_pickle=True).item()
                     for i in tmp_dict['id']:
                         if i in n_timesteps:

--- a/parcels/particlefile/particlefilesoa.py
+++ b/parcels/particlefile/particlefilesoa.py
@@ -3,6 +3,7 @@ import os
 from glob import glob
 import numpy as np
 import xarray as xr
+import gzip
 
 try:
     from mpi4py import MPI
@@ -85,7 +86,8 @@ class ParticleFileSOA(BaseParticleFile):
         # loop over all files
         for npyfile in file_list:
             try:
-                data_dict = np.load(npyfile, allow_pickle=True).item()
+                with gzip.open(npyfile,'rb') as f:
+                    data_dict = np.load(f, allow_pickle=True).item()
             except NameError:
                 raise RuntimeError('Cannot combine npy files into netcdf file because your ParticleFile is '
                                    'still open on interpreter shutdown.\nYou can use '
@@ -139,7 +141,8 @@ class ParticleFileSOA(BaseParticleFile):
             if os.path.exists(tempwritedir):
                 pset_info_local = np.load(os.path.join(tempwritedir, 'pset_info.npy'), allow_pickle=True).item()
                 for npyfile in pset_info_local['file_list']:
-                    tmp_dict = np.load(npyfile, allow_pickle=True).item()
+                    with gzip.open(npyfile,'rb') as f:
+                        tmp_dict = np.load(f, allow_pickle=True).item()
                     for i in tmp_dict['id']:
                         if i in n_timesteps:
                             n_timesteps[i] += 1

--- a/parcels/particlefile/particlefilesoa.py
+++ b/parcels/particlefile/particlefilesoa.py
@@ -86,7 +86,7 @@ class ParticleFileSOA(BaseParticleFile):
         # loop over all files
         for npyfile in file_list:
             try:
-                with gzip.open(npyfile,'rb') as f:
+                with gzip.open(npyfile, 'rb') as f:
                     data_dict = np.load(f, allow_pickle=True).item()
             except NameError:
                 raise RuntimeError('Cannot combine npy files into netcdf file because your ParticleFile is '
@@ -141,7 +141,7 @@ class ParticleFileSOA(BaseParticleFile):
             if os.path.exists(tempwritedir):
                 pset_info_local = np.load(os.path.join(tempwritedir, 'pset_info.npy'), allow_pickle=True).item()
                 for npyfile in pset_info_local['file_list']:
-                    with gzip.open(npyfile,'rb') as f:
+                    with gzip.open(npyfile, 'rb') as f:
                         tmp_dict = np.load(f, allow_pickle=True).item()
                     for i in tmp_dict['id']:
                         if i in n_timesteps:


### PR DESCRIPTION
This pull request compresses the *.npy temporary files with the gzip module. There should be no user facing changes, unless they monitor the out-* directory to see how far along things have gotten. In that case they need to use gzip.open() to open the *.npy.gz files. 

Any code that processes the temporary files in the out-* directories will need to be modified, following the pattern in this pull request. 

