### PR TITLE
Fixing the installation instructions for v3.0 by setting conda solver

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,13 @@ The steps below are the installation instructions for Linux, macOS and Windows.
 .. code-block:: bash
 
     conda activate base
+    conda install -n base conda-libmamba-solver
+    conda config --set solver libmamba
     conda create -n parcels -c conda-forge parcels cartopy jupyter
+
+.. note::
+
+  The second and third line are temporarily needed to select the latest version 3.0 of Parcels. This will be fixed in the next release of conda. See `here <https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community>`_ for more background information.
 
 .. note::
 


### PR DESCRIPTION
As discussed at https://github.com/conda-forge/parcels-feedstock/issues/100, some users did not end up with the newest v3.0 when installing parcels via conda. This turned out to be because of the solver used in conda. 

As suggested by @ocefpaf, we now (temporarily) add instructions to set the solver to `libmamba` in the installation instructions, see also https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community