### PR TITLE
Removing stray recovery kernel mentions

### DIFF
--- a/docs/examples/documentation_geospatial.ipynb
+++ b/docs/examples/documentation_geospatial.ipynb
@@ -172,14 +172,13 @@
     "\n",
     "\n",
     "def DeleteParticle(particle, fieldset, time):\n",
-    "    particle.delete()\n",
-    "\n",
+    "    if particle.state > 4:\n",
+    "        particle.delete()\n",
     "\n",
     "pset.execute(\n",
-    "    AdvectionRK4,\n",
+    "    [AdvectionRK4, DeleteParticle],\n",
     "    runtime=timedelta(days=120),\n",
     "    dt=dt,\n",
-    "    recovery={ErrorCode.ErrorOutOfBounds: DeleteParticle},\n",
     "    output_file=output_file,\n",
     ")"
    ]

--- a/docs/examples/tutorial_NestedFields.ipynb
+++ b/docs/examples/tutorial_NestedFields.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "In some applications, you may have access to different fields that each cover only part of the region of interest. Then, you would like to combine them all together. You may also have a field covering the entire region and another one only covering part of it, but with a higher resolution. The set of those fields form what we call nested fields.\n",
     "\n",
-    "It is possible to combine all those fields with kernels, either with different if/else statements depending on particle position, or using recovery kernels (if only two levels of nested fields).\n",
+    "It is possible to combine all those fields with kernels, either with different if/else statements depending on particle position.\n",
     "\n",
     "However, an easier way to work with nested fields in Parcels is to combine all those fields into one `NestedField` object. The Parcels code will then try to successively interpolate the different fields.\n",
     "\n",

--- a/docs/reference/misc.rst
+++ b/docs/reference/misc.rst
@@ -30,7 +30,7 @@ parcels.tools.loggers module
     :undoc-members:
 
 parcels.tools.exampledata_utils module
------------------------------------
+--------------------------------------
 
 .. automodule:: parcels.tools.exampledata_utils
     :members:

--- a/parcels/interaction/interactionkernel.py
+++ b/parcels/interaction/interactionkernel.py
@@ -242,7 +242,7 @@ class InteractionKernel(BaseKernel):
 
         while n_error > 0:
             error_pset = pset.error_particles
-            # Apply recovery kernel
+            # Check for StatusCodes
             for p in error_pset:
                 if p.state == StatusCode.StopExecution:
                     return

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -572,7 +572,7 @@ class Kernel(BaseKernel):
 
         while n_error > 0:
             error_pset = pset.error_particles
-            # Apply recovery kernel
+            # Check for StatusCodes
             for p in error_pset:
                 if p.state == StatusCode.StopExecution:
                     return


### PR DESCRIPTION
This PR cleans up some mentions of recovery kernels, which have been deprecated in v3.0