### PR TITLE
Cleaning setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,4 @@ setup(name='parcels',
       python_requires='>=3.8',
       packages=find_packages(),
       package_data={'parcels': ['include/*']},
-      entry_points={'console_scripts': [
-          'parcels_convert_npydir_to_netcdf = parcels.scripts.convert_npydir_to_netcdf:main']}
       )


### PR DESCRIPTION
Following #1377, the setup.py script can be cleaned a bit

- [x] Remove legacy `parcels_convert_npydir_to_netcdf` from setup.py
- [ ] Investigate whether it's possible to remove the setup tools version system
- [ ] Investigate whether it's possible to remove setup.py altogether
- [ ] Update installation instructions on the website