### PR TITLE
Throwing explicit error in codegenerator when using random() in JIT Kernel

### DIFF
--- a/parcels/compilation/codegenerator.py
+++ b/parcels/compilation/codegenerator.py
@@ -319,6 +319,10 @@ class IntrinsicTransformer(ast.NodeTransformer):
                 raise NotImplementedError("Cannot convert numpy functions in kernels to C-code.\n"
                                           "Either use functions from the math library or run Parcels in Scipy mode.\n"
                                           "For more information, see http://oceanparcels.org/faq.html#kernelwriting")
+            elif node.value.id in ['random']:
+                raise NotImplementedError("Cannot convert random functions in kernels to C-code.\n"
+                                          "Use `import parcels.rng as ParcelsRandom` and then ParcelsRandom.random(), ParcelsRandom.uniform() etc.\n"
+                                          "For more information, see http://oceanparcels.org/faq.html#kernelwriting")
             else:
                 raise NotImplementedError("Cannot convert '%s' used in kernel to C-code" % node.value.id)
 


### PR DESCRIPTION
As discussed in #1224