### PR TITLE
Changing np.infty to np.inf for compatibility with NumPy 2.0

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1186,7 +1186,7 @@ class FieldSet:
             Default is 1.
         """
         signdt = np.sign(dt)
-        nextTime = np.infty if dt > 0 else -np.infty
+        nextTime = np.inf if dt > 0 else -np.inf
 
         for g in self.gridset.grids:
             g.update_status = 'not_updated'
@@ -1320,7 +1320,7 @@ class FieldSet:
                 depth_data = f.grid.depth_field.data
                 f.grid.depth = depth_data if isinstance(depth_data, np.ndarray) else np.array(depth_data)
 
-        if abs(nextTime) == np.infty or np.isnan(nextTime):  # Second happens when dt=0
+        if abs(nextTime) == np.inf or np.isnan(nextTime):  # Second happens when dt=0
             return nextTime
         else:
             nSteps = int((nextTime - time) / dt)

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -169,7 +169,7 @@ class Grid:
                 assert self.depth.shape[2] == self.ydim, "Third dim must be y."
 
     def computeTimeChunk(self, f, time, signdt):
-        nextTime_loc = np.infty if signdt >= 0 else -np.infty
+        nextTime_loc = np.inf if signdt >= 0 else -np.inf
         periods = self.periods.value if isinstance(self.periods, c_int) else self.periods
         prev_time_indices = self.time
         if self.update_status == 'not_updated':

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -59,7 +59,7 @@ class ParticleFile(ABC):
     time_origin = None
     lonlatdepth_dtype = None
 
-    def __init__(self, name, particleset, outputdt=np.infty, chunks=None, create_new_zarrfile=True):
+    def __init__(self, name, particleset, outputdt=np.inf, chunks=None, create_new_zarrfile=True):
 
         self.outputdt = outputdt.total_seconds() if isinstance(outputdt, delta) else outputdt
         self.chunks = chunks

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -882,7 +882,7 @@ class ParticleSet(ABC):
             raise ValueError('Time step dt is too small')
         if (dt * 1e6) % 1 != 0:
             raise ValueError('Output interval should not have finer precision than 1e-6 s')
-        outputdt = output_file.outputdt if output_file else np.infty
+        outputdt = output_file.outputdt if output_file else np.inf
         if isinstance(outputdt, delta):
             outputdt = outputdt.total_seconds()
         if isinstance(callbackdt, delta):
@@ -920,7 +920,7 @@ class ParticleSet(ABC):
         self.particledata._data['dt'][:] = dt
 
         if callbackdt is None:
-            interupt_dts = [np.infty, outputdt]
+            interupt_dts = [np.inf, outputdt]
             if self.repeatdt is not None:
                 interupt_dts.append(self.repeatdt)
             callbackdt = np.min(np.array(interupt_dts))
@@ -928,11 +928,11 @@ class ParticleSet(ABC):
         if self.repeatdt:
             next_prelease = self.repeat_starttime + (abs(time - self.repeat_starttime) // self.repeatdt + 1) * self.repeatdt * np.sign(dt)
         else:
-            next_prelease = np.infty if dt > 0 else - np.infty
+            next_prelease = np.inf if dt > 0 else - np.inf
         if output_file:
             next_output = time + dt
         else:
-            next_output = time + np.infty if dt > 0 else - np.infty
+            next_output = time + np.inf if dt > 0 else - np.inf
         next_callback = time + callbackdt if dt > 0 else time - callbackdt
         next_input = self.fieldset.computeTimeChunk(time, np.sign(dt)) if self.fieldset is not None else np.inf
 


### PR DESCRIPTION
Like the title says, this PR updates `np.infty` to `np.inf` to fix breaking changes introduced in [NumPy v2.0.0](https://numpy.org/devdocs/release/2.0.0-notes.html).

Closes #1588 