### PR TITLE
Create tutorial_kernelloop.ipynb

### DIFF
--- a/docs/examples/tutorial_kernelloop.ipynb
+++ b/docs/examples/tutorial_kernelloop.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The Parcels Kernel loop\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This tutorial explains how Parcels loops through Kernels, and what happens under the hood when you combine Kernels. \n",
+    "\n",
+    "This is probably not very relevant when you only use the built-in Advection kernels, but can be important when you writing and combining adding your Kernels!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
This PR creates a temporary pplasceholder for tutorial_kernelloop, which is necessary for the linkchecker in pydocstyle to work for #1402 (which expects there to be a https://docs.oceanparcels.org/en/latest/tutorial_kernelloop.html)