### PR TITLE
Removing particleset.density

### DIFF
--- a/tests/test_particlesets.py
+++ b/tests/test_particlesets.py
@@ -383,22 +383,6 @@ def test_pset_multi_execute_delete(fieldset, mode, npart=10, n=5):
     assert np.allclose(pset.lat, n*0.1, atol=1e-12)
 
 
-@pytest.mark.parametrize('mode', ['scipy', 'jit'])
-@pytest.mark.parametrize('area_scale', [True, False])
-def test_density(fieldset, mode, area_scale):
-    lons, lats = np.meshgrid(np.linspace(0.05, 0.95, 10), np.linspace(-30, 30, 20))
-    pset = ParticleSet(fieldset, pclass=ptype[mode], lon=lons, lat=lats)
-    arr = pset.density(area_scale=area_scale)
-    if area_scale:
-        assert np.allclose(arr, 1 / fieldset.U.cell_areas(), rtol=1e-3)  # check that density equals 1/area
-    else:
-        assert np.sum(arr) == lons.size  # check conservation of particles
-        inds = np.where(arr)
-        for i in range(len(inds[0])):  # check locations (low atol because of coarse grid)
-            assert np.allclose(fieldset.U.lon[inds[1][i]], pset[i].lon, atol=fieldset.U.lon[1]-fieldset.U.lon[0])
-            assert np.allclose(fieldset.U.lat[inds[0][i]], pset[i].lat, atol=fieldset.U.lat[1]-fieldset.U.lat[0])
-
-
 @pytest.mark.parametrize('staggered_grid', ['Agrid', 'Cgrid'])
 def test_from_field_exact_val(staggered_grid):
     xdim = 4


### PR DESCRIPTION
Removing the `pset.density` function, as it is purely a post-processing analysis function that is not needed for particle simulations. Users can use `numpy.hist2d` instead