### PR TITLE
CICD: Update to use mamba

### DIFF
--- a/.github/actions/install-parcels/action.yml
+++ b/.github/actions/install-parcels/action.yml
@@ -1,15 +1,18 @@
-name: Setup Anaconda and install parcels
+name: Setup Conda and install parcels
 description: >
-  In-repo composite action to setup Anaconda and install parcels. Installation of parcels relies on
+  In-repo composite action to setup Conda and install parcels. Installation of parcels relies on
   `setup.py` file being available in the root. For general setup of Anaconda environments, just use
-  the `conda-incubator/setup-miniconda` action (setting C variables as required)
+  the `mamba-org/provision-with-micromamba` action (setting C variables as required), or the `conda-incubator/setup-miniconda` action.
 inputs:
   environment-file:
-    description: "Anaconda environment file"
-    required: true
+    description: Conda environment file to use.
+    default: environment.yml
   environment-name:
-    description: "Anaconda environment name"
-    required: true
+    description: Name to use for the Conda environment
+    default: test
+  extra-specs:
+    description: Extra packages to install
+    required: false
 runs:
   using: "composite"
   steps:
@@ -18,16 +21,16 @@ runs:
       uses: al-cheb/configure-pagefile-action@v1.3
       with:
         minimum-size: 8GB
-    - name: Setup Miniconda
-      uses: conda-incubator/setup-miniconda@v2.2.0
+    - name: Install micromamba (${{ inputs.environment-file }})
+      uses: mamba-org/provision-with-micromamba@v15
       with:
-        miniconda-version: "latest"
-        activate-environment: ${{ inputs.environment-name }} # Needs to be the same as listed in the env file
         environment-file: ${{ inputs.environment-file }}
-        auto-activate-base: false
-        auto-update-conda: true
-    - run: conda info
-      shell: bash -el {0}
+        environment-name: ${{ inputs.environment-name }}
+        extra-specs: ${{ inputs.extra-specs }}
+        channels: conda-forge
+        channel-priority: 'strict'
+        cache-env: true
+        cache-downloads: true
     - name: Install parcels
       run: python setup.py install
       shell: bash -el {0}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Miniconda and parcels
+      - name: Setup Conda and parcels
         uses: ./.github/actions/install-parcels
         with:
           environment-file: environment_py3_${{ matrix.os-short }}.yml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Miniconda and parcels
+      - name: Setup Conda and parcels
         uses: ./.github/actions/install-parcels
         with:
           environment-file: environment_py3_${{ matrix.os-short }}.yml


### PR DESCRIPTION
Switch workflows to use Mamba instead of Anaconda, resulting in faster dependency resolving and caching of environments.

Setup is now ~3 times faster (~15m -> ~5m), even without caching. 

The pandas codebase [also uses Mamba in CI/CD](https://github.com/pandas-dev/pandas/blob/main/.github/actions/setup-conda/action.yml).