### PR TITLE
Equal distribution of particles to MPI processors

### DIFF
--- a/parcels/collection/collectionaos.py
+++ b/parcels/collection/collectionaos.py
@@ -101,9 +101,10 @@ class ParticleCollectionAOS(ParticleCollection):
                 if partitions is not False:
                     if self._pu_indicators is None:
                         if mpi_rank == 0:
-                            coords = np.vstack((lon, lat)).transpose()
-                            kmeans = KMeans(n_clusters=mpi_size, random_state=0).fit(coords)
-                            self._pu_indicators = kmeans.labels_
+                            # distribute particles equally among MPI processors
+                            labels = np.linspace(0, mpi_size, lon.size, endpoint=False)
+                            labels = np.floor(labels)
+                            self._pu_indicators = labels
                         else:
                             self._pu_indicators = None
                         self._pu_indicators = mpi_comm.bcast(self._pu_indicators, root=0)

--- a/parcels/collection/collectionaos.py
+++ b/parcels/collection/collectionaos.py
@@ -3,6 +3,7 @@ from operator import attrgetter  # NOQA
 
 from ctypes import c_void_p
 
+import copy
 import numpy as np
 
 from parcels.collection.collections import ParticleCollection
@@ -101,10 +102,19 @@ class ParticleCollectionAOS(ParticleCollection):
                 if partitions is not False:
                     if self._pu_indicators is None:
                         if mpi_rank == 0:
-                            # distribute particles equally among MPI processors
+                            coords = np.vstack((lon, lat)).transpose()
+                            kmeans = KMeans(n_clusters=mpi_size, random_state=0).fit(coords)
                             labels = np.linspace(0, mpi_size, lon.size, endpoint=False)
                             labels = np.floor(labels)
-                            self._pu_indicators = labels
+                            reorderedCoords = copy.copy(labels)
+                            for i in range(0, len(kmeans.cluster_centers_)):
+                                clusterCentre = kmeans.cluster_centers_[i]
+                                distances = map(lambda point: ((point[0]-clusterCentre[0])**2 + (point[1]-clusterCentre[1])**2), coords)
+                                sortedDistanceIdxs = np.argsort(list(distances))
+                                numberToChoose = sum(labels == i)
+                                reorderedCoords[sortedDistanceIdxs[0:numberToChoose]] = i
+                                coords[sortedDistanceIdxs[0:numberToChoose],:] = float('inf')
+                            self._pu_indicators = reorderedCoords
                         else:
                             self._pu_indicators = None
                         self._pu_indicators = mpi_comm.bcast(self._pu_indicators, root=0)

--- a/parcels/collection/collectionsoa.py
+++ b/parcels/collection/collectionsoa.py
@@ -102,10 +102,10 @@ class ParticleCollectionSOA(ParticleCollection):
                 if partitions is not False:
                     if (self._pu_indicators is None) or (len(self._pu_indicators) != len(lon)):
                         if mpi_rank == 0:
-                            coords = np.vstack((lon, lat)).transpose()
-                            kmeans = KMeans(n_clusters=mpi_size, random_state=0).fit(coords)
-                            # New comment
-                            self._pu_indicators = kmeans.labels_
+                            # distribute particles equally among MPI processors
+                            labels = np.linspace(0, mpi_size, lon.size, endpoint=False)
+                            labels = np.floor(labels)
+                            self._pu_indicators = labels
                         else:
                             self._pu_indicators = None
                         self._pu_indicators = mpi_comm.bcast(self._pu_indicators, root=0)

--- a/parcels/collection/collectionsoa.py
+++ b/parcels/collection/collectionsoa.py
@@ -104,6 +104,7 @@ class ParticleCollectionSOA(ParticleCollection):
                         if mpi_rank == 0:
                             coords = np.vstack((lon, lat)).transpose()
                             kmeans = KMeans(n_clusters=mpi_size, random_state=0).fit(coords)
+                            # New comment
                             self._pu_indicators = kmeans.labels_
                         else:
                             self._pu_indicators = None


### PR DESCRIPTION
When running simulations in MPI mode involving the repeated release of small quantities of particles (e.g. 100 particles across 10 MPI processors), we would occasionally receive the error 'Cannot initialise with fewer particles than MPI processors'. The cause of this appeared to be the way that K-means was distributing the particles among the MPI processors. Specifically, K-means does not return clusters of a fixed or minimum size, thus it is highly possible that some MPI processors will be allocated fewer than the minimum number of required particles, especially if the number of particles is small and the number of MPI processors approaches the maximum for a given number of particles (e.g. 10 MPI processors is the maximum for 100 particles, as 100 particles / 10 processors = 10 particles per processor). To overcome this, we equally distribute the available particles among the MPI processors using Numpy's linspace method. We create a linearly spaced array that is the same length as the number particles. The array contains decimals ranging from 0 to the number of MPI processors, and that array is then rounded down so that the values represent integer indices to MPI processors. As before, this change requires that the user has requested at least the minimum required number of MPI processors, but it ensures that the minimum number is always sufficient.

This change has only been tested for collectionsoa.py but not collectionaos.py.