### PR TITLE
Compilation info as metadata

### DIFF
--- a/parcels/compilation/codegenerator.py
+++ b/parcels/compilation/codegenerator.py
@@ -529,7 +529,7 @@ class KernelGenerator(ABC, ast.NodeVisitor):
                     s = s + ")"
                 node.ccode = str(c.Statement(s))
             else:
-                raise RuntimeError("This print statement is not supported in Python3 version of Parcels")
+                raise RuntimeError("This print statement is not supported")
         else:
             for a in node.args:
                 self.visit(a)

--- a/parcels/compilation/codegenerator.py
+++ b/parcels/compilation/codegenerator.py
@@ -199,14 +199,8 @@ class ParticleNode(IntrinsicNode):
     def __init__(self, obj):
         ccode = ""
         attr_node_class = None
-        if 'Array' in obj.name:
-            attr_node_class = ArrayParticleAttributeNode
-            ccode = 'particles'
-        elif 'Object' in obj.name:
-            attr_node_class = ObjectParticleAttributeNode
-            ccode = 'particle'
-        else:
-            raise AttributeError("Particle Base Class neither matches an 'Array' nor an 'Object' type - cgen class interpretation invalid.")
+        attr_node_class = ArrayParticleAttributeNode
+        ccode = 'particles'
         super().__init__(obj, ccode)
         self.attr_node_class = attr_node_class
 

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -24,8 +24,7 @@ except:
 
 import parcels.rng as ParcelsRandom  # noqa
 from parcels.application_kernels.advection import AdvectionAnalytical, AdvectionRK4_3D
-from parcels.compilation.codegenerator import ArrayKernelGenerator as KernelGenerator
-from parcels.compilation.codegenerator import LoopGenerator
+from parcels.compilation.codegenerator import KernelGenerator, LoopGenerator
 from parcels.field import Field, NestedField, VectorField
 from parcels.grid import GridCode
 from parcels.tools.global_statics import get_cache_dir

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -404,7 +404,8 @@ class Kernel(BaseKernel):
                     all_files_array.append(self.src_file)
                 compiler.compile(self.src_file, self.lib_file, self.log_file)
         if len(all_files_array) > 0:
-            logger.info(f"Compiled {self.name} ==> {self.src_file}")
+            if self.delete_cfiles is False:
+                logger.info(f"Compiled {self.name} ==> {self.src_file}")
             if self.log_file is not None:
                 all_files_array.append(self.log_file)
 

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -964,17 +964,17 @@ class ParticleSet(ABC):
         min_rt = np.min(self.particledata.data['time_nextloop'])
         max_rt = np.max(self.particledata.data['time_nextloop'])
 
-        # Derive _starttime and endtime from arguments or fieldset defaults
-        _starttime = min_rt if dt >= 0 else max_rt
+        # Derive starttime and endtime from arguments or fieldset defaults
+        starttime = min_rt if dt >= 0 else max_rt
         if self.repeatdt is not None and self.repeat_starttime is None:
-            self.repeat_starttime = _starttime
+            self.repeat_starttime = starttime
         if runtime is not None:
-            endtime = _starttime + runtime * np.sign(dt)
+            endtime = starttime + runtime * np.sign(dt)
         elif endtime is None:
             mintime, maxtime = self.fieldset.gridset.dimrange('time_full')
             endtime = maxtime if dt >= 0 else mintime
 
-        if (abs(endtime-_starttime) < 1e-5 or runtime == 0) and dt == 0:
+        if (abs(endtime-starttime) < 1e-5 or runtime == 0) and dt == 0:
             raise RuntimeError("dt and runtime are zero, or endtime is equal to Particle.time. "
                                "ParticleSet.execute() will not do anything.")
 
@@ -985,7 +985,7 @@ class ParticleSet(ABC):
             if self.repeatdt is not None:
                 interupt_dts.append(self.repeatdt)
             callbackdt = np.min(np.array(interupt_dts))
