### PR TITLE
Patch test_mpi_run failing test

### DIFF
--- a/tests/test_mpirun.py
+++ b/tests/test_mpirun.py
@@ -18,7 +18,7 @@ except:
 @pytest.mark.parametrize('nump', [4, 8])
 def test_mpi_run(pset_mode, tmpdir, repeatdt, maxage, nump):
     if MPI:
-        stommel_file = path.join(path.dirname(__file__), '..', 'parcels',
+        stommel_file = path.join(path.dirname(__file__), '..', 'docs',
                                  'examples', 'example_stommel.py')
         outputMPI = tmpdir.join('StommelMPI')
         outputNoMPI = tmpdir.join('StommelNoMPI.zarr')


### PR DESCRIPTION
#1373 brought attention to a failing test.
```
2023-06-06T20:55:38.4679682Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:38.4686512Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:38.4915012Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:38.5551849Z tests/test_mpirun.py::test_mpi_run[4-1728000-51840000-soa] FAILED
2023-06-06T20:55:38.5827945Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:38.5831462Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:38.6057289Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:38.6650437Z tests/test_mpirun.py::test_mpi_run[4-1728000-51840000-aos] FAILED
2023-06-06T20:55:38.6933471Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:38.6936979Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:38.7159353Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:38.7758002Z tests/test_mpirun.py::test_mpi_run[4-864000-864000-soa] FAILED
2023-06-06T20:55:38.8026223Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:38.8036252Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:38.8307130Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.0938007Z tests/test_mpirun.py::test_mpi_run[4-864000-864000-aos] FAILED
2023-06-06T20:55:39.1210140Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.1218373Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.1462250Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.2071574Z tests/test_mpirun.py::test_mpi_run[8-1728000-51840000-soa] FAILED
2023-06-06T20:55:39.2341828Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.2343158Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.2571557Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.3173648Z tests/test_mpirun.py::test_mpi_run[8-1728000-51840000-aos] FAILED
2023-06-06T20:55:39.3443671Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.3447012Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.3672499Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.4293354Z tests/test_mpirun.py::test_mpi_run[8-864000-864000-soa] FAILED
2023-06-06T20:55:39.4565676Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.4572676Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.4821466Z python: can't open file '/home/runner/work/parcels/parcels/tests/../parcels/examples/example_stommel.py': [Errno 2] No such file or directory
2023-06-06T20:55:39.5431554Z tests/test_mpirun.py::test_mpi_run[8-864000-864000-aos] FAILED
...
2023-06-06T21:00:58.1045211Z =========================== short test summary info ============================
2023-06-06T21:00:58.1045645Z FAILED tests/test_mpirun.py::test_mpi_run[4-1728000-51840000-soa] - ValueError: must supply at least one object to concatenate
2023-06-06T21:00:58.1046074Z FAILED tests/test_mpirun.py::test_mpi_run[4-1728000-51840000-aos] - ValueError: must supply at least one object to concatenate
2023-06-06T21:00:58.1046516Z FAILED tests/test_mpirun.py::test_mpi_run[4-864000-864000-soa] - ValueError: must supply at least one object to concatenate
2023-06-06T21:00:58.1046933Z FAILED tests/test_mpirun.py::test_mpi_run[4-864000-864000-aos] - ValueError: must supply at least one object to concatenate
2023-06-06T21:00:58.1047352Z FAILED tests/test_mpirun.py::test_mpi_run[8-1728000-51840000-soa] - ValueError: must supply at least one object to concatenate
2023-06-06T21:00:58.1047772Z FAILED tests/test_mpirun.py::test_mpi_run[8-1728000-51840000-aos] - ValueError: must supply at least one object to concatenate
2023-06-06T21:00:58.1048193Z FAILED tests/test_mpirun.py::test_mpi_run[8-864000-864000-soa] - ValueError: must supply at least one object to concatenate
2023-06-06T21:00:58.1048609Z FAILED tests/test_mpirun.py::test_mpi_run[8-864000-864000-aos] - ValueError: must supply at least one object to concatenate
2023-06-06T21:00:58.1048818Z = 8 failed, 1843 passed, 1 skipped, 13 xfailed, 157 warnings in 2025.08s (0:33:45) =
```
Not sure why it wasn't failing before in all the other PRs

