### PR TITLE
Updating fieldfilebuffer to not not unravel lonlat-indices when not provided

### DIFF
--- a/parcels/fieldfilebuffer.py
+++ b/parcels/fieldfilebuffer.py
@@ -79,7 +79,6 @@ class NetcdfFileBuffer(_FileBuffer):
     def lonlat(self):
         lon = self.dataset[self.dimensions['lon']]
         lat = self.dataset[self.dimensions['lat']]
-        print('self.nolonlatindices', self.nolonlatindices)
         if self.nolonlatindices:
             if len(lon.shape) < 3:
                 lon_subset = np.array(lon)


### PR DESCRIPTION
As suggestion by @CKehl in #1009, there is a potential speed improvement in the fieldfilebuffer when no `indices` are provided for lon and lat; by avoiding the unraveling of these indices