### PR TITLE
isort support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,8 @@ repos:
     rev: '6.0.0'
     hooks:
     -   id: flake8
+-   repo: https://github.com/pycqa/isort
+    rev: 5.11.5
+    hooks:
+    -   id: isort
+        name: isort (python)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/environment_py3_linux.yml
+++ b/environment_py3_linux.yml
@@ -27,6 +27,9 @@ dependencies:
   - pykdtree
   - zarr
 
+  # Formatting
+  - isort
+
   # Testing
   - pytest
   - pytest-html

--- a/environment_py3_osx.yml
+++ b/environment_py3_osx.yml
@@ -27,6 +27,9 @@ dependencies:
   - pykdtree
   - zarr
 
+  # Formatting
+  - isort
+
   # Testing
   - pytest
   - pytest-html

--- a/environment_py3_win.yml
+++ b/environment_py3_win.yml
@@ -24,6 +24,9 @@ dependencies:
   - pykdtree
   - zarr
 
+  # Formatting
+  - isort
+
   # Testing
   - pytest
   - pytest-html

--- a/parcels/__init__.py
+++ b/parcels/__init__.py
@@ -1,19 +1,19 @@
 from ._version import version
+
 __version__ = version
 
-from parcels.fieldset import *  # noqa
-from parcels.particle import *  # noqa
-from parcels.collection import *  # noqa
-from parcels.particleset import *  # noqa
-from parcels.particlefile import *  # noqa
-from parcels.field import *  # noqa
-from parcels.particleset import *  # noqa
-from parcels.kernel import *  # noqa
-from parcels.interaction import *  # noqa
-from parcels.application_kernels import *  # noqa
 import parcels.rng as ParcelsRandom  # noqa
+from parcels.application_kernels import *  # noqa
+from parcels.collection import *  # noqa
 from parcels.compilation import *  # noqa
-from parcels.scripts import *  # noqa
-from parcels.gridset import *  # noqa
+from parcels.field import *  # noqa
+from parcels.fieldset import *  # noqa
 from parcels.grid import *  # noqa
+from parcels.gridset import *  # noqa
+from parcels.interaction import *  # noqa
+from parcels.kernel import *  # noqa
+from parcels.particle import *  # noqa
+from parcels.particlefile import *  # noqa
+from parcels.particleset import *  # noqa
+from parcels.scripts import *  # noqa
 from parcels.tools import *  # noqa

--- a/parcels/_version.py
+++ b/parcels/_version.py
@@ -1,5 +1,6 @@
-import subprocess
 import os
+import subprocess
+
 try:
     version = subprocess.check_output(['git', '-C', os.path.dirname(__file__), 'describe', '--tags'], stderr=subprocess.PIPE).decode('ascii').strip()
 except:

--- a/parcels/application_kernels/TEOSseawaterdensity.py
+++ b/parcels/application_kernels/TEOSseawaterdensity.py
@@ -1,7 +1,6 @@
 """Collection of pre-built sea water density kernels"""
 import math
 
-
 __all__ = ['PolyTEOS10_bsq']
 
 

--- a/parcels/application_kernels/advection.py
+++ b/parcels/application_kernels/advection.py
@@ -3,7 +3,6 @@ import math
 
 from parcels.tools.statuscodes import OperationCode
 
-
 __all__ = ['AdvectionRK4', 'AdvectionEE', 'AdvectionRK45', 'AdvectionRK4_3D',
            'AdvectionAnalytical']
 
@@ -110,6 +109,7 @@ def AdvectionAnalytical(particle, fieldset, time):
     Note that the time-dependent scheme is currently implemented with 'intermediate timesteps'
     (default 10 per model timestep) and not yet with the full analytical time integration"""
     import numpy as np
+
     import parcels.tools.interpolation_utils as i_u
 
     tol = 1e-10

--- a/parcels/application_kernels/advectiondiffusion.py
+++ b/parcels/application_kernels/advectiondiffusion.py
@@ -5,7 +5,6 @@ import math
 
 import parcels.rng as ParcelsRandom
 
-
 __all__ = ['DiffusionUniformKh', 'AdvectionDiffusionM1', 'AdvectionDiffusionEM', ]
 
 

--- a/parcels/application_kernels/interaction.py
+++ b/parcels/application_kernels/interaction.py
@@ -3,7 +3,6 @@ import numpy as np
 
 from parcels.tools.statuscodes import OperationCode, StateCode
 
-
 __all__ = ['AsymmetricAttraction', 'NearestNeighborWithinRange',
            'MergeWithNearestNeighbor']
 

--- a/parcels/collection/__init__.py
+++ b/parcels/collection/__init__.py
@@ -1,4 +1,4 @@
-from .collections import *  # noqa: F401
-from .iterators import *  # noqa: F401
 from .collectionaos import *  # noqa: F401
+from .collections import *  # noqa: F401
 from .collectionsoa import *  # noqa: F401
+from .iterators import *  # noqa: F401

--- a/parcels/collection/collectionaos.py
+++ b/parcels/collection/collectionaos.py
@@ -1,15 +1,16 @@
-from operator import attrgetter  # NOQA
-
 from ctypes import c_void_p
+from operator import attrgetter  # NOQA
 
 import numpy as np
 
 from parcels.collection.collections import ParticleCollection
-from parcels.collection.iterators import BaseParticleAccessor
-from parcels.collection.iterators import BaseParticleCollectionIterator
-from parcels.collection.iterators import BaseParticleCollectionIterable
-from parcels.particle import ScipyParticle, JITParticle  # noqa
+from parcels.collection.iterators import (
+    BaseParticleAccessor,
+    BaseParticleCollectionIterable,
+    BaseParticleCollectionIterator,
+)
 from parcels.field import Field
+from parcels.particle import JITParticle, ScipyParticle  # noqa
 from parcels.tools.converters import convert_to_flat_array
 from parcels.tools.loggers import logger
 from parcels.tools.statuscodes import NotTestedError

--- a/parcels/collection/collections.py
+++ b/parcels/collection/collections.py
@@ -1,9 +1,10 @@
+from abc import ABC, abstractmethod
+
 import numpy as np
-from abc import ABC
-from abc import abstractmethod
+
+from parcels.particle import ScipyParticle
 
 from .iterators import BaseParticleAccessor
-from parcels.particle import ScipyParticle
 
 """
 Author: Dr. Christian Kehl

--- a/parcels/collection/collectionsoa.py
+++ b/parcels/collection/collectionsoa.py
@@ -1,14 +1,17 @@
-from operator import attrgetter
-from ctypes import Structure, POINTER
 from bisect import bisect_left
+from ctypes import POINTER, Structure
+from operator import attrgetter
 
 import numpy as np
 
 from parcels.collection.collections import ParticleCollection
-from parcels.collection.iterators import BaseParticleAccessor
-from parcels.collection.iterators import BaseParticleCollectionIterator, BaseParticleCollectionIterable
-from parcels.particle import ScipyParticle, JITParticle  # noqa
+from parcels.collection.iterators import (
+    BaseParticleAccessor,
+    BaseParticleCollectionIterable,
+    BaseParticleCollectionIterator,
+)
 from parcels.field import Field
