### PR TITLE
Clarifying particle_dlon variable use in kernel loop tutorial

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,16 +72,13 @@ linkcheck_ignore = [
     r"https://www\.sciencedirect\.com/.*",  # Site doesn't allow crawling
     r"https://lxml\.de/",  # Crawler occasionally fails to establish connection
     r"https://linux\.die\.net/",  # Site doesn't allow crawling
+    r"https://github\.com/github.com/OceanParcels/parcels/blob/*py#L*",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
 
     # To monitor
     r"http://marine.copernicus.eu/",  # 2023-06-07 Site non-responsive
     r"https://www\.nodc\.noaa\.gov/",  # 2023-06-23 Site non-responsive
     r"https://mybinder\.org/",  # 2023-09-02 Site non-responsive
     r"https://ariane-code.cnrs.fr/",  # 2024-04-30 Site non-responsive
-]
-
-linkcheck_anchors_ignore_for_url = [
-    r"https://github\.com/",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
 ]
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,10 @@ linkcheck_ignore = [
     r"https://ariane-code.cnrs.fr/",  # 2024-04-30 Site non-responsive
 ]
 
+linkcheck_anchors_ignore_for_url = [
+    r"https://github\.com/OceanParcels/parcels/blob/*#L*",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
+]
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ linkcheck_ignore = [
     r"https://www\.sciencedirect\.com/.*",  # Site doesn't allow crawling
     r"https://lxml\.de/",  # Crawler occasionally fails to establish connection
     r"https://linux\.die\.net/",  # Site doesn't allow crawling
-    r"https://github\.com/github.com/OceanParcels/parcels/blob/*py#L*",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
+    r"https://github\.com/github\.com/OceanParcels/parcels/blob/*py#L*",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
 
     # To monitor
     r"http://marine.copernicus.eu/",  # 2023-06-07 Site non-responsive

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ linkcheck_ignore = [
 ]
 
 linkcheck_anchors_ignore_for_url = [
-    r"https://github\.com/OceanParcels/parcels/blob/*#L*",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
+    r"https://github\.com/",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
 ]
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,12 +78,7 @@ linkcheck_ignore = [
     r"https://www\.nodc\.noaa\.gov/",  # 2023-06-23 Site non-responsive
     r"https://mybinder\.org/",  # 2023-09-02 Site non-responsive
     r"https://ariane-code.cnrs.fr/",  # 2024-04-30 Site non-responsive
-]
-
-linkcheck_anchors = False
-
-linkcheck_anchors_ignore_for_url = [
-    r"https://github\.com/",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
+    r"https://github.com/OceanParcels/parcels/blob/daa4b062ed8ae0b2be3d87367d6b45599d6f95db/parcels/.*",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
 ]
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ linkcheck_ignore = [
 ]
 
 linkcheck_anchors_ignore_for_url = [
-    r"https://github\.com/OceanParcels/parcels/blob/daa4b062ed8ae0b2be3d87367d6b45599d6f95db/parcels/kernel\.py",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
+    r"https://github\.com/",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
 ]
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,8 @@ linkcheck_ignore = [
     r"https://ariane-code.cnrs.fr/",  # 2024-04-30 Site non-responsive
 ]
 
+linkcheck_anchors = False
+
 linkcheck_anchors_ignore_for_url = [
     r"https://github\.com/",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,13 +72,16 @@ linkcheck_ignore = [
     r"https://www\.sciencedirect\.com/.*",  # Site doesn't allow crawling
     r"https://lxml\.de/",  # Crawler occasionally fails to establish connection
     r"https://linux\.die\.net/",  # Site doesn't allow crawling
-    r"https://github\.com/github\.com/OceanParcels/parcels/blob/*py#L*",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
 
     # To monitor
     r"http://marine.copernicus.eu/",  # 2023-06-07 Site non-responsive
     r"https://www\.nodc\.noaa\.gov/",  # 2023-06-23 Site non-responsive
     r"https://mybinder\.org/",  # 2023-09-02 Site non-responsive
     r"https://ariane-code.cnrs.fr/",  # 2024-04-30 Site non-responsive
+]
+
+linkcheck_anchors_ignore_for_url = [
+    r"https://github\.com/OceanParcels/parcels/blob/daa4b062ed8ae0b2be3d87367d6b45599d6f95db/parcels/kernel\.py",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
 ]
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/examples/documentation_MPI.ipynb
+++ b/docs/examples/documentation_MPI.ipynb
@@ -192,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The notebook below shows an example script to explore the scaling of the time taken for `pset.execute()` as a function of zonal and meridional `chunksize` for a dataset from the [CMEMS](http://marine.copernicus.eu/) portal.\n"
+    "The notebook below shows an example script to explore the scaling of the time taken for `pset.execute()` as a function of zonal and meridional `chunksize` for a dataset from the [Copernicus Marine Service](http://marine.copernicus.eu/) portal.\n"
    ]
   },
   {

--- a/docs/examples/documentation_stuck_particles.ipynb
+++ b/docs/examples/documentation_stuck_particles.ipynb
@@ -99,7 +99,7 @@
     "\n",
     "Arakawa A grids are unstaggered grids where the velocities $u$, $v$ (and $w$), pressure and other tracers are defined at the same position (on so-called nodes). In numerical models, these nodes can be located **at the corner _or_ at the center of the grid cells**. This means that the cell boundaries, and therefore the solid-fluid boundaries can either be located at the nodes (**figure 1A**) or at 0.5 dx distance from the nodes (**figure 1B**) respectively.\n",
     "\n",
-    "Many ocean models natively run on a C grid, because boundary conditions are easier to implement there (see [C grid](#2.-C-grids)). Sometimes, the C-grid output of these models is interpolated onto an A grid. This is the case for all(?) the data available from [CMEMS](https://resources.marine.copernicus.eu/?option=com_csw&view=details&product_id=GLOBAL_ANALYSIS_FORECAST_PHY_001_024), which provide the data on a rectilinear A grid velocity field.\n",
+    "Many ocean models natively run on a C grid, because boundary conditions are easier to implement there (see [C grid](#2.-C-grids)). Sometimes, the C-grid output of these models is interpolated onto an A grid. This is the case for all(?) the data available from [Copernicus Marine Data Store](https://data.marine.copernicus.eu/products), which provide the data on a rectilinear A grid velocity field.\n",
     "\n",
     "To visualize this, in **figure 1** we show the nodes and cells of a coastal region. The ocean cells and nodes are in red and the land cells and nodes are in white.\n"
    ]

--- a/docs/examples/documentation_unstuck_Agrid.ipynb
+++ b/docs/examples/documentation_unstuck_Agrid.ipynb
@@ -1457,7 +1457,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now simulate the three different boundary conditions by advecting the 9 particles from above in a time-evolving SMOC dataset from [CMEMS](https://resources.marine.copernicus.eu/?option=com_csw&view=details&product_id=GLOBAL_ANALYSIS_FORECAST_PHY_001_024).\n"
+    "We now simulate the three different boundary conditions by advecting the 9 particles from above in a time-evolving SMOC dataset from the [Copernicus Marine Data Store](https://data.marine.copernicus.eu/product/GLOBAL_ANALYSISFORECAST_PHY_001_024/services).\n"
    ]
   },
   {

--- a/docs/examples/tutorial_kernelloop.ipynb
+++ b/docs/examples/tutorial_kernelloop.ipynb
@@ -26,7 +26,17 @@
     "\n",
     "When you run a Parcels simulation (i.e. a call to `pset.execute()`), the Kernel loop is the main part of the code that is executed. This part of the code loops through all particles and executes the Kernels that are defined for each particle.\n",
     "\n",
-    "In order to make sure that the displacements of a particle in the different Kernels can be summed, all Kernels add to a _change_ in position. This is important, because there are situations where movement kernels would otherwise not commute. Take the example of advecting particles by currents _and_ winds. If the particle would first be moved by the currents and then by the winds, the result could be different from first moving by the winds and then by the currents. Instead, by adding the changes in position, the ordering of the Kernels has no consequence on the particle displacement."
+    "In order to make sure that the displacements of a particle in the different Kernels can be summed, all Kernels add to a _change_ in position (`particle_dlon`, `particle_dlat`, and `particle_ddepth`). This is important, because there are situations where movement kernels would otherwise not commute. Take the example of advecting particles by currents _and_ winds. If the particle would first be moved by the currents and then by the winds, the result could be different from first moving by the winds and then by the currents. Instead, by adding the changes in position, the ordering of the Kernels has no consequence on the particle displacement."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "__Note__ that the variables `particle_dlon`, `particle_dlat`, and `particle_ddepth` are defined by the wrapper function that Parcels generates for each Kernel. This is why you don't have to define these variables yourself when writing a Kernel. See [here](https://github.com/OceanParcels/parcels/blob/daa4b062ed8ae0b2be3d87367d6b45599d6f95db/parcels/kernel.py#L277-L294) for the implementation of the wrapper functions.\n",
+    "</div>"
    ]
   },
   {

--- a/docs/examples/tutorial_kernelloop.ipynb
+++ b/docs/examples/tutorial_kernelloop.ipynb
@@ -35,7 +35,7 @@
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "__Note__ that the variables `particle_dlon`, `particle_dlat`, and `particle_ddepth` are defined by the wrapper function that Parcels generates for each Kernel. This is why you don't have to define these variables yourself when writing a Kernel. See [here](https://github.com/OceanParcels/parcels/blob/daa4b062ed8ae0b2be3d87367d6b45599d6f95db/parcels/kernel.py#L277-L294) for the implementation of the wrapper functions.\n",
+    "__Note__ that the variables `particle_dlon`, `particle_dlat`, and `particle_ddepth` are defined by the wrapper function that Parcels generates for each Kernel. This is why you don't have to define these variables yourself when writing a Kernel. See [here](https://github.com/OceanParcels/parcels/blob/daa4b062ed8ae0b2be3d87367d6b45599d6f95db/parcels/kernel.py#user-content-L277-L294) for the implementation of the wrapper functions.\n",
     "</div>"
    ]
   },

