### PR TITLE
Fix Binder filepath typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [oceanparcels.org](http://oceanparcels.org/) for further information about [
 
 ### Launch Parcels Tutorials on mybinder.org
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/OceanParcels/parcels/master?labpath=parcels%2Fdocs%2Fexamples)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/OceanParcels/parcels/master?labpath=docs%2Fexamples%2Fparcels_tutorial.ipynb)
 [![unit-tests](https://github.com/OceanParcels/parcels/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/OceanParcels/parcels/actions/workflows/unit-tests.yml)
 [![codecov](https://codecov.io/gh/OceanParcels/parcels/branch/master/graph/badge.svg)](https://codecov.io/gh/OceanParcels/parcels)
 [![Anaconda-release](https://anaconda.org/conda-forge/parcels/badges/version.svg)](https://anaconda.org/conda-forge/parcels/)

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -1,7 +1,7 @@
 Documentation and Tutorials
 ===========================
 
-Parcels has several documentation and tutorial Jupyter notebooks which go through various aspects of parcels. Static versions of these notebooks are available below in the site, with the interactive notebooks being available either completely online at the following `Binder link <https://mybinder.org/v2/gh/OceanParcels/parcels/master?labpath=parcels%2Fdocs%2Fexamples>`_, or locally by downloading :download:`parcels_tutorials.zip </_downloads/parcels_tutorials.zip>` and running with your own Parcels installation.
+Parcels has several documentation and tutorial Jupyter notebooks which go through various aspects of parcels. Static versions of these notebooks are available below in the site, with the interactive notebooks being available either completely online at the following `Binder link <https://mybinder.org/v2/gh/OceanParcels/parcels/master?labpath=docs%2Fexamples%2Fparcels_tutorial.ipynb>`_, or locally by downloading :download:`parcels_tutorials.zip </_downloads/parcels_tutorials.zip>` and running with your own Parcels installation.
 
 
 


### PR DESCRIPTION
Fixes https://github.com/OceanParcels/parcels/pull/1368#issuecomment-1581932278

Path should be `docs/examples` not `parcels/docs/examples`