+from parcels.particle import JITParticle, ScipyParticle  # noqa
 from parcels.tools.converters import convert_to_flat_array
 from parcels.tools.loggers import logger
 from parcels.tools.statuscodes import NotTestedError

--- a/parcels/collection/iterators.py
+++ b/parcels/collection/iterators.py
@@ -1,5 +1,5 @@
-from abc import ABC
-from abc import abstractmethod
+from abc import ABC, abstractmethod
+
 from parcels.tools.statuscodes import OperationCode, StateCode
 
 

--- a/parcels/compilation/__init__.py
+++ b/parcels/compilation/__init__.py
@@ -1,2 +1,2 @@
-from .codegenerator import *  # noqa
 from .codecompiler import *  # noqa
+from .codegenerator import *  # noqa

--- a/parcels/compilation/codegenerator.py
+++ b/parcels/compilation/codegenerator.py
@@ -1,18 +1,14 @@
 import ast
-from abc import ABC
-from abc import abstractmethod
 import collections
 import math
-import numpy as np
 import random
+from abc import ABC, abstractmethod
 from copy import copy
 
 import cgen as c
+import numpy as np
 
-from parcels.field import Field
-from parcels.field import NestedField
-from parcels.field import SummedField
-from parcels.field import VectorField
+from parcels.field import Field, NestedField, SummedField, VectorField
 from parcels.grid import Grid
 from parcels.particle import JITParticle
 from parcels.tools.loggers import logger

--- a/parcels/examples/example_brownian.py
+++ b/parcels/examples/example_brownian.py
@@ -3,13 +3,15 @@ from datetime import timedelta as delta
 import numpy as np
 import pytest
 
-from parcels import DiffusionUniformKh
-from parcels import Field
-from parcels import FieldSet
-from parcels import JITParticle
-from parcels import ParticleSet
-from parcels import ParcelsRandom
-from parcels import ScipyParticle
+from parcels import (
+    DiffusionUniformKh,
+    Field,
+    FieldSet,
+    JITParticle,
+    ParcelsRandom,
+    ParticleSet,
+    ScipyParticle,
+)
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 

--- a/parcels/examples/example_dask_chunk_OCMs.py
+++ b/parcels/examples/example_dask_chunk_OCMs.py
@@ -3,18 +3,20 @@ from datetime import timedelta as delta
 from glob import glob
 from os import path
 
+import dask
 import numpy as np
 import pytest
-import dask
 
-from parcels import AdvectionRK4
-from parcels import Field
-from parcels import FieldSet
-from parcels import JITParticle
-from parcels import ParticleFile
-from parcels import ParticleSet
-from parcels import ScipyParticle
-from parcels import Variable
+from parcels import (
+    AdvectionRK4,
+    Field,
+    FieldSet,
+    JITParticle,
+    ParticleFile,
+    ParticleSet,
+    ScipyParticle,
+    Variable,
+)
 from parcels.tools.statuscodes import DaskChunkingError
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/parcels/examples/example_decaying_moving_eddy.py
+++ b/parcels/examples/example_decaying_moving_eddy.py
@@ -3,11 +3,7 @@ from datetime import timedelta as delta
 import numpy as np
 import pytest
 
-from parcels import AdvectionRK4
-from parcels import FieldSet
-from parcels import JITParticle
-from parcels import ParticleSet
-from parcels import ScipyParticle
+from parcels import AdvectionRK4, FieldSet, JITParticle, ParticleSet, ScipyParticle
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 

--- a/parcels/examples/example_globcurrent.py
+++ b/parcels/examples/example_globcurrent.py
@@ -6,16 +6,17 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from parcels import AdvectionRK4
-from parcels import ErrorCode
-from parcels import Field
-from parcels import FieldSet
-from parcels import JITParticle
-from parcels import TimeExtrapolationError
-from parcels import ParticleSet
-from parcels import ScipyParticle
-from parcels import Variable
-
+from parcels import (
+    AdvectionRK4,
+    ErrorCode,
+    Field,
+    FieldSet,
+    JITParticle,
+    ParticleSet,
+    ScipyParticle,
+    TimeExtrapolationError,
+    Variable,
+)
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 

--- a/parcels/examples/example_mitgcm.py
+++ b/parcels/examples/example_mitgcm.py
@@ -3,6 +3,7 @@ from os import path
 
 import numpy as np
 import xarray as xr