--- a/docs/examples/tutorial_kernelloop.ipynb
+++ b/docs/examples/tutorial_kernelloop.ipynb
@@ -35,7 +35,7 @@
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "__Note__ that the variables `particle_dlon`, `particle_dlat`, and `particle_ddepth` are defined by the wrapper function that Parcels generates for each Kernel. This is why you don't have to define these variables yourself when writing a Kernel. See [here](https://github.com/OceanParcels/parcels/blob/daa4b062ed8ae0b2be3d87367d6b45599d6f95db/parcels/kernel.py#user-content-L277-L294) for the implementation of the wrapper functions.\n",
+    "__Note__ that the variables `particle_dlon`, `particle_dlat`, and `particle_ddepth` are defined by the wrapper function that Parcels generates for each Kernel. This is why you don't have to define these variables yourself when writing a Kernel. See [here](https://github.com/OceanParcels/parcels/blob/daa4b062ed8ae0b2be3d87367d6b45599d6f95db/parcels/kernel.py#L277-L294) for the implementation of the wrapper functions.\n",
     "</div>"
    ]
   },


### PR DESCRIPTION
Adding a note to the kernel loop notebook about naming of the `particle_dlon`, `particle_dlat`, and `particle_ddepth` variables

This follows from a conversation with @surgura about confusion why `particle_dlon` etc did not have to be specified in custom Kernels