### PR TITLE
Adding support for using Field.from_netcdf() with variable as a dict

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -314,8 +314,8 @@ class Field:
             list of filenames to read for the field. filenames can be a list ``[files]`` or
             a dictionary ``{dim:[files]}`` (if lon, lat, depth and/or data not stored in same files as data)
             In the latter case, time values are in filenames[data]
-        variable : tuple of str or str
-            Tuple mapping field name to variable name in the NetCDF file.
+        variable : dict, tuple of str or str
+            Dict or tuple mapping field name to variable name in the NetCDF file.
         dimensions : dict
             Dictionary mapping variable names for the relevant dimensions in the NetCDF file
         indices :
@@ -385,6 +385,9 @@ class Field:
 
         if isinstance(variable, str):  # for backward compatibility with Parcels < 2.0.0
             variable = (variable, variable)
+        elif isinstance(variable, dict):
+            assert len(variable) == 1, 'Field.from_netcdf() supports only one variable at a time. Use FieldSet.from_netcdf() for multiple variables.'
+            variable = tuple(variable.items())[0]
         assert len(variable) == 2, 'The variable tuple must have length 2. Use FieldSet.from_netcdf() for multiple variables'
 
         data_filenames = cls.get_dim_filenames(filenames, 'data')

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -138,6 +138,30 @@ def test_fieldset_from_parcels(xdim, ydim, tmpdir, filename='test_parcels'):
     assert np.allclose(fieldset.V.data[0, :], data['V'], rtol=1e-12)
 
 
+def test_field_from_netcdf_variables():
+    data_path = path.join(path.dirname(__file__), 'test_data/')
+    filename = data_path + 'perlinfieldsU.nc'
+    dims = {'lon': 'x', 'lat': 'y'}
+
+    variable = 'vozocrtx'
+    f1 = Field.from_netcdf(filename, variable, dims)
+    variable = ('U', 'vozocrtx')
+    f2 = Field.from_netcdf(filename, variable, dims)
+    variable = {'U': 'vozocrtx'}
+    f3 = Field.from_netcdf(filename, variable, dims)
+
+    assert np.allclose(f1.data, f2.data, atol=1e-12)
+    assert np.allclose(f1.data, f3.data, atol=1e-12)
+
+    failed = False
+    try:
+        variable = {'U': 'vozocrtx', 'nav_lat': 'nav_lat'}  # multiple variables will fail
+        f3 = Field.from_netcdf(filename, variable, dims)
+    except AssertionError:
+        failed = True
+    assert failed
+
+
 @pytest.mark.parametrize('calendar, cftime_datetime',
                          zip(_get_cftime_calendars(),
                              _get_cftime_datetimes()))


### PR DESCRIPTION
This PR implements support for using `Field.from_netcdf()` with `variable` as a `dict`, in order to more closely resemble the syntax for `FieldSet.from_netcdf()`, where `variables` is a `dict`