### PR TITLE
Fixing the vonmises distribution tests in test_diffusion

### DIFF
--- a/.github/workflows/ci-workflow-integrationtests.yml
+++ b/.github/workflows/ci-workflow-integrationtests.yml
@@ -39,6 +39,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@master
+      - name: Configure pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+        with:
+          minimum-size: 8GB
       - name: Test Windows
         env:
           OS_NAME: win

--- a/.github/workflows/ci-workflow-unittests.yml
+++ b/.github/workflows/ci-workflow-unittests.yml
@@ -50,9 +50,8 @@ jobs:
       - uses: actions/checkout@master
       - name: Configure pagefile
         uses: al-cheb/configure-pagefile-action@v1.2
-      - name: Set up pagefile
-        run: |
-          (Get-CimInstance Win32_PageFileUsage).AllocatedBaseSize      - name: Test Windows
+        with:
+          minimum-size: 8GB
       - name: Test Windows
         env:
           OS_NAME: win

--- a/.github/workflows/ci-workflow-unittests.yml
+++ b/.github/workflows/ci-workflow-unittests.yml
@@ -48,6 +48,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@master
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
       - name: Test Windows
         env:
           OS_NAME: win

--- a/.github/workflows/ci-workflow-unittests.yml
+++ b/.github/workflows/ci-workflow-unittests.yml
@@ -48,10 +48,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set Swap Space
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 10
+      - name: Configure pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+      - name: Set up pagefile
+        run: |
+          (Get-CimInstance Win32_PageFileUsage).AllocatedBaseSize      - name: Test Windows
       - name: Test Windows
         env:
           OS_NAME: win

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -143,6 +143,7 @@ def test_randomvonmises(mode, pset_mode, mu, kappa, npart=10000):
     angles = np.array([p.angle for p in pset])
 
     assert np.allclose(np.mean(angles), mu, atol=.1)
-    scipy_mises = stats.vonmises.rvs(kappa, loc=mu, size=10000)
-    assert np.allclose(np.mean(angles), np.mean(scipy_mises), atol=.1)
-    assert np.allclose(np.std(angles), np.std(scipy_mises), atol=.1)
+    vonmises_mean = stats.vonmises.mean(kappa=kappa, loc=mu)
+    assert np.allclose(np.mean(angles), vonmises_mean, atol=.1)
+    vonmises_var = stats.vonmises.var(kappa=kappa, loc=mu)
+    assert np.allclose(np.var(angles), vonmises_var, atol=.1)


### PR DESCRIPTION
Because of a change to the vonmises distribution implementation in scipy v1.10.0. This fixes #1274 