### PR TITLE
unpin zarr version upper bound

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - nbval
   - scikit-learn
   - pykdtree
-  - zarr>=2.11.0,<2.18.0
+  - zarr>=2.11.0
 
   # Formatting
   - black

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - nbval
   - scikit-learn
   - pykdtree
-  - zarr>=2.11.0
+  - zarr>=2.11.0,!=2.18.0
 
   # Formatting
   - black


### PR DESCRIPTION
Per #1564 a simple change of the environment.yml back to `zarr>=2.11.0`.

Still seeing a couple of failed parameterized tests for `test_mpi_run` but this may be a local issue.

Thought I'd just put this PR up here for discussion of those tests or whatever else we may want to do here. Feel free to disregard if not helpful.