### PR TITLE
Fixing numpy deprecationwarning in timeslices concatenation

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -245,9 +245,8 @@ class Field(object):
                     ftime = filebuffer.time
                     timeslices.append(ftime)
                     dataFiles.append([fname] * len(ftime))
-            timeslices = np.array(timeslices)
-            time = np.concatenate(timeslices)
-            dataFiles = np.concatenate(np.array(dataFiles))
+            time = np.concatenate(timeslices).ravel()
+            dataFiles = np.concatenate(dataFiles).ravel()
         if time.size == 1 and time[0] is None:
             time[0] = 0
         time_origin = TimeConverter(time[0])


### PR DESCRIPTION
This commit fixes the `VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated.` warning