### PR TITLE
Removing the header message from documentation notebooks

### DIFF
--- a/docs/examples/documentation_MPI.ipynb
+++ b/docs/examples/documentation_MPI.ipynb
@@ -11,13 +11,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<center><i> NOTE THAT THIS DOCUMENTATION NOTEBOOK CAN'T BE RUN WITH THE EXAMPLE-OUTPUT THAT SHIPS WITH PARCELS. THESE DOCUMENTATION NOTEBOOKS ARE FOR BACKGROUND INFO ONLY <i></center>\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Parcels can be run in Parallel with MPI. To do this, first follow the installation instructions at http://oceanparcels.org/#parallel_install.\n"
    ]
   },

--- a/docs/examples/documentation_homepage_animation.ipynb
+++ b/docs/examples/documentation_homepage_animation.ipynb
@@ -9,14 +9,6 @@
    ]
   },
   {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<center><i> NOTE THAT THIS DOCUMENTATION NOTEBOOK CAN'T BE RUN WITH THE EXAMPLE-OUTPUT THAT SHIPS WITH PARCELS. THESE DOCUMENTATION NOTEBOOKS ARE FOR BACKGROUND INFO ONLY <i></center>\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {

--- a/docs/examples/documentation_indexing.ipynb
+++ b/docs/examples/documentation_indexing.ipynb
@@ -11,13 +11,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<center><i> NOTE THAT THIS DOCUMENTATION NOTEBOOK CAN'T BE RUN WITH THE EXAMPLE-OUTPUT THAT SHIPS WITH PARCELS. THESE DOCUMENTATION NOTEBOOKS ARE FOR BACKGROUND INFO ONLY <i></center>\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Parcels supports `Fields` on any curvilinear `Grid`. For velocity `Fields` (`U`, `V` and `W`), there are some additional restrictions if the `Grid` is discretized as an Arakawa B- or Arakawa C-grid. That is because under the hood, Parcels uses a specific interpolation scheme for each of these grid types. This is described in [Section 2 of Delandmeter and Van Sebille (2019)](https://www.geosci-model-dev.net/12/3571/2019/gmd-12-3571-2019.html) and summarized below.\n",
     "\n",
     "The summary is: \n",

--- a/docs/examples/documentation_stuck_particles.ipynb
+++ b/docs/examples/documentation_stuck_particles.ipynb
@@ -19,17 +19,6 @@
     }
    },
    "source": [
-    "<center><i> NOTE THAT THIS DOCUMENTATION NOTEBOOK CAN'T BE RUN WITH THE EXAMPLE-OUTPUT THAT SHIPS WITH PARCELS. THESE DOCUMENTATION NOTEBOOKS ARE FOR BACKGROUND INFO ONLY <i></center>\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
     "In some Parcels simulations, particles end up moving onto parts of the grid where the velocity field is not defined, such as for example onto land. In this tutorial we look at how this depends on the grid structure.\n",
     "\n",
     "**Short conclusion: Particles can get stuck on Arakawa A grids and B grids but should not get stuck on C grids.**\n",

--- a/docs/examples/documentation_unstuck_Agrid.ipynb
+++ b/docs/examples/documentation_unstuck_Agrid.ipynb
@@ -11,13 +11,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<center><i> NOTE THAT THIS DOCUMENTATION NOTEBOOK CAN'T BE RUN WITH THE EXAMPLE-OUTPUT THAT SHIPS WITH PARCELS. THESE DOCUMENTATION NOTEBOOKS ARE FOR BACKGROUND INFO ONLY <i></center>\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "In [another notebook](https://docs.oceanparcels.org/en/latest/examples/documentation_stuck_particles.html), we have shown how particles may end up getting stuck on land, especially in A gridded velocity fields. Here we show how you can work around this problem and how large the effects of the solutions on the trajectories are.\n",
     "\n",
     "Common solutions are:\n",


### PR DESCRIPTION
Now that users will see the documentation on sphinx, there is no need anymore for the header messages that was in some of the documentation notebooks: 

_"NOTE THAT THIS DOCUMENTATION NOTEBOOK CAN'T BE RUN WITH THE EXAMPLE-OUTPUT THAT SHIPS WITH PARCELS. THESE DOCUMENTATION NOTEBOOKS ARE FOR BACKGROUND INFO ONLY"._ 

Therefore removing these