### PR TITLE
Projection is never None at this point of the code and the if-clause is ill defined

### DIFF
--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -48,7 +48,7 @@ def plotparticles(particles, with_particles=True, show_time=None, field=None, do
             return  # creating axes was not possible
         ax.set_title('Particles' + parsetimestr(particles.fieldset.U.grid.time_origin, show_time))
         latN, latS, lonE, lonW = parsedomain(domain, particles.fieldset.U)
-        if cartopy is None or projection is None:
+        if cartopy is None:
             if domain is not None:
                 if isinstance(particles.fieldset.U.grid, CurvilinearGrid):
                     ax.set_xlim(particles.fieldset.U.grid.lon[latS, lonW], particles.fieldset.U.grid.lon[latN, lonE])


### PR DESCRIPTION
If a user sets projection to None the `create_parcelsfig_axis` will create one with PlateCaree, making this if-clause ill defined and it will fail in some cases with the cryptic `ValueError: A LinearRing must have at least 3 coordinate tuples` that will confuse newcomers.

I'm not sure if this is the best solution but it does fix an issue some users I'm helping are experiencing. For now they are defining a projection explicitly to avoid setting the x-axis with the wrong values.