### PR TITLE
make it possible to import dataset with single time instance

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -280,10 +280,13 @@ class Field:
         if timestamps is not None:
             dataFiles = []
             for findex in range(len(data_filenames)):
-                stamps_in_file = 1 if isinstance(timestamps[findex], int) else len(timestamps[findex])
+                stamps_in_file = 1 if isinstance(timestamps[findex], (int, np.datetime64)) else len(timestamps[findex])
                 for f in [data_filenames[findex], ] * stamps_in_file:
                     dataFiles.append(f)
-            timeslices = np.array([stamp for file in timestamps for stamp in file])
+            if stamps_in_file == 1:
+                timeslices = timestamps
+            else:
+                timeslices = np.array([stamp for file in timestamps for stamp in file])
             time = timeslices
         else:
             timeslices = []

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -283,10 +283,7 @@ class Field:
                 stamps_in_file = 1 if isinstance(timestamps[findex], (int, np.datetime64)) else len(timestamps[findex])
                 for f in [data_filenames[findex], ] * stamps_in_file:
                     dataFiles.append(f)
-            if stamps_in_file == 1:
-                timeslices = timestamps
-            else:
-                timeslices = np.array([stamp for file in timestamps for stamp in file])
+            timeslices = np.array([stamp for file in timestamps for stamp in file])
             time = timeslices
         else:
             timeslices = []

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -193,8 +193,10 @@ def test_field_from_netcdf(with_timestamps):
     variable = 'U'
     dimensions = {'lon': 'glamf', 'lat': 'gphif'}
     if with_timestamps:
-        timestamps = [[2]]
-        Field.from_netcdf(filenames, variable, dimensions, interp_method='cgrid_velocity', timestamps=timestamps)
+        timestamp_types = [ [[2]],
+                            [[np.datetime64('2000-01-01')]] ]
+        for timestamps in timestamp_types:
+            Field.from_netcdf(filenames, variable, dimensions, interp_method='cgrid_velocity', timestamps=timestamps)
     else:
         Field.from_netcdf(filenames, variable, dimensions, interp_method='cgrid_velocity')
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -193,8 +193,7 @@ def test_field_from_netcdf(with_timestamps):
     variable = 'U'
     dimensions = {'lon': 'glamf', 'lat': 'gphif'}
     if with_timestamps:
-        timestamp_types = [ [[2]],
-                            [[np.datetime64('2000-01-01')]] ]
+        timestamp_types = [[[2]], [[np.datetime64('2000-01-01')]]]
         for timestamps in timestamp_types:
             Field.from_netcdf(filenames, variable, dimensions, interp_method='cgrid_velocity', timestamps=timestamps)
     else:


### PR DESCRIPTION
As shown in the [tutorial](https://docs.oceanparcels.org/en/latest/examples/tutorial_timestamps.html) it is possible to assign date information via the timestamp keyword. However, if a single instance is given, this gave errors. Hence the following adjustments resolve this issue.

Example code snippet:
```
depth = Field.from_netcdf([f"{elev_dir}/bodem-zunov4.nc"], 'Z',
                          {'lat': 'lat', 'lon': 'lon'},
                          interp_method=interp, time_periodic=True,
                          timestamps=[np.datetime64("2020-01-01")])
depth.name = 'Z'
fieldset.add_field(depth)
```
