### PR TITLE
Repeatdt small chunksize warning

### DIFF
--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -226,14 +226,14 @@ class ParticleFile(ABC):
             if self.create_new_zarrfile:
                 if self.chunks is None:
                     self.chunks = (len(ids), 1)
-                elif self.chunks[0] > len(ids):
-                    logger.warning(f'Chunk size for trajectory ({self.chunks[0]}) is larger than length of initial set to write. '
-                                   f'Reducing ParticleFile chunks to ({len(ids)}, {self.chunks[1]})')
-                    self.chunks = (len(ids), self.chunks[1])
+                if pset.repeatpclass is not None and self.chunks[0] < 1e4:
+                    logger.warning(f'ParticleFile chunks are set to {self.chunks}, but this may lead to '
+                                   f'a significant slowdown in Parcels when many calls to repeatdt. '
+                                   f'Consider setting a larger chunk size for your ParticleFile (e.g. chunks=(int(1e4), 1)).')
                 if (self.maxids > len(ids)) or (self.maxids > self.chunks[0]):
                     arrsize = (self.maxids, self.chunks[1])
                 else:
-                    arrsize = self.chunks
+                    arrsize = (len(ids), 1)
                 ds = xr.Dataset(attrs=self.metadata, coords={"trajectory": ("trajectory", pids),
                                                              "obs": ("obs", np.arange(arrsize[1], dtype=np.int32))})
                 attrs = self._create_variables_attribute_dict()

--- a/tests/test_mpirun.py
+++ b/tests/test_mpirun.py
@@ -9,8 +9,8 @@ import xarray as xr
 
 @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="skipping macOS test as problem with file in pytest")
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="skipping windows as mpi4py not available for windows")
-@pytest.mark.parametrize('repeatdt, maxage', [(20*86400, 600*86400), (10*86400, 10*86400)])
-@pytest.mark.parametrize('nump', [4, 8])
+@pytest.mark.parametrize('repeatdt, maxage', [(20*86400, 600*86400), (10*86400, 600*86400)])
+@pytest.mark.parametrize('nump', [8])
 def test_mpi_run(tmpdir, repeatdt, maxage, nump):
     stommel_file = path.join(path.dirname(__file__), '..', 'docs', 'examples', 'example_stommel.py')
     outputMPI = tmpdir.join('StommelMPI')


### PR DESCRIPTION
This PR adds support for setting the chunksize of the `trajectory` dimension in a ParticleFile larger than the initial ParticleSet. 

This is especially important when using `repeatdt`, as we've experienced that `pset.execute()` can become very slow for small initial particle sets that are very often repeated, because zarr writes one file for each particle in that case. Hence, there's now also a warning when using repeatdt and the chunksize is small.

This PR fixes #1316 and #1340, and supersedes #1387