### PR TITLE
Fixing sampling of fieldset.UV

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1656,7 +1656,7 @@ class VectorField(object):
             else:
                 return True
 
-    def spatial_slip_interpolation(self, ti, z, y, x, time, particle=None):
+    def spatial_slip_interpolation(self, ti, z, y, x, time, particle=None, applyConversion=True):
         (xsi, eta, zeta, xi, yi, zi) = self.U.search_indices(x, y, z, ti, time, particle=particle)
         di = ti if self.U.grid.zdim == 1 else zi  # general third dimension
 
@@ -1719,23 +1719,25 @@ class VectorField(object):
                     f_u = f_u / (1 - zeta)
                     f_v = f_v / (1 - zeta)
 
-        u = f_u * self.U.eval(time, z, y, x, particle)
-        v = f_v * self.V.eval(time, z, y, x, particle)
+        u = f_u * self.U.eval(time, z, y, x, particle, applyConversion=applyConversion)
+        v = f_v * self.V.eval(time, z, y, x, particle, applyConversion=applyConversion)
         if self.vector_type == '3D':
-            w = f_w * self.W.eval(time, z, y, x, particle)
+            w = f_w * self.W.eval(time, z, y, x, particle, applyConversion=applyConversion)
             return u, v, w
         else:
             return u, v
 
-    def eval(self, time, z, y, x, particle=None):
+    def eval(self, time, z, y, x, particle=None, applyConversion=True):
         if self.U.interp_method not in ['cgrid_velocity', 'partialslip', 'freeslip']:
             u = self.U.eval(time, z, y, x, particle=particle, applyConversion=False)
             v = self.V.eval(time, z, y, x, particle=particle, applyConversion=False)
-            u = self.U.units.to_target(u, x, y, z)
-            v = self.V.units.to_target(v, x, y, z)
+            if applyConversion:
+                u = self.U.units.to_target(u, x, y, z)
+                v = self.V.units.to_target(v, x, y, z)
             if self.vector_type == '3D':
                 w = self.W.eval(time, z, y, x, particle=particle, applyConversion=False)
-                w = self.W.units.to_target(w, x, y, z)
+                if applyConversion:
+                    w = self.W.units.to_target(w, x, y, z)
                 return (u, v, w)
             else:
                 return (u, v)
@@ -1750,12 +1752,12 @@ class VectorField(object):
                 t0 = grid.time[ti]
                 t1 = grid.time[ti + 1]
                 if self.vector_type == '3D':
-                    (u0, v0, w0) = interp[self.U.interp_method]['3D'](ti, z, y, x, time, particle=particle)
-                    (u1, v1, w1) = interp[self.U.interp_method]['3D'](ti + 1, z, y, x, time, particle=particle)
+                    (u0, v0, w0) = interp[self.U.interp_method]['3D'](ti, z, y, x, time, particle=particle, applyConversion=applyConversion)
+                    (u1, v1, w1) = interp[self.U.interp_method]['3D'](ti + 1, z, y, x, time, particle=particle, applyConversion=applyConversion)
                     w = w0 + (w1 - w0) * ((time - t0) / (t1 - t0))
                 else:
-                    (u0, v0) = interp[self.U.interp_method]['2D'](ti, z, y, x, time, particle=particle)
-                    (u1, v1) = interp[self.U.interp_method]['2D'](ti + 1, z, y, x, time, particle=particle)
+                    (u0, v0) = interp[self.U.interp_method]['2D'](ti, z, y, x, time, particle=particle, applyConversion=applyConversion)
+                    (u1, v1) = interp[self.U.interp_method]['2D'](ti + 1, z, y, x, time, particle=particle, applyConversion=applyConversion)
                 u = u0 + (u1 - u0) * ((time - t0) / (t1 - t0))
                 v = v0 + (v1 - v0) * ((time - t0) / (t1 - t0))
                 if self.vector_type == '3D':
@@ -1767,9 +1769,9 @@ class VectorField(object):
                 # of the defined time range or if we have hit an
                 # exact value in the time array.
                 if self.vector_type == '3D':
-                    return interp[self.U.interp_method]['3D'](ti, z, y, x, grid.time[ti], particle=particle)
+                    return interp[self.U.interp_method]['3D'](ti, z, y, x, grid.time[ti], particle=particle, applyConversion=applyConversion)
                 else:
-                    return interp[self.U.interp_method]['2D'](ti, z, y, x, grid.time[ti], particle=particle)
+                    return interp[self.U.interp_method]['2D'](ti, z, y, x, grid.time[ti], particle=particle, applyConversion=applyConversion)
 
     def __getitem__(self, key):
         if _isParticle(key):

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -35,8 +35,7 @@ def k_sample_uv_fixture():
 
 def k_sample_uv_noconvert():
     def SampleUVNoConvert(particle, fieldset, time):
-        particle.u = fieldset.U.eval(time, particle.depth, particle.lat, particle.lon, applyConversion=False)
-        particle.v = fieldset.V.eval(time, particle.depth, particle.lat, particle.lon, applyConversion=False)
+        (particle.u, particle.v) = fieldset.UV.eval(time, particle.depth, particle.lat, particle.lon, applyConversion=False)
     return SampleUVNoConvert
 
 


### PR DESCRIPTION
As reported in #1172, there was a bug in the sampling of velocities. When `fieldset.U` and `fieldset.V` are sampled independently, they return the velocities in `i` and `j` index, respectively; which on a curvilinear grid is not per se the same as the velocities in longitude and latitude direction. Furthermore, boundary conditions such as free slip and partial slip are not taken into account either when sampling `fieldset.U` and `fieldset.V` separately. 

The _correct_ way to sample a velocity is
```python
(particle.u, particle.v) = fieldset.UV[time, particle.depth, particle.lat, particle.lon]
```
Or, when wanting to avoid unit conversion
```python
(particle.u, particle.v) = fieldset.UV.eval(time, particle.depth, particle.lat, particle.lon, applyConversion=False)
```

This PR:
- [x] implements support for the second `UV.eval()` option (the first was already implemented, and is used by the default advection kernels).
- [ ] updates the sampling and unitconversion tutorials to explain that `fieldset.UV` should be sampled when requesting velocities at a location
- [ ] implements a warning when users still sample `fieldset.U` or `fieldset.V` separately (as there are hardly any use cases)