### PR TITLE
Printing cfile-name in compilation info

### DIFF
--- a/parcels/kernel/basekernel.py
+++ b/parcels/kernel/basekernel.py
@@ -261,7 +261,7 @@ class BaseKernel:
                     all_files_array.append(self.src_file)
                 compiler.compile(self.src_file, self.lib_file, self.log_file)
         if len(all_files_array) > 0:
-            logger.info(f"Compiled {self.name} ==> {self.lib_file}")
+            logger.info(f"Compiled {self.name} ==> {self.src_file}")
             if self.log_file is not None:
                 all_files_array.append(self.log_file)
 

--- a/parcels/rng.py
+++ b/parcels/rng.py
@@ -111,7 +111,7 @@ extern float pcls_vonmisesvariate(float mu, float kappa){
             with open(self.src_file, 'w+') as f:
                 f.write(self.ccode)
             ccompiler.compile(self.src_file, self.lib_file, self.log_file)
-            logger.info(f"Compiled ParcelsRandom ==> {self.lib_file}")
+            logger.info(f"Compiled ParcelsRandom ==> {self.src_file}")
 
     @property
     def lib(self):


### PR DESCRIPTION
This PR prints the name of the C-file instead of lib file, since the C-file is often what is much more relevant (can be viewed with e.g. `cat`)