### PR TITLE
Explaining statuscode kernel order

### DIFF
--- a/docs/examples/tutorial_kernelloop.ipynb
+++ b/docs/examples/tutorial_kernelloop.ipynb
@@ -413,7 +413,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Kernel functions such as the ones above can then be added to the list of kernels in `pset.execute()`."
+    "Kernel functions such as the ones above can then be added to the list of kernels in `pset.execute()`. \n",
+    "\n",
+    "Note that these Kernels that control what to do with `particle.state` should typically be added at the _end_ of the Kernel list, because otherwise later Kernels may overwrite the `particle.state` or the `particle_dlon` variables."
    ]
   }
  ],

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -510,8 +510,9 @@ class Field:
                     filebuffer.name = filebuffer.parse_name(variable[1])
                     buffer_data = filebuffer.data
                     if len(buffer_data.shape) == 4:
-                        errormessage = (f'Field {filebuffer.name} expecting a data shape of [tdim, zdim, ydim, xdim]. '
-                                        'Flag transpose=True could help to reorder the data.')
+                        errormessage = (f'Field {filebuffer.name} expecting a data shape of [tdim={grid.tdim}, zdim={grid.zdim}, '
+                                        f'ydim={grid.ydim - 2 * grid.meridional_halo}, xdim={grid.xdim - 2 * grid.zonal_halo}] '
+                                        f'but got shape {buffer_data.shape}. Flag transpose=True could help to reorder the data.')
                         assert buffer_data.shape[0] == grid.tdim, errormessage
                         assert buffer_data.shape[2] == grid.ydim - 2 * grid.meridional_halo, errormessage
                         assert buffer_data.shape[3] == grid.xdim - 2 * grid.zonal_halo, errormessage


### PR DESCRIPTION
Adding an explanation that Kernels that control what to do on statustcode should typically be put at the end of the Kernel list. This addresses https://github.com/OceanParcels/parcels/discussions/1507