### PR TITLE
Weekly (and manual) test running

### DIFF
--- a/.github/workflows/ci-workflow-integrationtests.yml
+++ b/.github/workflows/ci-workflow-integrationtests.yml
@@ -1,5 +1,6 @@
 name: integration-tests
 on:
+  workflow_dispatch:
   pull_request:
   schedule:
     - cron: "0 7 * * 1" # Run every Monday at 7:00 UTC

--- a/.github/workflows/ci-workflow-integrationtests.yml
+++ b/.github/workflows/ci-workflow-integrationtests.yml
@@ -1,6 +1,8 @@
 name: integration-tests
 on:
   pull_request:
+  schedule:
+    - cron: "0 7 * * 1" # Run every Monday at 7:00 UTC
 jobs:
   test_macOS:
     name: Integration testing on macOS python latest

--- a/.github/workflows/ci-workflow-unittests.yml
+++ b/.github/workflows/ci-workflow-unittests.yml
@@ -1,6 +1,8 @@
 name: unit-tests
 on:
   pull_request:
+  schedule:
+    - cron: "0 7 * * 1" # Run every Monday at 7:00 UTC
 jobs:
   pep8-linter:
     name: Testing PEP8 linter

--- a/.github/workflows/ci-workflow-unittests.yml
+++ b/.github/workflows/ci-workflow-unittests.yml
@@ -1,5 +1,6 @@
 name: unit-tests
 on:
+  workflow_dispatch:
   pull_request:
   schedule:
     - cron: "0 7 * * 1" # Run every Monday at 7:00 UTC


### PR DESCRIPTION
Update test workflows to also run weekly, allowing for the picking up of any bugs introduced by updates in dependencies (related to #1274).