### PR TITLE
Fixing the `sh: None: command not found warning`

### DIFF
--- a/parcels/compilation/codecompiler.py
+++ b/parcels/compilation/codecompiler.py
@@ -97,7 +97,6 @@ class GNU_parameters(Compiler_parameters):
             mpicc = mpicc_env
             mpicc = "mpicc" if mpicc is None and os._exists("mpicc") else None
             mpicc = "mpiCC" if mpicc is None and os._exists("mpiCC") else None
-            os.system("%s --version" % (mpicc))
         self._compiler = mpicc if MPI and mpicc is not None else cc_env if cc_env is not None else "gcc"
         opt_flags = ['-g', '-O3']
         arch_flag = ['-m64' if calcsize("P") == 8 else '-m32']


### PR DESCRIPTION
Removing a stray debug line that resulted in a `sh: None: command not found` warning on every compilation. This fixes #1054