### PR TITLE
Running MPI test without writing Stommel hydrodynamic fields

### DIFF
--- a/parcels/examples/example_stommel.py
+++ b/parcels/examples/example_stommel.py
@@ -166,12 +166,14 @@ Example of particle advection in the steady-state solution of the Stommel equati
                    help='max age of the particles (after which particles are deleted)')
     p.add_argument('-psm', '--pset_mode', choices=('soa', 'aos'), default='soa',
                    help='max age of the particles (after which particles are deleted)')
+    p.add_argument('-wf', '--write_fields', default=True,
+                   help='Write the hydrodynamic fields to NetCDF')
     args = p.parse_args()
 
     timer.args.stop()
     timer.stommel = timer.Timer('Stommel', parent=timer.root)
     stommel_example(args.particles, mode=args.mode, verbose=args.verbose, method=method[args.method],
-                    outfile=args.outfile, repeatdt=args.repeatdt, maxage=args.maxage)
+                    outfile=args.outfile, repeatdt=args.repeatdt, maxage=args.maxage, write_fields=args.write_fields)
     timer.stommel.stop()
     timer.root.stop()
     timer.root.print_tree()

--- a/tests/test_mpirun.py
+++ b/tests/test_mpirun.py
@@ -21,8 +21,8 @@ def test_mpi_run(pset_mode, tmpdir, repeatdt, maxage, nump):
         outputMPI = tmpdir.join('StommelMPI')
         outputNoMPI = tmpdir.join('StommelNoMPI.zarr')
 
-        system('mpirun -np 2 python %s -p %d -o %s -r %d -a %d -psm %s' % (stommel_file, nump, outputMPI, repeatdt, maxage, pset_mode))
-        system('python %s -p %d -o %s -r %d -a %d -psm %s' % (stommel_file, nump, outputNoMPI, repeatdt, maxage, pset_mode))
+        system('mpirun -np 2 python %s -p %d -o %s -r %d -a %d -psm %s -wf False' % (stommel_file, nump, outputMPI, repeatdt, maxage, pset_mode))
+        system('python %s -p %d -o %s -r %d -a %d -psm %s -wf False' % (stommel_file, nump, outputNoMPI, repeatdt, maxage, pset_mode))
 
         files = glob(path.join(outputMPI, "proc*"))
         ds1 = xr.concat([xr.open_zarr(f) for f in files], dim='trajectory',


### PR DESCRIPTION
Adding an argument to example_stommel so that fields do not need to be written in test_MPI. This solves #1281