### PR TITLE
Creating a new `Fieldset.from_modulefile()` method

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1064,7 +1064,7 @@ class FieldSet:
         return cls(u, v, fields=fields)
 
     @classmethod
-    def from_directory(cls, filename):
+    def from_directory(cls, filename, **kwargs):
         """Initialises FieldSet data from python file in directory
 
         Parameters
@@ -1078,7 +1078,7 @@ class FieldSet:
         fieldset_module = import_module(filename)
         if not hasattr(fieldset_module, 'create_fieldset'):
             raise IOError(f"FieldSet module {filename} does not contain a `create_fieldset` function")
-        return fieldset_module.create_fieldset()
+        return fieldset_module.create_fieldset(**kwargs)
 
     def get_fields(self):
         """Returns a list of all the :class:`parcels.field.Field` and :class:`parcels.field.VectorField`

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1064,8 +1064,8 @@ class FieldSet:
         return cls(u, v, fields=fields)
 
     @classmethod
-    def from_directory(cls, filename, **kwargs):
-        """Initialises FieldSet data from python file in directory
+    def from_modulefile(cls, filename, **kwargs):
+        """Initialises FieldSet data from a file containing a python module file with a create_fieldset() function.
 
         Parameters
         ----------

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from glob import glob
-from os import path
+from os import path, sep
+from importlib import import_module
 
 import dask.array as da
 import numpy as np
@@ -1061,6 +1062,23 @@ class FieldSet:
         u = fields.pop('U', None)
         v = fields.pop('V', None)
         return cls(u, v, fields=fields)
