### PR TITLE
`ParcelsRandom` functions sensitive to how they are imported

### DIFF
--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -312,7 +312,7 @@ def test_random_import_direct(fieldset, pset_mode, mode, npart=10):
     Tests whether importing the random functions used within parcels
     works within kernels via direct and submodule based imports.
 
-    This function tests the direct import    
+    This function tests the direct import.
     """
     from parcels.rng import random
 
@@ -332,7 +332,7 @@ def test_random_import_submodule(fieldset, pset_mode, mode, npart=10):
     Tests whether importing the random functions used within parcels
     works within kernels via direct and submodule based imports.
 
-    This function tests the submodule import    
+    This function tests the submodule import.
     """
     import parcels.rng as ParcelsRandom
 

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -315,6 +315,7 @@ def test_random_import_direct(fieldset, pset_mode, mode, npart=10):
     This function tests the direct import    
     """
     from parcels.rng import random
+
     def random_kern(particle, fieldset, time):
         rand = random()
         particle.lon += 0.001 * rand
@@ -334,6 +335,7 @@ def test_random_import_submodule(fieldset, pset_mode, mode, npart=10):
     This function tests the submodule import    
     """
     import parcels.rng as ParcelsRandom
+
     def random_kern(particle, fieldset, time):
         rand = ParcelsRandom.random()
         particle.lon += 0.001 * rand

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -302,3 +302,41 @@ def test_execution_keep_cfiles_and_nocompilation_warnings(pset_mode, fieldset, d
         assert path.exists(cfile)
         with open(logfile) as f:
             assert 'warning' not in f.read(), 'Compilation WARNING in log file'
+
+
+@pytest.mark.parametrize('pset_mode', pset_modes)
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_random_import_direct(fieldset, pset_mode, mode, npart=10):
+    """
+    Stemming from issue https://github.com/OceanParcels/parcels/issues/1224
+    Tests whether importing the random functions used within parcels
+    works within kernels via direct and submodule based imports.
+
+    This function tests the direct import    
+    """
+    from parcels.rng import random
+    def random_kern(particle, fieldset, time):
+        rand = random()
+        particle.lon += 0.001 * rand
+
+    pset = pset_type[pset_mode]['pset'](fieldset, pclass=ptype[mode], lon=[0.], lat=[0.])
+    pset.execute(pset.Kernel(AdvectionRK4) + pset.Kernel(random_kern), endtime=1., dt=1.)
+
+
+@pytest.mark.parametrize('pset_mode', pset_modes)
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_random_import_submodule(fieldset, pset_mode, mode, npart=10):
+    """
+    Stemming from issue https://github.com/OceanParcels/parcels/issues/1224
+    Tests whether importing the random functions used within parcels
+    works within kernels via direct and submodule based imports.
+
+    This function tests the submodule import    
+    """
+    import parcels.rng as ParcelsRandom
+    def random_kern(particle, fieldset, time):
+        rand = ParcelsRandom.random()
+        particle.lon += 0.001 * rand
+
+    pset = pset_type[pset_mode]['pset'](fieldset, pclass=ptype[mode], lon=[0.], lat=[0.])
+    pset.execute(pset.Kernel(AdvectionRK4) + pset.Kernel(random_kern), endtime=1., dt=1.)


### PR DESCRIPTION
As mentioned in #1224, functions within `parcels.rng` are sensitive to errors when used within kernels depending on how they are imported.
i.e.
The following code **does not work**
```py
from parcels.rng import random
...
def random_kern(particle, fieldset, time):
    rand = random()
    particle.lon += 0.001 * rand
```
while the following does:
```py
import parcels.rng as ParcelsRandom
...
def random_kern(particle, fieldset, time):
    rand = ParcelsRandom.random()
    particle.lon += 0.001 * rand
```

This PR adds two tests which target this issue (which I am not capable of understanding/solving myself).

If this is indended functionality, or not worth fixing, it would be good to update documentation or place a suitable warning if a user tries to import the random functions in the wrong way.

Fixes #1224