### PR TITLE
Changing environment dependencies to matplotlib-base

### DIFF
--- a/environment_py3_linux.yml
+++ b/environment_py3_linux.yml
@@ -14,7 +14,7 @@ dependencies:
   - mpi4py>=3.0.1
   - mpich>=3.2.1
   - jupyter
-  - matplotlib>=2.0.2
+  - matplotlib-base>=2.0.2
   - netcdf4>=1.1.9
   - numpy>=1.9.1
   - py>=1.4.27

--- a/environment_py3_osx.yml
+++ b/environment_py3_osx.yml
@@ -14,7 +14,7 @@ dependencies:
   - mpi4py>=3.0.1
   - mpich>=3.2.1
   - jupyter
-  - matplotlib>=2.0.2
+  - matplotlib-base>=2.0.2
   - netcdf4>=1.1.9
   - numpy>=1.9.1
   - py>=1.4.27

--- a/environment_py3_win.yml
+++ b/environment_py3_win.yml
@@ -11,7 +11,7 @@ dependencies:
   - git
   - jupyter
   - m2w64-toolchain
-  - matplotlib>=2.0.2
+  - matplotlib-base>=2.0.2
   - netcdf4>=1.1.9
   - numpy>=1.9.1
   - py>=1.4.27


### PR DESCRIPTION
This addresses #1173; at least in the parcels repo; now also needs to be updated in the [conda-forge/parcels-feedstock](https://github.com/conda-forge/parcels-feedstock) repo. 

I have confirmed that animations in e.g. the [tutorial_output](https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_output.ipynb) notebook still work also with matplotlib-base (so don't depend on e.g. `qt`)