### PR TITLE
Adding hint for export CC=gcc in compilation error message

### DIFF
--- a/parcels/compilation/codecompiler.py
+++ b/parcels/compilation/codecompiler.py
@@ -237,7 +237,10 @@ Compilation command: %s
 Source/Destination file: %s
 Log file: %s
 
-Log output: %s""" % (" ".join(cmd), src, logfile.name, logfile2.read())
+Log output: %s
+If you are on macOS, it might help to type 'export CC=gcc'
+
+""" % (" ".join(cmd), src, logfile.name, logfile2.read())
                 raise RuntimeError(err)
         return True
 


### PR DESCRIPTION
Many users on macOS experience an error like
```
subprocess.CalledProcessError: Command '['x86_64-apple-darwin13.4.0-clang', '-Wall', '-fPIC', '-std=gnu11', '-I/Users/erik/Codes/parcels/parcels/include', '-I.', '-g', '-O3', '-DDOUBLE_COORD_VARIABLES', '-m64', '-o', '/var/folders/s5/gxtkk3c12yqgd7hkt1b_s0vr0000gq/T/parcels-503/lib4ee78d013308407857c72e449de0d7e5_0.so', '/var/folders/s5/gxtkk3c12yqgd7hkt1b_s0vr0000gq/T/parcels-503/4ee78d013308407857c72e449de0d7e5_0.c', '-shared', '-lm', '-m64']' returned non-zero exit status 1.
```
This can be fixed by issuing `export CC=gcc`. While this is noted in the installation instructions at https://oceanparcels.org/#installing, it may help to also give this hint in the error itself.