### PR TITLE
Removing redundant code for manual Field.advancetime

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1368,18 +1368,6 @@ class Field(object):
             raise ValueError("data_concatenate is used for computeTimeChunk, with tindex in [0, 1]")
         return data
 
-    def advancetime(self, field_new, advanceForward):
-        if isinstance(self.data) is not isinstance(field_new):
-            logger.warning("[Field.advancetime] New field data and persistent field data have different types - time advance not possible.")
-            return
-        lib = np if isinstance(self.data, np.ndarray) else da
-        if advanceForward == 1:  # forward in time, so appending at end
-            self.data = lib.concatenate((self.data[1:, :, :], field_new.data[:, :, :]), 0)
-            self.time = self.grid.time
-        else:  # backward in time, so prepending at start
-            self.data = lib.concatenate((field_new.data[:, :, :], self.data[:-1, :, :]), 0)
-            self.time = self.grid.time
-
     def computeTimeChunk(self, data, tindex):
         g = self.grid
         timestamp = self.timestamps

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1002,33 +1002,6 @@ class FieldSet(object):
                 if isinstance(v, Field) and (v.name != 'U') and (v.name != 'V'):
                     v.write(filename)
 
-    def advancetime(self, fieldset_new):
-        """Replace oldest time on FieldSet with new FieldSet
-
-        :param fieldset_new: FieldSet snapshot with which the oldest time has to be replaced"""
-
-        logger.warning_once("Fieldset.advancetime() is deprecated.\n \
-                             Parcels deals automatically with loading only 2 time steps simultaneously\
-                             such that the total allocated memory remains limited.")
-
-        advance = 0
-        for gnew in fieldset_new.gridset.grids:
-            gnew.advanced = False
-
-        for fnew in fieldset_new.get_fields():
-            if isinstance(fnew, VectorField):
-                continue
-            f = getattr(self, fnew.name)
-            gnew = fnew.grid
-            if not gnew.advanced:
-                g = f.grid
-                advance2 = g.advancetime(gnew)
-                if advance2*advance < 0:
-                    raise RuntimeError("Some Fields of the Fieldset are advanced forward and other backward")
-                advance = advance2
-                gnew.advanced = True
-            f.advancetime(fnew, advance == 1)
-
     def computeTimeChunk(self, time, dt):
         """Load a chunk of three data time steps into the FieldSet.
         This is used when FieldSet uses data imported from netcdf,

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -143,21 +143,6 @@ class Grid(object):
             return self.lon_remapping.particle_to_target(lon)
         return lon
 
-    def advancetime(self, grid_new):
-        assert isinstance(grid_new.time_origin, type(self.time_origin)), 'time_origin of new and old grids must be either both None or both a date'
-        if self.time_origin:
-            grid_new.time = grid_new.time + self.time_origin.reltime(grid_new.time_origin)
-        if len(grid_new.time) != 1:
-            raise RuntimeError('New FieldSet needs to have only one snapshot')
-        if grid_new.time > self.time[-1]:  # forward in time, so appending at end
-            self.time = np.concatenate((self.time[1:], grid_new.time))
-            return 1
-        elif grid_new.time < self.time[0]:  # backward in time, so prepending at start
-            self.time = np.concatenate((grid_new.time, self.time[:-1]))
-            return -1
-        else:
-            raise RuntimeError("Time of field_new in Field.advancetime() overlaps with times in old Field")
-
     def check_zonal_periodic(self):
         if self.zonal_periodic or self.mesh == 'flat' or self.lon.size == 1:
             return


### PR DESCRIPTION
This PR cleans some code that was deprecated years ago and can go now (noticed thanks to the [codecov.io report](https://app.codecov.io/gh/OceanParcels/parcels))