### PR TITLE
Remove python from binder environment file

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -3,5 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.8
   - parcels


### PR DESCRIPTION
As we now get an error as below

```
# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/srv/conda/lib/python3.11/site-packages/conda/exception_handler.py", line 16, in __call__
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/srv/conda/lib/python3.11/site-packages/conda_env/cli/main.py", line 49, in do_call
        exit_code = getattr(module, func_name)(args, parser)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/srv/conda/lib/python3.11/site-packages/conda/notices/core.py", line 123, in wrapper
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/srv/conda/lib/python3.11/site-packages/conda_env/cli/main_update.py", line 139, in execute
        result[installer_type] = installer.install(prefix, specs, args, env)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/srv/conda/lib/python3.11/site-packages/mamba/mamba_env.py", line 153, in mamba_install
        transaction.fetch_extract_packages()
    RuntimeError: Could not set URL (code: 14 - url = /wheel-0.40.0-pyhd8ed1ab_0.conda)

`$ /srv/conda/bin/mamba update -p /srv/conda/envs/notebook --file .binder/environment.yml`
```
Following suggestion at https://discourse.jupyter.org/t/mybinder-stopped-working-for-repo/21170, removing the `python>=3.8` from the binder environment file might help