### PR TITLE
Fix casting warnings

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1449,6 +1449,7 @@ class Field:
                                           interp_method=self.interp_method,
                                           data_full_zdim=self.data_full_zdim,
                                           chunksize=self.chunksize,
+                                          cast_data_dtype=self.cast_data_dtype,
                                           rechunk_callback_fields=rechunk_callback_fields,
                                           chunkdims_name_map=self.netcdf_chunkdims_name_map,
                                           netcdf_decodewarning=self.netcdf_decodewarning)

--- a/parcels/fieldfilebuffer.py
+++ b/parcels/fieldfilebuffer.py
@@ -22,6 +22,7 @@ class _FileBuffer:
         self.indices = indices
         self.dataset = None
         self.timestamp = timestamp
+        self.cast_data_dtype = kwargs.pop('cast_data_dtype', np.float32)
         self.ti = None
         self.interp_method = interp_method
         self.data_full_zdim = data_full_zdim
@@ -207,7 +208,7 @@ class NetcdfFileBuffer(_FileBuffer):
         data = self.dataset[self.name]
         ti = range(data.shape[0]) if self.ti is None else self.ti
         data = self._apply_indices(data, ti)
-        return np.array(data)
+        return np.array(data, dtype=self.cast_data_dtype)
 
     @property
     def time(self):
@@ -740,7 +741,7 @@ class DaskFileBuffer(NetcdfFileBuffer):
                 self.rechunk_callback_fields()
                 self.chunking_finalized = True
 
-        return data
+        return data.astype(self.cast_data_dtype)
 
 
 class DeferredDaskFileBuffer(DaskFileBuffer):

--- a/parcels/particlefile/baseparticlefile.py
+++ b/parcels/particlefile/baseparticlefile.py
@@ -285,7 +285,6 @@ class BaseParticleFile(ABC):
                                 data[ids_once] = pset.collection.getvardata(var, indices_to_write_once)
                                 dims = ["trajectory"]
                             else:
-                                # nan_val = np.nan if self.vars_to_write[var] in [np.float32, np.float64] else np.iinfo(self.vars_to_write[var]).max
                                 data = np.full(arrsize, self.fill_value_map[self.vars_to_write[var]], dtype=self.vars_to_write[var])
                                 data[ids, 0] = pset.collection.getvardata(var, indices_to_write)
                                 dims = ["trajectory", "obs"]


### PR DESCRIPTION
This PR fixes some casting warnings (`invalid value encountered in cast`) that are thrown by numpy > 1.20.3