### PR TITLE
Updating timestamps tutorial to remove time_periodic=True option

### DIFF
--- a/docs/examples/tutorial_timestamps.ipynb
+++ b/docs/examples/tutorial_timestamps.ipynb
@@ -155,7 +155,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note, by the way, that adding the `time_periodic=True` argument to `Field.from_netcdf()` will also mean that the climatology can be cycled for multiple years.\n"
+    "Note, by the way, that adding the `time_periodic` argument to `Field.from_netcdf()` will also mean that the climatology can be cycled for multiple years.\n"
    ]
   },
   {


### PR DESCRIPTION
Fixing an old deprecated use of `time_periodic`, as reported by @ignasivalles in #1475 