+
 from parcels import (
     AdvectionRK4,
     FieldSet,

--- a/parcels/examples/example_moving_eddies.py
+++ b/parcels/examples/example_moving_eddies.py
@@ -7,14 +7,15 @@ from os import path
 import numpy as np
 import pytest
 
-from parcels import AdvectionEE
-from parcels import AdvectionRK4
-from parcels import AdvectionRK45
-from parcels import FieldSet
-from parcels import JITParticle
-from parcels import ParticleSet
-from parcels import ScipyParticle
-
+from parcels import (
+    AdvectionEE,
+    AdvectionRK4,
+    AdvectionRK45,
+    FieldSet,
+    JITParticle,
+    ParticleSet,
+    ScipyParticle,
+)
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 method = {'RK4': AdvectionRK4, 'EE': AdvectionEE, 'RK45': AdvectionRK45}

--- a/parcels/examples/example_nemo_curvilinear.py
+++ b/parcels/examples/example_nemo_curvilinear.py
@@ -6,12 +6,15 @@ from os import path
 import numpy as np
 import pytest
 
-from parcels import AdvectionRK4, AdvectionAnalytical
-from parcels import FieldSet
-from parcels import JITParticle
-from parcels import ParticleFile
-from parcels import ParticleSet
-from parcels import ScipyParticle
+from parcels import (
+    AdvectionAnalytical,
+    AdvectionRK4,
+    FieldSet,
+    JITParticle,
+    ParticleFile,
+    ParticleSet,
+    ScipyParticle,
+)
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 advection = {'RK4': AdvectionRK4, 'AA': AdvectionAnalytical}
@@ -56,9 +59,9 @@ def run_nemo_curvilinear(mode, outfile, advtype='RK4'):
 
 
 def make_plot(trajfile):
-    import xarray as xr
-    import matplotlib.pyplot as plt
     import cartopy
+    import matplotlib.pyplot as plt
+    import xarray as xr
 
     class ParticleData(object):
         def __init__(self):

--- a/parcels/examples/example_ofam.py
+++ b/parcels/examples/example_ofam.py
@@ -6,12 +6,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from parcels import AdvectionRK4
-from parcels import FieldSet
-from parcels import JITParticle
-from parcels import ParticleSet
-from parcels import ScipyParticle
-
+from parcels import AdvectionRK4, FieldSet, JITParticle, ParticleSet, ScipyParticle
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 

--- a/parcels/examples/example_peninsula.py
+++ b/parcels/examples/example_peninsula.py
@@ -6,16 +6,17 @@ from datetime import timedelta as delta
 import numpy as np
 import pytest
 
-from parcels import AdvectionEE
-from parcels import AdvectionRK4
-from parcels import AdvectionRK45
-from parcels import AdvectionAnalytical
-from parcels import FieldSet
-from parcels import JITParticle
-from parcels import ParticleSet
-from parcels import ScipyParticle
-from parcels import Variable
-
+from parcels import (
+    AdvectionAnalytical,
+    AdvectionEE,
+    AdvectionRK4,
+    AdvectionRK45,
+    FieldSet,
+    JITParticle,
+    ParticleSet,
+    ScipyParticle,
+    Variable,
+)
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 method = {'RK4': AdvectionRK4, 'EE': AdvectionEE, 'RK45': AdvectionRK45}

--- a/parcels/examples/example_radial_rotation.py
+++ b/parcels/examples/example_radial_rotation.py
@@ -4,11 +4,7 @@ from datetime import timedelta as delta
 import numpy as np
 import pytest
 
-from parcels import AdvectionRK4
-from parcels import FieldSet
-from parcels import JITParticle
-from parcels import ParticleSet
-from parcels import ScipyParticle
+from parcels import AdvectionRK4, FieldSet, JITParticle, ParticleSet, ScipyParticle
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 

--- a/parcels/examples/example_recursive_errorhandling.py
+++ b/parcels/examples/example_recursive_errorhandling.py
@@ -1,12 +1,14 @@
 import numpy as np
 import pytest
 
-from parcels import ErrorCode
-from parcels import FieldSet
-from parcels import JITParticle
-from parcels import ParticleSet
-from parcels import ParcelsRandom
-from parcels import ScipyParticle
+from parcels import (
+    ErrorCode,
+    FieldSet,
+    JITParticle,
+    ParcelsRandom,
+    ParticleSet,
+    ScipyParticle,
+)
 
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
 

--- a/parcels/examples/example_stommel.py
+++ b/parcels/examples/example_stommel.py
@@ -5,16 +5,22 @@ from datetime import timedelta as delta
 import numpy as np
 import pytest
 
-from parcels import AdvectionEE
-from parcels import AdvectionRK4
-from parcels import AdvectionRK45
-from parcels import FieldSet
-from parcels import JITParticle
-from parcels import ScipyParticle
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
-from parcels import timer
-from parcels import Variable
+from parcels import (  # noqa
+    AdvectionEE,
+    AdvectionRK4,
+    AdvectionRK45,
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    ScipyParticle,
+    Variable,
+    timer,
+)
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1,34 +1,36 @@
 import collections
 import datetime
 import math
-from ctypes import c_float
-from ctypes import c_int
-from ctypes import POINTER
-from ctypes import pointer
-from ctypes import Structure
+from ctypes import POINTER, Structure, c_float, c_int, pointer
+from pathlib import Path
 
 import dask.array as da
 import numpy as np
 import xarray as xr
-from pathlib import Path
 
 import parcels.tools.interpolation_utils as i_u
-from .fieldfilebuffer import (NetcdfFileBuffer, DeferredNetcdfFileBuffer,
-                              DaskFileBuffer, DeferredDaskFileBuffer)
-from .grid import CGrid
-from .grid import Grid
-from .grid import GridCode
-from parcels.tools.converters import Geographic
-from parcels.tools.converters import GeographicPolar
-from parcels.tools.converters import TimeConverter
-from parcels.tools.converters import UnitConverter
-from parcels.tools.converters import unitconverters_map
-from parcels.tools.statuscodes import FieldOutOfBoundError
-from parcels.tools.statuscodes import FieldOutOfBoundSurfaceError
-from parcels.tools.statuscodes import FieldSamplingError
-from parcels.tools.statuscodes import TimeExtrapolationError
+from parcels.tools.converters import (
+    Geographic,
+    GeographicPolar,
+    TimeConverter,
+    UnitConverter,
+    unitconverters_map,
+)
 from parcels.tools.loggers import logger
+from parcels.tools.statuscodes import (
+    FieldOutOfBoundError,
+    FieldOutOfBoundSurfaceError,
+    FieldSamplingError,
+    TimeExtrapolationError,
+)
 
+from .fieldfilebuffer import (
+    DaskFileBuffer,
+    DeferredDaskFileBuffer,
+    DeferredNetcdfFileBuffer,
+    NetcdfFileBuffer,
+)
+from .grid import CGrid, Grid, GridCode
 
 __all__ = ['Field', 'VectorField', 'SummedField', 'NestedField']
 

--- a/parcels/fieldfilebuffer.py
+++ b/parcels/fieldfilebuffer.py
@@ -1,13 +1,13 @@
-import dask.array as da
-from dask import config as da_conf
-from dask import utils as da_utils
-import numpy as np
-import xarray as xr
-from netCDF4 import Dataset as ncDataset
-
 import datetime
 import math
+
+import dask.array as da
+import numpy as np
 import psutil
+import xarray as xr
+from dask import config as da_conf
+from dask import utils as da_utils
+from netCDF4 import Dataset as ncDataset
 
 from parcels.tools.converters import convert_xarray_time_units
 from parcels.tools.loggers import logger

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1,20 +1,18 @@
+import warnings
 from copy import deepcopy
 from glob import glob
 from os import path
 
 import dask.array as da
 import numpy as np
-import warnings
 
-from parcels.field import Field, DeferredArray
-from parcels.field import NestedField
-from parcels.field import SummedField
-from parcels.field import VectorField
+from parcels.field import DeferredArray, Field, NestedField, SummedField, VectorField
 from parcels.grid import Grid
 from parcels.gridset import GridSet
 from parcels.tools.converters import TimeConverter, convert_xarray_time_units
-from parcels.tools.statuscodes import TimeExtrapolationError
 from parcels.tools.loggers import logger
+from parcels.tools.statuscodes import TimeExtrapolationError
+
 try:
     from mpi4py import MPI
 except:

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -1,12 +1,5 @@
 import functools
-from ctypes import c_double
-from ctypes import c_float
-from ctypes import c_int
-from ctypes import c_void_p
-from ctypes import cast
-from ctypes import POINTER
-from ctypes import pointer
-from ctypes import Structure
+from ctypes import POINTER, Structure, c_double, c_float, c_int, c_void_p, cast, pointer
 from enum import IntEnum
 
 import numpy as np

--- a/parcels/interaction/__init__.py
+++ b/parcels/interaction/__init__.py
@@ -1,5 +1,4 @@
 from .baseinteractionkernel import BaseInteractionKernel  # noqa
 from .interactionkernelsoa import InteractionKernelSOA  # noqa
 
-
 __all__ = ["BaseInteractionKernel", "InteractionKernelSOA"]

--- a/parcels/interaction/interactionkernelsoa.py
+++ b/parcels/interaction/interactionkernelsoa.py
@@ -3,19 +3,17 @@ import random  # noqa
 from collections import defaultdict
 
 import numpy as np
+
 try:
     from mpi4py import MPI
 except:
     MPI = None
 
-from parcels.field import NestedField
-from parcels.field import SummedField
-from parcels.field import VectorField
-from parcels.interaction.baseinteractionkernel import BaseInteractionKernel
 import parcels.rng as ParcelsRandom  # noqa
-from parcels.tools.statuscodes import StateCode, OperationCode, ErrorCode
+from parcels.field import NestedField, SummedField, VectorField
+from parcels.interaction.baseinteractionkernel import BaseInteractionKernel
 from parcels.tools.loggers import logger
-
+from parcels.tools.statuscodes import ErrorCode, OperationCode, StateCode
 
 __all__ = ['InteractionKernelSOA']
 

--- a/parcels/interaction/neighborsearch/__init__.py
+++ b/parcels/interaction/neighborsearch/__init__.py
@@ -1,8 +1,16 @@
+from parcels.interaction.neighborsearch.bruteforce import (  # noqa
+    BruteFlatNeighborSearch,
+)
+from parcels.interaction.neighborsearch.bruteforce import (  # noqa
+    BruteSphericalNeighborSearch,
+)
 from parcels.interaction.neighborsearch.hashflat import HashFlatNeighborSearch
-from parcels.interaction.neighborsearch.hashspherical import HashSphericalNeighborSearch  # noqa
-from parcels.interaction.neighborsearch.bruteforce import BruteFlatNeighborSearch  # noqa
-from parcels.interaction.neighborsearch.bruteforce import BruteSphericalNeighborSearch  # noqa
-from parcels.interaction.neighborsearch.kdtreeflat import KDTreeFlatNeighborSearch  # noqa
+from parcels.interaction.neighborsearch.hashspherical import (  # noqa
+    HashSphericalNeighborSearch,
+)
+from parcels.interaction.neighborsearch.kdtreeflat import (  # noqa
+    KDTreeFlatNeighborSearch,
+)
 
 __all__ = ["HashFlatNeighborSearch", "HashSphericalNeighborSearch",
            "BruteFlatNeighborSearch",

--- a/parcels/interaction/neighborsearch/__init__.py
+++ b/parcels/interaction/neighborsearch/__init__.py
@@ -1,7 +1,5 @@
 from parcels.interaction.neighborsearch.bruteforce import (  # noqa
     BruteFlatNeighborSearch,
-)
-from parcels.interaction.neighborsearch.bruteforce import (  # noqa
     BruteSphericalNeighborSearch,
 )
 from parcels.interaction.neighborsearch.hashflat import HashFlatNeighborSearch

--- a/parcels/interaction/neighborsearch/base.py
+++ b/parcels/interaction/neighborsearch/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 
 import numpy as np
+
 from parcels.interaction.neighborsearch.distanceutils import spherical_distance
 
 

--- a/parcels/interaction/neighborsearch/bruteforce.py
+++ b/parcels/interaction/neighborsearch/bruteforce.py
@@ -1,5 +1,7 @@
-from parcels.interaction.neighborsearch.base import BaseFlatNeighborSearch
-from parcels.interaction.neighborsearch.base import BaseSphericalNeighborSearch
+from parcels.interaction.neighborsearch.base import (
+    BaseFlatNeighborSearch,
+    BaseSphericalNeighborSearch,
+)
 
 
 class BruteFlatNeighborSearch(BaseFlatNeighborSearch):

--- a/parcels/interaction/neighborsearch/hashflat.py
+++ b/parcels/interaction/neighborsearch/hashflat.py
@@ -1,8 +1,10 @@
 import numpy as np
 
 from parcels.interaction.neighborsearch.base import BaseFlatNeighborSearch
-from parcels.interaction.neighborsearch.basehash import BaseHashNeighborSearch
-from parcels.interaction.neighborsearch.basehash import hash_split
+from parcels.interaction.neighborsearch.basehash import (
+    BaseHashNeighborSearch,
+    hash_split,
+)
 
 
 class HashFlatNeighborSearch(BaseHashNeighborSearch, BaseFlatNeighborSearch):

--- a/parcels/interaction/neighborsearch/hashspherical.py
+++ b/parcels/interaction/neighborsearch/hashspherical.py
@@ -3,8 +3,10 @@ from math import ceil
 import numpy as np
 
 from parcels.interaction.neighborsearch.base import BaseSphericalNeighborSearch
-from parcels.interaction.neighborsearch.basehash import BaseHashNeighborSearch
-from parcels.interaction.neighborsearch.basehash import hash_split
+from parcels.interaction.neighborsearch.basehash import (
+    BaseHashNeighborSearch,
+    hash_split,
+)
 
 
 class HashSphericalNeighborSearch(BaseHashNeighborSearch,

--- a/parcels/kernel/basekernel.py
+++ b/parcels/kernel/basekernel.py
@@ -1,37 +1,38 @@
-import re
-import _ctypes
 import inspect
-import numpy.ctypeslib as npct
-from time import time as ostime
-from os import path
-from os import remove
-from sys import platform
-from sys import version_info
+import re
 from ast import FunctionDef
 from hashlib import md5
-from parcels.tools.loggers import logger
+from os import path, remove
+from sys import platform, version_info
+from time import time as ostime
+
+import _ctypes
 import numpy as np
+import numpy.ctypeslib as npct
 from numpy import ndarray
+
+from parcels.tools.loggers import logger
 
 try:
     from mpi4py import MPI
 except:
     MPI = None
 
-from parcels.tools.global_statics import get_cache_dir
+from parcels.application_kernels.advection import AdvectionAnalytical, AdvectionRK4_3D
 
 # === import just necessary field classes to perform setup checks === #
-from parcels.field import Field
-from parcels.field import VectorField
-from parcels.field import NestedField
-from parcels.field import SummedField
+from parcels.field import (
+    Field,
+    FieldOutOfBoundError,
+    FieldOutOfBoundSurfaceError,
+    NestedField,
+    SummedField,
+    TimeExtrapolationError,
+    VectorField,
+)
 from parcels.grid import GridCode
-from parcels.field import FieldOutOfBoundError
-from parcels.field import FieldOutOfBoundSurfaceError
-from parcels.field import TimeExtrapolationError
-from parcels.tools.statuscodes import StateCode, OperationCode, ErrorCode
-from parcels.application_kernels.advection import AdvectionRK4_3D
-from parcels.application_kernels.advection import AdvectionAnalytical
+from parcels.tools.global_statics import get_cache_dir
+from parcels.tools.statuscodes import ErrorCode, OperationCode, StateCode
 
 __all__ = ['BaseKernel']
 

--- a/parcels/kernel/kernelaos.py
+++ b/parcels/kernel/kernelaos.py
@@ -3,28 +3,24 @@ import math  # noqa
 import random  # noqa
 from ast import parse
 from copy import deepcopy
-from ctypes import byref
-from ctypes import c_double
-from ctypes import c_int
+from ctypes import byref, c_double, c_int
 from os import path
 
 import numpy as np
+
 try:
     from mpi4py import MPI
 except:
     MPI = None
 
-from parcels.kernel.basekernel import BaseKernel
+import parcels.rng as ParcelsRandom  # noqa
 from parcels.compilation.codegenerator import ObjectKernelGenerator as KernelGenerator
 from parcels.compilation.codegenerator import ParticleObjectLoopGenerator
-from parcels.field import NestedField
-from parcels.field import SummedField
-from parcels.field import VectorField
-import parcels.rng as ParcelsRandom  # noqa
-from parcels.tools.statuscodes import StateCode, OperationCode, ErrorCode  # noqa
-from parcels.tools.statuscodes import recovery_map as recovery_base_map
+from parcels.field import NestedField, SummedField, VectorField
+from parcels.kernel.basekernel import BaseKernel
 from parcels.tools.loggers import logger
-
+from parcels.tools.statuscodes import ErrorCode, OperationCode, StateCode  # noqa
+from parcels.tools.statuscodes import recovery_map as recovery_base_map
 
 __all__ = ['KernelAOS']
 

--- a/parcels/kernel/kernelsoa.py
+++ b/parcels/kernel/kernelsoa.py
@@ -3,28 +3,24 @@ import math  # noqa
 import random  # noqa
 from ast import parse
 from copy import deepcopy
-from ctypes import byref
-from ctypes import c_double
-from ctypes import c_int
+from ctypes import byref, c_double, c_int
 from os import path
 
 import numpy as np
+
 try:
     from mpi4py import MPI
 except:
     MPI = None
 
-from parcels.kernel.basekernel import BaseKernel
+import parcels.rng as ParcelsRandom  # noqa
 from parcels.compilation.codegenerator import ArrayKernelGenerator as KernelGenerator
 from parcels.compilation.codegenerator import LoopGenerator
-from parcels.field import NestedField
-from parcels.field import SummedField
-from parcels.field import VectorField
-import parcels.rng as ParcelsRandom  # noqa
-from parcels.tools.statuscodes import StateCode, OperationCode, ErrorCode
-from parcels.tools.statuscodes import recovery_map as recovery_base_map
+from parcels.field import NestedField, SummedField, VectorField
+from parcels.kernel.basekernel import BaseKernel
 from parcels.tools.loggers import logger
-
+from parcels.tools.statuscodes import ErrorCode, OperationCode, StateCode
+from parcels.tools.statuscodes import recovery_map as recovery_base_map
 
 __all__ = ['KernelSOA']
 

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -4,8 +4,8 @@ from operator import attrgetter
 import numpy as np
 
 from parcels.field import Field
-from parcels.tools.statuscodes import StateCode
 from parcels.tools.loggers import logger
+from parcels.tools.statuscodes import StateCode
 
 __all__ = ['ScipyParticle', 'JITParticle', 'Variable', 'ScipyInteractionParticle']
 

--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -1,8 +1,8 @@
 """Module controlling the writing of ParticleSets to Zarr file"""
-from abc import ABC
-from abc import abstractmethod
-from datetime import timedelta as delta
 import os
+from abc import ABC, abstractmethod
+from datetime import timedelta as delta
+
 import numpy as np
 import xarray as xr
 import zarr

--- a/parcels/particleset/baseparticleset.py
+++ b/parcels/particleset/baseparticleset.py
@@ -1,24 +1,22 @@
-import numpy as np
-from abc import ABC
-from abc import abstractmethod
+import time as time_module
+from abc import ABC, abstractmethod
 from datetime import datetime
 from datetime import timedelta as delta
 from os import path
-import time as time_module
-import cftime
 
+import cftime
+import numpy as np
 from tqdm import tqdm
 
-from parcels.tools.statuscodes import StateCode
-from parcels.tools.global_statics import get_package_dir
-from parcels.compilation.codecompiler import GNUCompiler
-from parcels.field import NestedField
-from parcels.field import SummedField
 from parcels.application_kernels.advection import AdvectionRK4
-from parcels.kernel.basekernel import BaseKernel as Kernel
 from parcels.collection.collections import ParticleCollection
-from parcels.tools.loggers import logger
+from parcels.compilation.codecompiler import GNUCompiler
+from parcels.field import NestedField, SummedField
 from parcels.interaction.baseinteractionkernel import BaseInteractionKernel
+from parcels.kernel.basekernel import BaseKernel as Kernel
+from parcels.tools.global_statics import get_package_dir
+from parcels.tools.loggers import logger
+from parcels.tools.statuscodes import StateCode
 
 
 class NDCluster(ABC):

--- a/parcels/particleset/particlesetaos.py
+++ b/parcels/particleset/particlesetaos.py
@@ -1,27 +1,27 @@
-from datetime import date
-from datetime import datetime
+import sys
+from copy import copy
+from ctypes import c_void_p
+from datetime import date, datetime
 from datetime import timedelta as delta
 
-import sys
 import numpy as np
 import xarray as xr
-from ctypes import c_void_p
-from copy import copy
 
+from parcels.collection.collectionaos import (  # NOQA
+    ParticleCollectionAOS,
+    ParticleCollectionIterableAOS,
+    ParticleCollectionIteratorAOS,
+)
+from parcels.field import NestedField, SummedField
 from parcels.grid import GridCode
-from parcels.field import NestedField
-from parcels.field import SummedField
 from parcels.kernel.kernelaos import KernelAOS
-from parcels.particle import Variable, ScipyParticle, JITParticle # NOQA
+from parcels.particle import JITParticle, ScipyParticle, Variable  # NOQA
 from parcels.particlefile.particlefileaos import ParticleFileAOS
-from parcels.tools.converters import convert_to_flat_array
-from parcels.tools.statuscodes import StateCode, OperationCode  # NOQA
 from parcels.particleset.baseparticleset import BaseParticleSet
-from parcels.collection.collectionaos import ParticleCollectionAOS
-from parcels.collection.collectionaos import ParticleCollectionIteratorAOS, ParticleCollectionIterableAOS  # NOQA
-
-from parcels.tools.converters import _get_cftime_calendars
+from parcels.tools.converters import _get_cftime_calendars, convert_to_flat_array
 from parcels.tools.loggers import logger
+from parcels.tools.statuscodes import OperationCode, StateCode  # NOQA
+
 try:
     from mpi4py import MPI
 except:

--- a/parcels/particleset/particlesetsoa.py
+++ b/parcels/particleset/particlesetsoa.py
@@ -1,30 +1,30 @@
-from datetime import date
-from datetime import datetime
+import sys
+from copy import copy
+from datetime import date, datetime
 from datetime import timedelta as delta
 
-import sys
 import numpy as np
 import xarray as xr
-from copy import copy
 
-from parcels.grid import GridCode
-from parcels.grid import CurvilinearGrid
-from parcels.kernel import Kernel
-from parcels.particle import Variable, ScipyParticle, JITParticle  # noqa
-from parcels.particlefile import ParticleFile
-from parcels.tools.statuscodes import StateCode
-from parcels.particleset.baseparticleset import BaseParticleSet
-from parcels.collection.collectionsoa import ParticleCollectionSOA
-from parcels.collection.collectionsoa import ParticleCollectionIteratorSOA  # noqa
 from parcels.collection.collectionsoa import ParticleCollectionIterableSOA  # noqa
-from parcels.tools.converters import convert_to_flat_array
-from parcels.tools.converters import _get_cftime_calendars
-from parcels.tools.loggers import logger
+from parcels.collection.collectionsoa import ParticleCollectionIteratorSOA  # noqa
+from parcels.collection.collectionsoa import ParticleCollectionSOA
+from parcels.grid import CurvilinearGrid, GridCode
 from parcels.interaction.interactionkernelsoa import InteractionKernelSOA
-from parcels.interaction.neighborsearch import BruteSphericalNeighborSearch
-from parcels.interaction.neighborsearch import BruteFlatNeighborSearch
-from parcels.interaction.neighborsearch import KDTreeFlatNeighborSearch
-from parcels.interaction.neighborsearch import HashSphericalNeighborSearch
+from parcels.interaction.neighborsearch import (
+    BruteFlatNeighborSearch,
+    BruteSphericalNeighborSearch,
+    HashSphericalNeighborSearch,
+    KDTreeFlatNeighborSearch,
+)
+from parcels.kernel import Kernel
+from parcels.particle import JITParticle, ScipyParticle, Variable  # noqa
+from parcels.particlefile import ParticleFile
+from parcels.particleset.baseparticleset import BaseParticleSet
+from parcels.tools.converters import _get_cftime_calendars, convert_to_flat_array
+from parcels.tools.loggers import logger
+from parcels.tools.statuscodes import StateCode
+
 try:
     from mpi4py import MPI
 except:

--- a/parcels/plotting.py
+++ b/parcels/plotting.py
@@ -1,15 +1,13 @@
+import copy
 from datetime import datetime
 from datetime import timedelta as delta
 
 import numpy as np
-import copy
 
-from parcels.field import Field
-from parcels.field import VectorField
-from parcels.grid import CurvilinearGrid
-from parcels.grid import GridCode
-from parcels.tools.statuscodes import TimeExtrapolationError
+from parcels.field import Field, VectorField
+from parcels.grid import CurvilinearGrid, GridCode
 from parcels.tools.loggers import logger
+from parcels.tools.statuscodes import TimeExtrapolationError
 
 
 def plotparticles(particles, with_particles=True, show_time=None, field=None, domain=None,

--- a/parcels/rng.py
+++ b/parcels/rng.py
@@ -1,15 +1,13 @@
 import uuid
-import _ctypes
-from ctypes import c_float
-from ctypes import c_int
-from os import path
-from os import remove
+from ctypes import c_float, c_int
+from os import path, remove
 from sys import platform
 
+import _ctypes
 import numpy.ctypeslib as npct
 
-from parcels.tools import get_cache_dir, get_package_dir
 from parcels.compilation.codecompiler import GNUCompiler
+from parcels.tools import get_cache_dir, get_package_dir
 from parcels.tools.loggers import logger
 
 __all__ = ['seed', 'random', 'uniform', 'randint', 'normalvariate', 'expovariate', 'vonmisesvariate']

--- a/parcels/scripts/__init__.py
+++ b/parcels/scripts/__init__.py
@@ -1,1 +1,3 @@
-from .plottrajectoriesfile import plotTrajectoriesFile  # NOQA get flake8 to ignore unused import.
+from .plottrajectoriesfile import (
+    plotTrajectoriesFile,  # NOQA get flake8 to ignore unused import.
+)

--- a/parcels/scripts/__init__.py
+++ b/parcels/scripts/__init__.py
@@ -1,3 +1,1 @@
-from .plottrajectoriesfile import (
-    plotTrajectoriesFile,  # NOQA get flake8 to ignore unused import.
-)
+from .plottrajectoriesfile import plotTrajectoriesFile  # noqa: F401

--- a/parcels/scripts/get_examples.py
+++ b/parcels/scripts/get_examples.py
@@ -1,9 +1,8 @@
 """Get example scripts, notebooks, and data files."""
 import argparse
 import os
-from datetime import datetime
-from datetime import timedelta
 import shutil
+from datetime import datetime, timedelta
 
 import pkg_resources
 from tqdm import tqdm

--- a/parcels/scripts/plottrajectoriesfile.py
+++ b/parcels/scripts/plottrajectoriesfile.py
@@ -5,9 +5,8 @@ import numpy as np
 import xarray as xr
 
 from parcels import Field
-from parcels.plotting import cartopy_colorbar
-from parcels.plotting import create_parcelsfig_axis
-from parcels.plotting import plotfield
+from parcels.plotting import cartopy_colorbar, create_parcelsfig_axis, plotfield
+
 try:
     import matplotlib.animation as animation
     from matplotlib import rc

--- a/parcels/tools/__init__.py
+++ b/parcels/tools/__init__.py
@@ -1,6 +1,6 @@
 from .converters import *  # noqa
 from .global_statics import *  # noqa
-from .statuscodes import *  # noqa
 from .interpolation_utils import *  # noqa
 from .loggers import *  # noqa
+from .statuscodes import *  # noqa
 from .timer import *  # noqa

--- a/parcels/tools/converters.py
+++ b/parcels/tools/converters.py
@@ -1,12 +1,11 @@
 # flake8: noqa: E999
 import inspect
 from datetime import timedelta as delta
-from math import cos
-from math import pi
-import xarray as xr
+from math import cos, pi
 
 import cftime
 import numpy as np
+import xarray as xr
 
 __all__ = ['UnitConverter', 'Geographic', 'GeographicPolar', 'GeographicSquare',
            'GeographicPolarSquare', 'unitconverters_map', 'TimeConverter',

--- a/parcels/tools/global_statics.py
+++ b/parcels/tools/global_statics.py
@@ -1,8 +1,9 @@
 import os
 import sys
-import _ctypes
-from tempfile import gettempdir
 from pathlib import Path
+from tempfile import gettempdir
+
+import _ctypes
 
 try:
     from os import getuid

--- a/parcels/tools/timer.py
+++ b/parcels/tools/timer.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import datetime
 import time
+
 try:
     from mpi4py import MPI
 except:

--- a/performance/example_performanceProfiling.py
+++ b/performance/example_performanceProfiling.py
@@ -1,18 +1,20 @@
-from parcels import FieldSet, ParticleSet, JITParticle, AdvectionRK4
-from datetime import timedelta as delta
+import gc
+import os
+import sys
+import time as ostime
 from argparse import ArgumentParser
-import numpy as np
+from datetime import timedelta as delta
+from glob import glob
+
 import dask as da
 import dask.array as daArray
-from glob import glob
-import time as ostime
 import matplotlib.pyplot as plt
-import os
-import parcels
+import numpy as np
 import psutil
 
-import gc
-import sys
+import parcels
+from parcels import AdvectionRK4, FieldSet, JITParticle, ParticleSet
+
 try:
     from mpi4py import MPI
 except:

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,7 @@ ignore = E501,F403,E226,E722,W503
 
 [tool:pytest]
 python_files = test_*.py example_*.py *tutorial*
+
+[isort]
+profile = black
+skip_gitignore = True

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 """Install Parcels and dependencies."""
 
 try:
-    from setuptools import setup, find_packages
+    from setuptools import find_packages, setup
 except ImportError:
-    from distutils.core import setup, find_packages
+    from distutils.core import find_packages, setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -1,14 +1,32 @@
-from parcels import (FieldSet, Field, ScipyParticle, JITParticle, ErrorCode, StateCode,
-                     AdvectionEE, AdvectionRK4, AdvectionRK45, AdvectionRK4_3D,
-                     AdvectionAnalytical, AdvectionDiffusionM1, AdvectionDiffusionEM)
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
-import numpy as np
-import pytest
 import math
 from datetime import timedelta as delta
-from parcels import logger
+
+import numpy as np
+import pytest
 import xarray as xr
+
+from parcels import (  # noqa
+    AdvectionAnalytical,
+    AdvectionDiffusionEM,
+    AdvectionDiffusionM1,
+    AdvectionEE,
+    AdvectionRK4,
+    AdvectionRK4_3D,
+    AdvectionRK45,
+    ErrorCode,
+    Field,
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    ScipyParticle,
+    StateCode,
+    logger,
+)
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,6 +1,7 @@
-from parcels.tools.converters import TimeConverter, _get_cftime_datetimes
 import cftime
 import numpy as np
+
+from parcels.tools.converters import TimeConverter, _get_cftime_datetimes
 
 
 def test_TimeConverter():

--- a/tests/test_data/create_testfields.py
+++ b/tests/test_data/create_testfields.py
@@ -1,13 +1,18 @@
-from parcels import FieldSet, GridCode
-import numpy as np
 import math
+
+import numpy as np
+
+from parcels import FieldSet, GridCode
+
 try:
     from pympler import asizeof
 except:
     asizeof = None
 
 from os import path
+
 import xarray as xr
+
 try:
     from parcels.tools import perlin2d as PERLIN
 except:

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -1,13 +1,27 @@
-from parcels import (FieldSet, Field, RectilinearZGrid, JITParticle,
-                     DiffusionUniformKh, AdvectionDiffusionM1, AdvectionDiffusionEM,
-                     ScipyParticle, Variable)
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
-from parcels import ParcelsRandom
 from datetime import timedelta as delta
+
 import numpy as np
 import pytest
 from scipy import stats
+
+from parcels import (  # noqa
+    AdvectionDiffusionEM,
+    AdvectionDiffusionM1,
+    DiffusionUniformKh,
+    Field,
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    ParcelsRandom,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    RectilinearZGrid,
+    ScipyParticle,
+    Variable,
+)
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -1,22 +1,44 @@
-from parcels import FieldSet, ScipyParticle, JITParticle, Variable, AdvectionRK4, AdvectionRK4_3D, RectilinearZGrid, ErrorCode, OutOfTimeError
-from parcels.field import Field, VectorField
-from parcels.fieldfilebuffer import DaskFileBuffer
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
-from parcels.tools.converters import TimeConverter, _get_cftime_calendars, _get_cftime_datetimes, UnitConverter, GeographicPolar
-import dask.array as da
-import dask
-from datetime import timedelta as delta
 import datetime
-import numpy as np
-import xarray as xr
-import pytest
-from os import path
-import cftime
 import gc
-import psutil
 import os
 import sys
+from datetime import timedelta as delta
+from os import path
+
+import cftime
+import dask
+import dask.array as da
+import numpy as np
+import psutil
+import pytest
+import xarray as xr
+
+from parcels import (  # noqa
+    AdvectionRK4,
+    AdvectionRK4_3D,
+    ErrorCode,
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    OutOfTimeError,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    RectilinearZGrid,
+    ScipyParticle,
+    Variable,
+)
+from parcels.field import Field, VectorField
+from parcels.fieldfilebuffer import DaskFileBuffer
+from parcels.tools.converters import (
+    GeographicPolar,
+    TimeConverter,
+    UnitConverter,
+    _get_cftime_calendars,
+    _get_cftime_datetimes,
+)
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -1,11 +1,27 @@
-from parcels import (FieldSet, Field, NestedField, ScipyParticle, JITParticle, Geographic,
-                     AdvectionRK4, AdvectionRK4_3D, Variable, ErrorCode)
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
+from datetime import timedelta as delta
+from math import cos, pi
+
 import numpy as np
 import pytest
-from math import cos, pi
-from datetime import timedelta as delta
+
+from parcels import (  # noqa
+    AdvectionRK4,
+    AdvectionRK4_3D,
+    ErrorCode,
+    Field,
+    FieldSet,
+    Geographic,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    NestedField,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    ScipyParticle,
+    Variable,
+)
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,13 +1,31 @@
-from parcels import (FieldSet, Field, ScipyParticle, JITParticle, Variable, AdvectionRK4, AdvectionRK4_3D, ErrorCode, UnitConverter)
-from parcels import RectilinearZGrid, RectilinearSGrid, CurvilinearZGrid
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
-import numpy as np
-import xarray as xr
 import math
-import pytest
-from os import path
 from datetime import timedelta as delta
+from os import path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from parcels import (  # noqa
+    AdvectionRK4,
+    AdvectionRK4_3D,
+    CurvilinearZGrid,
+    ErrorCode,
+    Field,
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    RectilinearSGrid,
+    RectilinearZGrid,
+    ScipyParticle,
+    UnitConverter,
+    Variable,
+)
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/tests/test_interaction_kernel.py
+++ b/tests/test_interaction_kernel.py
@@ -1,14 +1,14 @@
 import numpy as np
 import pytest
 
-from parcels import (
-    FieldSet, ParticleSet, JITParticle, StateCode, Field
-)
-from parcels.particle import ScipyInteractionParticle, Variable, ScipyParticle
-from parcels.application_kernels.interaction import NearestNeighborWithinRange
-from parcels.application_kernels.interaction import AsymmetricAttraction
-from parcels.application_kernels.interaction import MergeWithNearestNeighbor
+from parcels import Field, FieldSet, JITParticle, ParticleSet, StateCode
 from parcels.application_kernels.advection import AdvectionRK4
+from parcels.application_kernels.interaction import (
+    AsymmetricAttraction,
+    MergeWithNearestNeighbor,
+    NearestNeighborWithinRange,
+)
+from parcels.particle import ScipyInteractionParticle, ScipyParticle, Variable
 
 ptype = {'scipy': ScipyInteractionParticle, 'jit': JITParticle}
 

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -1,13 +1,26 @@
+import sys
 from os import path
-from parcels import (
-    FieldSet, ScipyParticle, JITParticle, StateCode, OperationCode, ErrorCode, KernelError,
-    OutOfBoundsError, AdvectionRK4
-)
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
+
 import numpy as np
 import pytest
-import sys
+
+from parcels import (  # noqa
+    AdvectionRK4,
+    ErrorCode,
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelError,
+    KernelSOA,
+    OperationCode,
+    OutOfBoundsError,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    ScipyParticle,
+    StateCode,
+)
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}
@@ -305,7 +318,12 @@ def test_execution_keep_cfiles_and_nocompilation_warnings(pset_mode, fieldset, d
 
 
 def test_compilers():
-    from parcels.compilation.codecompiler import Clang_parameters, MinGW_parameters, VS_parameters, CCompiler_SS
+    from parcels.compilation.codecompiler import (
+        CCompiler_SS,
+        Clang_parameters,
+        MinGW_parameters,
+        VS_parameters,
+    )
 
     for param_class in [Clang_parameters, MinGW_parameters, VS_parameters]:
         params = param_class()  # noqa

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -1,14 +1,31 @@
-from parcels import FieldSet, ScipyParticle, JITParticle, Variable, StateCode
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
-from parcels.application_kernels.TEOSseawaterdensity import PolyTEOS10_bsq
-from parcels.application_kernels.EOSseawaterproperties import PressureFromLatDepth, PtempFromTemp, TempFromPtemp, UNESCODensity
-from parcels import ParcelsRandom
+import random as py_random
+import sys
+from os import path
+
 import numpy as np
 import pytest
-import random as py_random
-from os import path
-import sys
+
+from parcels import (  # noqa
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    ParcelsRandom,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    ScipyParticle,
+    StateCode,
+    Variable,
+)
+from parcels.application_kernels.EOSseawaterproperties import (
+    PressureFromLatDepth,
+    PtempFromTemp,
+    TempFromPtemp,
+    UNESCODensity,
+)
+from parcels.application_kernels.TEOSseawaterdensity import PolyTEOS10_bsq
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/tests/test_mpirun.py
+++ b/tests/test_mpirun.py
@@ -1,9 +1,11 @@
-from os import path, system
+import sys
 from glob import glob
+from os import path, system
+
 import numpy as np
 import pytest
-import sys
 import xarray as xr
+
 try:
     from mpi4py import MPI
 except:

--- a/tests/test_neighbor_search.py
+++ b/tests/test_neighbor_search.py
@@ -1,11 +1,13 @@
-import pytest
 import numpy as np
+import pytest
 
-from parcels.interaction.neighborsearch import BruteFlatNeighborSearch
-from parcels.interaction.neighborsearch import BruteSphericalNeighborSearch
-from parcels.interaction.neighborsearch import HashFlatNeighborSearch
-from parcels.interaction.neighborsearch import HashSphericalNeighborSearch
-from parcels.interaction.neighborsearch import KDTreeFlatNeighborSearch
+from parcels.interaction.neighborsearch import (
+    BruteFlatNeighborSearch,
+    BruteSphericalNeighborSearch,
+    HashFlatNeighborSearch,
+    HashSphericalNeighborSearch,
+    KDTreeFlatNeighborSearch,
+)
 from parcels.interaction.neighborsearch.basehash import BaseHashNeighborSearch
 
 

--- a/tests/test_particle_collections.py
+++ b/tests/test_particle_collections.py
@@ -1,8 +1,17 @@
-from parcels import FieldSet, ScipyParticle, JITParticle
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
 import numpy as np
 import pytest
+
+from parcels import (  # noqa
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    ScipyParticle,
+)
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/tests/test_particle_file.py
+++ b/tests/test_particle_file.py
@@ -1,14 +1,26 @@
-from parcels import (FieldSet, ScipyParticle, JITParticle, Variable, ErrorCode)
-from parcels.particlefile import _set_calendar
-from parcels.tools.converters import _get_cftime_calendars, _get_cftime_datetimes
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
+import os
+
+import cftime
 import numpy as np
 import pytest
-import os
-import cftime
 import xarray as xr
 from zarr.storage import MemoryStore
+
+from parcels import (  # noqa
+    ErrorCode,
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    ScipyParticle,
+    Variable,
+)
+from parcels.particlefile import _set_calendar
+from parcels.tools.converters import _get_cftime_calendars, _get_cftime_datetimes
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/tests/test_particle_sets.py
+++ b/tests/test_particle_sets.py
@@ -1,9 +1,22 @@
-from parcels import (FieldSet, Field, ScipyParticle, JITParticle,
-                     Variable, StateCode, OperationCode, CurvilinearZGrid)
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
 import numpy as np
 import pytest
+
+from parcels import (  # noqa
+    CurvilinearZGrid,
+    Field,
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    OperationCode,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    ScipyParticle,
+    StateCode,
+    Variable,
+)
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -1,9 +1,21 @@
-from parcels import FieldSet, ScipyParticle, JITParticle, Variable, AdvectionRK4
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
+from operator import attrgetter
+
 import numpy as np
 import pytest
-from operator import attrgetter
+
+from parcels import (  # noqa
+    AdvectionRK4,
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    ScipyParticle,
+    Variable,
+)
 
 pset_modes = ['soa', 'aos']
 ptype = {'scipy': ScipyParticle, 'jit': JITParticle}

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,10 +1,21 @@
-from parcels import (FieldSet, JITParticle, AdvectionRK4, plotTrajectoriesFile)
-from parcels import ParticleSetSOA, ParticleFileSOA, KernelSOA  # noqa
-from parcels import ParticleSetAOS, ParticleFileAOS, KernelAOS  # noqa
 from datetime import timedelta as delta
+from os import path
+
 import numpy as np
 import pytest
-from os import path
+
+from parcels import (  # noqa
+    AdvectionRK4,
+    FieldSet,
+    JITParticle,
+    KernelAOS,
+    KernelSOA,
+    ParticleFileAOS,
+    ParticleFileSOA,
+    ParticleSetAOS,
+    ParticleSetSOA,
+    plotTrajectoriesFile,
+)
 
 pset_modes = ['soa', 'aos']
 pset_type = {'soa': {'pset': ParticleSetSOA, 'pfile': ParticleFileSOA, 'kernel': KernelSOA},


### PR DESCRIPTION
[isort](https://pycqa.github.io/isort) sorts your imports so that you don't have to. The tool organises them into [5 sections](https://pycqa.github.io/isort/docs/configuration/custom_sections_and_ordering.html) separated by newlines:

- FUTURE (eg. `from __future__ import annotations`)
- STDLIB (eg. `import os`)
- THIRDPARTY (eg. `import xarray`)
- FIRSTPARTY (eg. `import parcels.Field`)
- LOCALFOLDER (eg. `from .utils import square`)

Within each section the imports are sorted alphabetically, and also squashes imports down to one line.
eg.
```py
from parcels.field import Field
from parcels.field import NestedField
from parcels.field import SummedField
from parcels.field import VectorField
```
becomes
```py
from parcels.field import Field, NestedField, SummedField, VectorField
```

This will make import statements through the codebase much more structured, and easier to read. isort also has good integration with pre-commit.

You can add `# isort:skip` to a line to prevent isort from moving the import statement.