### PR TITLE
Compilation error message fix for local variable name that is also FieldSet constant

### DIFF
--- a/parcels/compilation/codegenerator.py
+++ b/parcels/compilation/codegenerator.py
@@ -320,6 +320,9 @@ class IntrinsicTransformer(ast.NodeTransformer):
     def visit_Assign(self, node):
         node.targets = [self.visit(t) for t in node.targets]
         node.value = self.visit(node.value)
+        if isinstance(node.value, ConstNode) and len(node.targets) > 0 and isinstance(node.targets[0], ast.Name):
+            if node.targets[0].id == node.value.ccode:
+                raise NotImplementedError(f"Assignment of fieldset.{node.value.ccode} to a local variable {node.targets[0].id} with same name in kernel. This is not allowed.")
         stmts = [node]
 
         # Inject statements from the stack

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -299,18 +299,13 @@ def test_empty_indices(tmpdir, filename='test_subsets'):
     data, dimensions = generate_fieldset(100, 100)
     filepath = tmpdir.join(filename)
     FieldSet.from_data(data, dimensions).write(filepath)
-    error_thrown = False
-    try:
+    with pytest.raises(RuntimeError):
         FieldSet.from_parcels(filepath, indices={'lon': []})
-    except RuntimeError:
-        error_thrown = True
-    assert error_thrown
 
 
 @pytest.mark.parametrize('calltype', ['from_data', 'from_nemo'])
 def test_illegal_dimensionsdict(calltype):
-    error_thrown = False
-    try:
+    with pytest.raises(NameError):
         if calltype == 'from_data':
             data, dimensions = generate_fieldset(10, 10)
             dimensions['test'] = None
@@ -320,11 +315,7 @@ def test_illegal_dimensionsdict(calltype):
             filenames = {'dx': fname, 'mesh_mask': fname}
             variables = {'dx': 'e1u'}
             dimensions = {'lon': 'glamu', 'lat': 'gphiu', 'test': 'test'}
-            error_thrown = False
             FieldSet.from_nemo(filenames, variables, dimensions)
-    except NameError:
-        error_thrown = True
-    assert error_thrown
 
 
 @pytest.mark.parametrize('xdim', [100, 200])
@@ -345,17 +336,12 @@ def test_add_duplicate_field(dupobject):
     fieldset = FieldSet.from_data(data, dimensions)
     field = Field('newfld', fieldset.U.data, lon=fieldset.U.lon, lat=fieldset.U.lat)
     fieldset.add_field(field)
-    error_thrown = False
-    try:
+    with pytest.raises(RuntimeError):
         if dupobject == 'same':
             fieldset.add_field(field)
         elif dupobject == 'new':
             field2 = Field('newfld', np.ones((2, 2)), lon=np.array([0, 1]), lat=np.array([0, 2]))
             fieldset.add_field(field2)
-    except RuntimeError:
-        error_thrown = True
-
-    assert error_thrown
 
 
 @pytest.mark.parametrize('fieldtype', ['normal', 'vector'])
@@ -366,16 +352,11 @@ def test_add_field_after_pset(fieldtype):
     field1 = Field('field1', fieldset.U.data, lon=fieldset.U.lon, lat=fieldset.U.lat)
     field2 = Field('field2', fieldset.U.data, lon=fieldset.U.lon, lat=fieldset.U.lat)
     vfield = VectorField('vfield', field1, field2)
-    error_thrown = False
-    try:
+    with pytest.raises(RuntimeError):
         if fieldtype == 'normal':
             fieldset.add_field(field1)
         elif fieldtype == 'vector':
             fieldset.add_vector_field(vfield)
-    except RuntimeError:
-        error_thrown = True
-
-    assert error_thrown
 
 
 @pytest.mark.parametrize('chunksize', ['auto', None])

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -119,12 +119,8 @@ def test_execution_fail_python_exception(fieldset, mode, npart=10):
     pset = ParticleSet(fieldset, pclass=ptype[mode],
                        lon=np.linspace(0, 1, npart),
                        lat=np.linspace(1, 0, npart))
