### PR TITLE
Using f-string in logger info for plotting

### DIFF
--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -96,7 +96,7 @@ def plotparticles(particles, with_particles=True, show_time=None, field=None, do
         plt.show()
     else:
         plt.savefig(savefile)
-        logger.info('Plot saved to ' + savefile + '.png')
+        logger.info(f'Plot saved to {savefile}')
         plt.close()
 
 


### PR DESCRIPTION
To support more types for savefile path (e.g. PathLike-objects); as suggested in #1221