### PR TITLE
Pinning zarr in environment files to <2.18.0

### DIFF
--- a/docs/environment_docs.yml
+++ b/docs/environment_docs.yml
@@ -23,7 +23,7 @@ dependencies:
   - nbval
   - scikit-learn
   - pykdtree
-  - zarr>=2.11.0
+  - zarr>=2.11.0,<2.18.0
 
   # Formatting
   - black

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - nbval
   - scikit-learn
   - pykdtree
-  - zarr>=2.11.0
+  - zarr>=2.11.0,<2.18.0
 
   # Formatting
   - black


### PR DESCRIPTION
Pinning the `zarr<2.18.0` in environment files, at least until v3.0.0 ships this summer. Following issue/suggestion in #1564. Thanks for reporting @jamespolly!