### PR TITLE
Separate dev dependencies

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           environment-file: environment_py3_${{ matrix.os-short }}.yml
           environment-name: py3_parcels
+      - run: pip install -r requirements-dev.txt
       - name: Integration test
         run: |
           parcels_get_examples examples

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           environment-file: environment_py3_${{ matrix.os-short }}.yml
           environment-name: py3_parcels
-      - run: pip install -r requirements-dev.txt
+      - run: conda env update -f requirements-dev.yml
       - name: Integration test
         run: |
           parcels_get_examples examples

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.8
-      - run: pip install -r requirements-dev.txt
+      - run: pip install flake8
       - name: flake8
         run: |
           python -m flake8 parcels

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,10 +9,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
-      - name: Python setup
-        run: |
-          pip install wheel
-          pip install flake8
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+      - run: pip install -r requirements-dev.txt
       - name: flake8
         run: |
           python -m flake8 parcels

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           environment-file: environment_py3_${{ matrix.os-short }}.yml
           environment-name: py3_parcels
+      - run: pip install -r requirements-dev.txt
       - name: Unit test
         run: |
           pytest -v -s --html=${{ matrix.os }}_unit_test_report.html --self-contained-html tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           environment-file: environment_py3_${{ matrix.os-short }}.yml
           environment-name: py3_parcels
-      - run: pip install -r requirements-dev.txt
+      - run: conda env update -f requirements-dev.yml
       - name: Unit test
         run: |
           pytest -v -s --html=${{ matrix.os }}_unit_test_report.html --self-contained-html tests

--- a/environment_py3_linux.yml
+++ b/environment_py3_linux.yml
@@ -24,8 +24,6 @@ dependencies:
   - xarray>=0.10.8
   - cftime>=1.3.1
   - dask>=2.0
-  - pytest
-  - pytest-html
   - nbval
   - scikit-learn
   - pykdtree

--- a/environment_py3_osx.yml
+++ b/environment_py3_osx.yml
@@ -24,8 +24,6 @@ dependencies:
   - xarray>=0.10.8
   - dask>=2.0
   - cftime>=1.3.1
-  - pytest
-  - pytest-html
   - nbval
   - scikit-learn
   - pykdtree

--- a/environment_py3_win.yml
+++ b/environment_py3_win.yml
@@ -22,8 +22,6 @@ dependencies:
   - dask<=2022.9.0
   - cftime>=1.3.1
   - ipykernel
-  - pytest
-  - pytest-html
   - nbval
   - pykdtree
   - zarr

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-html
+flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,0 @@
-pytest
-pytest-html
-flake8

--- a/requirements-dev.yml
+++ b/requirements-dev.yml
@@ -1,0 +1,7 @@
+# To be run after environment installation and activation
+# with `conda env update -f requirements-dev.yml`
+dependencies:
+  - pytest
+  - pytest-html
+  - flake8
+  - sphinx<6


### PR DESCRIPTION
I am looking to include a variety of dev dependencies to improve the quality of this codebase. Eg:

- sphinx (+ related packages)
- pre-commit
- coverage
...

It would be good to isolate these dependencies so that they are not shipped to individual users' installation.