### PR TITLE
Simplifying binder environment file

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,13 +1,7 @@
-name: py3_parcels
+name: parcels_binder
 channels:
   - conda-forge
   - defaults
 dependencies:
   - python>=3.8
   - parcels
-  - ffmpeg>=3.2.3
-  - mpi4py>=3.0.1
-  - mpich>=3.2.1
-  - py>=1.4.27
-  - scikit-learn
-  - pykdtree


### PR DESCRIPTION
This PR simplifies the Parcels binder environment file, as the typical binder user does not need mpi and scikitlearn features