-        time = _starttime
+        time = starttime
         if self.repeatdt:
             next_prelease = self.repeat_starttime + (abs(time - self.repeat_starttime) // self.repeatdt + 1) * self.repeatdt * np.sign(dt)
         else:
@@ -1000,7 +1000,7 @@ class ParticleSet(ABC):
         if output_file:
             logger.info(f'Output files are stored in {output_file.fname}.')
 
-        pbar = tqdm(total=abs(endtime - _starttime), file=sys.stdout)
+        pbar = tqdm(total=abs(endtime - starttime), file=sys.stdout)
 
         tol = 1e-12
         while (time < endtime and dt > 0) or (time > endtime and dt < 0) or dt == 0:

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -109,7 +109,7 @@ class ParticleSet(ABC):
 
         # ==== first: create a new subclass of the pclass that includes the required variables ==== #
         # ==== see dynamic-instantiation trick here: https://www.python-course.eu/python3_classes_and_type.php ==== #
-        class_name = "Array"+pclass.__name__
+        class_name = pclass.__name__
         array_class = None
         if class_name not in dir():
             def ArrayClass_init(self, *args, **kwargs):
@@ -924,6 +924,8 @@ class ParticleSet(ABC):
                 cppargs = ['-DDOUBLE_COORD_VARIABLES'] if self.particledata.lonlatdepth_dtype else None
                 self.kernel.compile(compiler=GNUCompiler(cppargs=cppargs, incdirs=[path.join(get_package_dir(), 'include'), "."]))
                 self.kernel.load_lib()
+        if output_file:
+            output_file.add_metadata('parcels_kernels', self.kernel.name)
 
         # Set up the interaction kernel(s) if not set and given.
         if self.interaction_kernel is None and pyfunc_inter is not None:

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -872,7 +872,7 @@ class ParticleSet(ABC):
         self.particledata.set_variable_write_status(var, write_status)
 
     def execute(self, pyfunc=AdvectionRK4, pyfunc_inter=None, endtime=None, runtime=None, dt=1.,
-                output_file=None, postIterationCallbacks=None, callbackdt=None):
+                output_file=None, verbose_progress=True, postIterationCallbacks=None, callbackdt=None):
         """Execute a given kernel function over the particle set for multiple timesteps.
 
         Optionally also provide sub-timestepping
@@ -896,6 +896,8 @@ class ParticleSet(ABC):
             Use a negative value for a backward-in-time simulation. (Default value = 1.)
         output_file :
             mod:`parcels.particlefile.ParticleFile` object for particle output (Default value = None)
+        verbose_progress : bool
+            Boolean for providing a progress bar for the kernel execution loop. (Default value = True)
         postIterationCallbacks :
             Optional) Array of functions that are to be called after each iteration (post-process, non-Kernel) (Default value = None)
         callbackdt :
@@ -1000,7 +1002,8 @@ class ParticleSet(ABC):
         if output_file:
             logger.info(f'Output files are stored in {output_file.fname}.')
 
-        pbar = tqdm(total=abs(endtime - starttime), file=sys.stdout)
+        if verbose_progress:
+            pbar = tqdm(total=abs(endtime - starttime), file=sys.stdout)
 
         tol = 1e-12
         while (time < endtime and dt > 0) or (time > endtime and dt < 0) or dt == 0:
@@ -1072,6 +1075,8 @@ class ParticleSet(ABC):
                 next_input = self.fieldset.computeTimeChunk(time, dt)
             if dt == 0:
                 break
-            pbar.update(abs(time - time_at_startofloop))
+            if verbose_progress:
+                pbar.update(abs(time - time_at_startofloop))
 
-        pbar.close()
+        if verbose_progress:
+            pbar.close()

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -250,7 +250,7 @@ def test_print(fieldset, mode, capfd):
         particle.p = 1e-3
         tmp = 5
         print("%d %f %f" % (particle.id, particle.p, tmp))
-    pset.execute(kernel, endtime=1., dt=1.)
+    pset.execute(kernel, endtime=1., dt=1., verbose_progress=False)
     out, err = capfd.readouterr()
     lst = out.split(' ')
     tol = 1e-8

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -259,7 +259,7 @@ def test_print(fieldset, mode, capfd):
     def kernel2(particle, fieldset, time):
         tmp = 3
         print("%f" % (tmp))
-    pset.execute(kernel2, endtime=2., dt=1.)
+    pset.execute(kernel2, endtime=2., dt=1., verbose_progress=False)
     out, err = capfd.readouterr()
     lst = out.split(' ')
     assert abs(float(lst[0]) - 3) < tol

--- a/tests/test_particlefile.py
+++ b/tests/test_particlefile.py
@@ -30,6 +30,20 @@ def fieldset_ficture(xdim=40, ydim=100):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_metadata(fieldset, mode, tmpdir):
+    filepath = tmpdir.join("pfile_metadata.zarr")
+    pset = ParticleSet(fieldset, pclass=ptype[mode], lon=0, lat=0)
+
+    def DoNothing(particle, fieldset, time):
+        pass
+
+    pset.execute(DoNothing, runtime=1, output_file=pset.ParticleFile(filepath))
+
+    ds = xr.open_zarr(filepath)
+    assert ds.attrs['parcels_kernels'].lower() == f'{mode}ParticleDoNothing'.lower()
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pfile_array_write_zarr_memorystore(fieldset, mode, npart=10):
     """Checkt that writing to a Zarr MemoryStore works."""
     zarr_store = MemoryStore()


### PR DESCRIPTION
This PR changes the way that Compilation Information is presented. It is now only displayed as a logging message if `delete_cfiles=False`; and is always stored as a metadata attribute in the zarr output

Furthermore, this PR also cleans up the codeconverter (old stray code that was left after #1423)

Todo
- [x] Always show progress bar, even for short runs, as this gives useful feedback to users and also gives a more accurate time estimate (and remove `verbose_progress=True` option?)