### PR TITLE
Adding support for delete_cfiles as pset.execute() keyword

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -735,10 +735,10 @@ class ParticleSet(ABC):
             delete_cfiles=delete_cfiles,
         )
 
-    def InteractionKernel(self, pyfunc_inter):
+    def InteractionKernel(self, pyfunc_inter, delete_cfiles=True):
         if pyfunc_inter is None:
             return None
-        return InteractionKernel(self.fieldset, self.particledata.ptype, pyfunc=pyfunc_inter)
+        return InteractionKernel(self.fieldset, self.particledata.ptype, pyfunc=pyfunc_inter, delete_cfiles=delete_cfiles)
 
     def ParticleFile(self, *args, **kwargs):
         """Wrapper method to initialise a :class:`parcels.particlefile.ParticleFile` object from the ParticleSet."""
@@ -805,7 +805,7 @@ class ParticleSet(ABC):
         self.particledata.set_variable_write_status(var, write_status)
 
     def execute(self, pyfunc=AdvectionRK4, pyfunc_inter=None, endtime=None, runtime=None, dt=1.,
-                output_file=None, verbose_progress=True, postIterationCallbacks=None, callbackdt=None):
+                output_file=None, verbose_progress=True, postIterationCallbacks=None, callbackdt=None, delete_cfiles=True):
         """Execute a given kernel function over the particle set for multiple timesteps.
 
         Optionally also provide sub-timestepping
@@ -836,7 +836,9 @@ class ParticleSet(ABC):
         callbackdt :
             Optional, in conjecture with 'postIterationCallbacks', timestep interval to (latest) interrupt the running kernel and invoke post-iteration callbacks from 'postIterationCallbacks' (Default value = None)
         pyfunc_inter :
-             (Default value = None)
+            (Default value = None)
+        delete_cfiles : bool
+            Whether to delete the C-files after compilation in JIT mode (default is True)
         """
         # check if pyfunc has changed since last compile. If so, recompile
         if self.kernel is None or (self.kernel.pyfunc is not pyfunc and self.kernel is not pyfunc):
@@ -844,7 +846,7 @@ class ParticleSet(ABC):
             if isinstance(pyfunc, Kernel):
                 self.kernel = pyfunc
             else:
-                self.kernel = self.Kernel(pyfunc)
+                self.kernel = self.Kernel(pyfunc, delete_cfiles=delete_cfiles)
             # Prepare JIT kernel execution
             if self.particledata.ptype.uses_jit:
                 self.kernel.remove_lib()
@@ -859,7 +861,7 @@ class ParticleSet(ABC):
             if isinstance(pyfunc_inter, InteractionKernel):
                 self.interaction_kernel = pyfunc_inter
             else:
-                self.interaction_kernel = self.InteractionKernel(pyfunc_inter)
+                self.interaction_kernel = self.InteractionKernel(pyfunc_inter, delete_cfiles=delete_cfiles)
 
         # Convert all time variables to seconds
         if isinstance(endtime, delta):

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -338,7 +338,7 @@ def test_update_kernel_in_script(fieldset, mode):
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="skipping windows test as windows compiler generates warning")
 def test_execution_keep_cfiles_and_nocompilation_warnings(fieldset, delete_cfiles):
     pset = ParticleSet(fieldset, pclass=JITParticle, lon=[0.], lat=[0.])
-    pset.execute(pset.Kernel(AdvectionRK4, delete_cfiles=delete_cfiles), endtime=1., dt=1.)
+    pset.execute(AdvectionRK4, delete_cfiles=delete_cfiles, endtime=1., dt=1.)
     cfile = pset.kernel.src_file
     logfile = pset.kernel.log_file
     del pset.kernel


### PR DESCRIPTION
This PR adds support for the `delete_cfiles=False` flag directly in the `pset.execute()` call. Since we use Kernel lists (#1347), custom kernels are often not converted to Kernel objects anymore, so it makes more sense to have this flag here