### PR TITLE
Fixing a bug in 2D spicy linear_invdist_land interpolation

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -932,7 +932,7 @@ class Field(object):
                                 return 0
                             else:
                                 return self.data[ti, yi+j, xi+i]
-                        elif land[i][j] == 0:
+                        elif land[j][i] == 0:
                             val += self.data[ti, yi+j, xi+i] / distance
                             w_sum += 1 / distance
                 return val / w_sum
@@ -981,7 +981,7 @@ class Field(object):
                                 if land[k][j][i] == 1:  # index search led us directly onto land
                                     return 0
                                 else:
-                                    return self.data[ti, zi+i, yi+j, xi+k]
+                                    return self.data[ti, zi+k, yi+j, xi+i]
                             elif land[k][j][i] == 0:
                                 val += self.data[ti, zi+k, yi+j, xi+i] / distance
                                 w_sum += 1 / distance

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -234,14 +234,20 @@ def test_nearest_neighbour_interpolation3D(pset_mode, mode, k_sample_p, npart=81
 
 @pytest.mark.parametrize('pset_mode', pset_modes)
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
+@pytest.mark.parametrize('withDepth', [True, False])
 @pytest.mark.parametrize('arrtype', ['ones', 'rand'])
-def test_inversedistance_nearland(pset_mode, mode, arrtype, k_sample_p, npart=81):
-    dims = (4, 4, 6)
-    P = np.random.rand(dims[0], dims[1], dims[2])+2 if arrtype == 'rand' else np.ones(dims, dtype=np.float32)
-    P[1, 1:2, 1:6] = np.nan  # setting some values to land (NaN)
-    dimensions = {'lon': np.linspace(0., 1., dims[2], dtype=np.float32),
-                  'lat': np.linspace(0., 1., dims[1], dtype=np.float32),
-                  'depth': np.linspace(0., 1., dims[0], dtype=np.float32)}
+def test_inversedistance_nearland(pset_mode, mode, withDepth, arrtype, k_sample_p, npart=81):
+    dims = (4, 4, 6) if withDepth else (4, 6)
+    dimensions = {'lon': np.linspace(0., 1., dims[-1], dtype=np.float32),
+                  'lat': np.linspace(0., 1., dims[-2], dtype=np.float32)}
+    if withDepth:
+        dimensions['depth'] = np.linspace(0., 1., dims[0], dtype=np.float32)
+        P = np.random.rand(dims[0], dims[1], dims[2])+2 if arrtype == 'rand' else np.ones(dims, dtype=np.float32)
+        P[1, 1:2, 1:6] = np.nan  # setting some values to land (NaN)
+    else:
+        P = np.random.rand(dims[0], dims[1])+2 if arrtype == 'rand' else np.ones(dims, dtype=np.float32)
+        P[1:2, 1:6] = np.nan  # setting some values to land (NaN)
+
     data = {'U': np.zeros(dims, dtype=np.float32),
             'V': np.zeros(dims, dtype=np.float32),
             'P': P}
@@ -249,12 +255,12 @@ def test_inversedistance_nearland(pset_mode, mode, arrtype, k_sample_p, npart=81
     fieldset.P.interp_method = 'linear_invdist_land_tracer'
 
     xv, yv = np.meshgrid(np.linspace(0.1, 0.9, int(np.sqrt(npart))), np.linspace(0.1, 0.9, int(np.sqrt(npart))))
-    # combine a pset at 0m with pset at 1m, as meshgrid does not do 3D
     pset = pset_type[pset_mode]['pset'](fieldset, pclass=pclass(mode), lon=xv.flatten(), lat=yv.flatten(),
                                         depth=np.zeros(npart))
-    pset2 = pset_type[pset_mode]['pset'](fieldset, pclass=pclass(mode), lon=xv.flatten(), lat=yv.flatten(),
-                                         depth=np.ones(npart))
-    pset.add(pset2)
+    if withDepth:
+        pset2 = pset_type[pset_mode]['pset'](fieldset, pclass=pclass(mode), lon=xv.flatten(), lat=yv.flatten(),
+                                             depth=np.ones(npart))
+        pset.add(pset2)
     pset.execute(k_sample_p, endtime=1, dt=1)
     if arrtype == 'rand':
         assert np.all((pset.p > 2) & (pset.p < 3))


### PR DESCRIPTION
While increasing codecoverage, I found a bug in the 2D version of linear_invdist_land interpolation in spy mode (only the 3D case was tested, and that worked). This PR cherry-picks the commit that fixes it into its own PR