### PR TITLE
Fixing 'fatal: not a git repository' warning

### DIFF
--- a/parcels/_version.py
+++ b/parcels/_version.py
@@ -1,6 +1,6 @@
 import subprocess
 import os
 try:
-    version = subprocess.check_output(['git', '-C', os.path.dirname(__file__), 'describe', '--tags']).decode('ascii').strip()
+    version = subprocess.check_output(['git', '-C', os.path.dirname(__file__), 'describe', '--tags'], stderr=subprocess.PIPE).decode('ascii').strip()
 except:
     from parcels._version_setup import version as version  # noqa


### PR DESCRIPTION
This fixes #1250 by piping the standard error when Parcels is installed over conda (and hence is not a git repository)