-    error_thrown = False
-    try:
+    with pytest.raises(RuntimeError):
         pset.execute(PythonFail, endtime=20., dt=2.)
-    except RuntimeError:
-        error_thrown = True
-    assert error_thrown
     assert len(pset) == npart
     assert np.isclose(pset.time[0], 10)
     assert np.allclose(pset.time[1:], 0.)
@@ -139,12 +135,8 @@ def test_execution_fail_out_of_bounds(fieldset, mode, npart=10):
     pset = ParticleSet(fieldset, pclass=ptype[mode],
                        lon=np.linspace(0, 1, npart),
                        lat=np.linspace(1, 0, npart))
-    error_thrown = False
-    try:
+    with pytest.raises(FieldOutOfBoundError):
         pset.execute(MoveRight, endtime=10., dt=1.)
-    except FieldOutOfBoundError:
-        error_thrown = True
-    assert error_thrown
     assert len(pset) == npart
     assert (pset.lon - 1. > -1.e12).all()
 

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -204,12 +204,8 @@ def test_varname_as_fieldname():
     def kernel_varname(particle, fieldset, time):
         vertical_speed = fieldset.vertical_speed  # noqa
 
-    error_thrown = False
-    try:
+    with pytest.raises(Exception):
         pset.execute(kernel_varname, endtime=1, dt=1.)
-    except NotImplementedError:
-        error_thrown = True
-    assert error_thrown
 
 
 def test_abs():

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -204,7 +204,7 @@ def test_varname_as_fieldname():
     def kernel_varname(particle, fieldset, time):
         vertical_speed = fieldset.vertical_speed  # noqa
 
-    with pytest.raises(Exception):
+    with pytest.raises(NotImplementedError):
         pset.execute(kernel_varname, endtime=1, dt=1.)
 
 

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -198,7 +198,7 @@ def test_varname_as_fieldname():
     def kernel_particlename(particle, fieldset, time):
         particle.speed = fieldset.speed[particle]  # noqa
 
-    pset.execute(kernel_particlename, endtime=1, dt=1., delete_cfiles=True)
+    pset.execute(kernel_particlename, endtime=1, dt=1.)
     assert pset[0].speed == 10
 
     def kernel_varname(particle, fieldset, time):
@@ -206,7 +206,7 @@ def test_varname_as_fieldname():
 
     error_thrown = False
     try:
-        pset.execute(kernel_varname, endtime=1, dt=1., delete_cfiles=True)
+        pset.execute(kernel_varname, endtime=1, dt=1.)
     except NotImplementedError:
         error_thrown = True
     assert error_thrown

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -61,12 +61,8 @@ def test_variable_init(fieldset, mode, npart=10):
 def test_variable_unsupported_dtypes(fieldset, mode, type):
     """Test that checks errors thrown for unsupported dtypes in JIT mode."""
     TestParticle = ptype[mode].add_variable('p', dtype=type, initial=10.)
-    error_thrown = False
-    try:
+    with pytest.raises((RuntimeError, TypeError)):
         ParticleSet(fieldset, pclass=TestParticle, lon=[0], lat=[0])
-    except (RuntimeError, TypeError):
-        error_thrown = True
-    assert error_thrown
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
@@ -74,12 +70,8 @@ def test_variable_special_names(fieldset, mode):
     """Test that checks errors thrown for special names."""
     for vars in ['z', 'lon']:
         TestParticle = ptype[mode].add_variable(vars, dtype=np.float32, initial=10.)
-        error_thrown = False
-        try:
+        with pytest.raises(AttributeError):
             ParticleSet(fieldset, pclass=TestParticle, lon=[0], lat=[0])
-        except AttributeError:
-            error_thrown = True
-        assert error_thrown
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])


### PR DESCRIPTION
Fixing the compilation error message when a local Kernel variable has same name as a FieldSet constant

This fixes #1512