### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+contact_links:
+  - name: Question/Help/Support
+    url: https://github.com/OceanParcels/parcels/discussions
+    about: >
+      Have a question about parcels? Or troubleshooting a specific usecase? Then submit a discussion instead, and we'll be happy to help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 contact_links:
-  - name: Question/Help/Support
+  - name: Parcels use question, help, or support
     url: https://github.com/OceanParcels/parcels/discussions
     about: >
-      Have a question about parcels? Or troubleshooting a specific usecase? Then submit a discussion instead, and we'll be happy to help.
+      Have a question about Parcels? Or do you need troubleshooting for a specific usecase? Then start a Discussion thread instead, and we'll be happy to help.

--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,0 +1,8 @@
+---
+name: parcels feature requests, enhancements, bug reporting
+about: Create an issue about improvements to the parcels codebase
+title: ''
+labels: ''
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,6 +1,6 @@
 ---
-name: parcels feature requests, enhancements, bug reporting
-about: Create an issue about improvements to the parcels codebase
+name: Parcels feature requests, enhancements, or bug reporting
+about: Create an Issue about bugs in the Parcels codebase, or required improvements
 title: ''
 labels: ''
 assignees: ''


### PR DESCRIPTION
Currently questions regarding using parcels occur in both issues and discussions. Adding [simple issue templates](https://github.com/VeckoTheGecko/parcels/issues/new/choose) would encourage users to use the discussions for parcels usecase questions, while keeping the issues for parcels development purposes.