### PR TITLE
Fixing link to partition function in the parcels structure tutorial

### DIFF
--- a/docs/examples/tutorial_parcels_structure.ipynb
+++ b/docs/examples/tutorial_parcels_structure.ipynb
@@ -450,7 +450,7 @@
    "source": [
     "### For more tutorials on MPI and parallelisation:\n",
     "\n",
-    "- [Optimising the partitioning of the particles with a user-defined `partition_function`](https://docs.oceanparcels.org/en/latest/examples/documentation_MPI.html#Optimising-the-partitioning-of-the-particles-with-a-user-defined-partition_function)\n",
+    "- [Optimising the partitioning of the particles with a user-defined partition function](https://docs.oceanparcels.org/en/latest/examples/documentation_MPI.html#Optimising-the-partitioning-of-the-particles-with-a-user-defined-partition_function)\n",
     "- [Future developments: load balancing](https://docs.oceanparcels.org/en/latest/examples/documentation_MPI.html#Future-developments:-load-balancing)"
    ]
   },


### PR DESCRIPTION
Fixing link to partition function in the parcels structure tutorial, as links with `code` can't be parsed well by sphinx