+
+    @classmethod
+    def from_directory(cls, filename):
+        """Initialises FieldSet data from python file in directory
+
+        Parameters
+        ----------
+        filename: path to a python file containing at least a create_fieldset() function,
+            which returns a FieldSet object.
+        """
+        # change the filename to a module name
+        filename = filename.rstrip('.py').replace(sep, '.')
+
+        fieldset_module = import_module(filename)
+        if not hasattr(fieldset_module, 'create_fieldset'):
+            raise IOError(f"FieldSet module {filename} does not contain a `create_fieldset` function")
+        return fieldset_module.create_fieldset()
 
     def get_fields(self):
         """Returns a list of all the :class:`parcels.field.Field` and :class:`parcels.field.VectorField`

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from glob import glob
-from os import path, sep
 from importlib import import_module
+from os import path, sep
 
 import dask.array as da
 import numpy as np

--- a/tests/test_data/fieldset_nemo.py
+++ b/tests/test_data/fieldset_nemo.py
@@ -3,7 +3,7 @@ from os import path
 import parcels
 
 
-def create_fieldset():
+def create_fieldset(indices=None):
     data_path = path.join(path.dirname(__file__))
 
     filenames = {'U': {'lon': path.join(data_path, 'mask_nemo_cross_180lon.nc'),
@@ -14,4 +14,5 @@ def create_fieldset():
                        'data': path.join(data_path, 'Vv_eastward_nemo_cross_180lon.nc')}}
     variables = {'U': 'U', 'V': 'V'}
     dimensions = {'lon': 'glamf', 'lat': 'gphif', 'time': 'time_counter'}
-    return parcels.FieldSet.from_nemo(filenames, variables, dimensions)
+    indices = indices or {}
+    return parcels.FieldSet.from_nemo(filenames, variables, dimensions, indices=indices)

--- a/tests/test_data/fieldset_nemo.py
+++ b/tests/test_data/fieldset_nemo.py
@@ -1,5 +1,6 @@
-import parcels
 from os import path
+
+import parcels
 
 
 def create_fieldset():

--- a/tests/test_data/fieldset_nemo.py
+++ b/tests/test_data/fieldset_nemo.py
@@ -1,0 +1,16 @@
+import parcels
+from os import path
+
+
+def create_fieldset():
+    data_path = path.join(path.dirname(__file__))
+
+    filenames = {'U': {'lon': path.join(data_path, 'mask_nemo_cross_180lon.nc'),
+                       'lat': path.join(data_path, 'mask_nemo_cross_180lon.nc'),
+                       'data': path.join(data_path, 'Uu_eastward_nemo_cross_180lon.nc')},
+                 'V': {'lon': path.join(data_path, 'mask_nemo_cross_180lon.nc'),
+                       'lat': path.join(data_path, 'mask_nemo_cross_180lon.nc'),
+                       'data': path.join(data_path, 'Vv_eastward_nemo_cross_180lon.nc')}}
+    variables = {'U': 'U', 'V': 'V'}
+    dimensions = {'lon': 'glamf', 'lat': 'gphif', 'time': 'time_counter'}
+    return parcels.FieldSet.from_nemo(filenames, variables, dimensions)

--- a/tests/test_data/fieldset_nemo_error.py
+++ b/tests/test_data/fieldset_nemo_error.py
@@ -1,0 +1,16 @@
+import parcels
+from os import path
+
+
+def random_function_name():
+    data_path = path.join(path.dirname(__file__))
+
+    filenames = {'U': {'lon': path.join(data_path, 'mask_nemo_cross_180lon.nc'),
+                       'lat': path.join(data_path, 'mask_nemo_cross_180lon.nc'),
+                       'data': path.join(data_path, 'Uu_eastward_nemo_cross_180lon.nc')},
+                 'V': {'lon': path.join(data_path, 'mask_nemo_cross_180lon.nc'),
+                       'lat': path.join(data_path, 'mask_nemo_cross_180lon.nc'),
+                       'data': path.join(data_path, 'Vv_eastward_nemo_cross_180lon.nc')}}
+    variables = {'U': 'U', 'V': 'V'}
+    dimensions = {'lon': 'glamf', 'lat': 'gphif', 'time': 'time_counter'}
+    return parcels.FieldSet.from_nemo(filenames, variables, dimensions)

--- a/tests/test_data/fieldset_nemo_error.py
+++ b/tests/test_data/fieldset_nemo_error.py
@@ -1,5 +1,6 @@
-import parcels
 from os import path
+
+import parcels
 
 
 def random_function_name():

--- a/tests/test_data/fieldset_nemo_error.py
+++ b/tests/test_data/fieldset_nemo_error.py
@@ -15,3 +15,7 @@ def random_function_name():
     variables = {'U': 'U', 'V': 'V'}
     dimensions = {'lon': 'glamf', 'lat': 'gphif', 'time': 'time_counter'}
     return parcels.FieldSet.from_nemo(filenames, variables, dimensions)
+
+
+def none_returning_function():
+    return None

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -204,6 +204,11 @@ def test_fieldset_from_directory():
     fieldset = FieldSet.from_directory('test_data/fieldset_nemo')
     assert fieldset.U.creation_log == 'from_nemo'
 
+    indices = {'lon': range(6, 10)}
+    fieldset = FieldSet.from_directory('test_data/fieldset_nemo', indices=indices)
+    print(fieldset.U.grid.lon.shape)
+    assert fieldset.U.grid.lon.shape[1] == 4
+
 
 def test_fieldset_from_directory_error():
     with pytest.raises(IOError):

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -200,6 +200,12 @@ def test_field_from_netcdf(with_timestamps):
         Field.from_netcdf(filenames, variable, dimensions, interp_method='cgrid_velocity')
 
 
+def test_fieldset_from_directory():
+    from test_data import fieldset_nemo
+    fieldset = fieldset_nemo.create_fieldset()
+    assert fieldset.U.creation_log == 'from_nemo'
+
+
 def test_field_from_netcdf_fieldtypes():
     data_path = path.join(path.dirname(__file__), 'test_data/')
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -201,9 +201,13 @@ def test_field_from_netcdf(with_timestamps):
 
 
 def test_fieldset_from_directory():
-    from test_data import fieldset_nemo
-    fieldset = fieldset_nemo.create_fieldset()
+    fieldset = FieldSet.from_directory('test_data/fieldset_nemo')
     assert fieldset.U.creation_log == 'from_nemo'
+
+
+def test_fieldset_from_directory_error():
+    with pytest.raises(IOError):
+        FieldSet.from_directory('test_data/fieldset_nemo_error')
 
 
 def test_field_from_netcdf_fieldtypes():

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -200,19 +200,20 @@ def test_field_from_netcdf(with_timestamps):
         Field.from_netcdf(filenames, variable, dimensions, interp_method='cgrid_velocity')
 
 
-def test_fieldset_from_directory():
-    fieldset = FieldSet.from_directory('test_data/fieldset_nemo')
+def test_fieldset_from_modulefile():
+    data_path = path.join(path.dirname(__file__), 'test_data/')
+    fieldset = FieldSet.from_modulefile(data_path + 'fieldset_nemo.py')
     assert fieldset.U.creation_log == 'from_nemo'
 
     indices = {'lon': range(6, 10)}
-    fieldset = FieldSet.from_directory('test_data/fieldset_nemo', indices=indices)
-    print(fieldset.U.grid.lon.shape)
+    fieldset = FieldSet.from_modulefile(data_path + 'fieldset_nemo.py', indices=indices)
     assert fieldset.U.grid.lon.shape[1] == 4
 
 
-def test_fieldset_from_directory_error():
+def test_fieldset_from_modulefile_error():
+    data_path = path.join(path.dirname(__file__), 'test_data/')
     with pytest.raises(IOError):
-        FieldSet.from_directory('test_data/fieldset_nemo_error')
+        FieldSet.from_modulefile(data_path + 'fieldset_nemo_error.py')
 
 
 def test_field_from_netcdf_fieldtypes():

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -209,11 +209,13 @@ def test_fieldset_from_modulefile():
     fieldset = FieldSet.from_modulefile(data_path + 'fieldset_nemo.py', indices=indices)
     assert fieldset.U.grid.lon.shape[1] == 4
 
-
-def test_fieldset_from_modulefile_error():
-    data_path = path.join(path.dirname(__file__), 'test_data/')
     with pytest.raises(IOError):
         FieldSet.from_modulefile(data_path + 'fieldset_nemo_error.py')
+
+    FieldSet.from_modulefile(data_path + 'fieldset_nemo_error.py', modulename='random_function_name')
+
+    with pytest.raises(IOError):
+        FieldSet.from_modulefile(data_path + 'fieldset_nemo_error.py', modulename='none_returning_function')
 
 
 def test_field_from_netcdf_fieldtypes():


### PR DESCRIPTION
In developing [plasticparcels](https://plastic.oceanparcels.org), we realised that for many teams it could be useful to have a way to directly and effortlessly create a `FieldSet` instance from all the files in a particular directory. This is particularly useful if many use the same data on a shared storage.

This PR implements a simple method, `Fieldset.from_modulefile(filename)`, that returns a FieldSet instance based on a python module file at `filename`. That file should include a `create_fieldset()` function, which returns a `FieldSet` object.

An example of how this can be used is in the unit tests:

The data manager places a function to create the fieldset somewhere (e.g. in the same directory as where the data is)
https://github.com/OceanParcels/parcels/blob/7d3cf6ed10e7b89fa0f840a8079cfaed972f0dfe/tests/test_data/fieldset_nemo.py#L5-L16

Then, a user only has to issue
https://github.com/OceanParcels/parcels/blob/548d62df1eabe31793cde92227f10a770bdc2913/tests/test_fieldset.py#L203-L205

The advantage is that users don't need to think anymore which fieldset creation method to use (`from_nemo`, `from_netcdf`, etc) and that all settings are immediately correct