### PR TITLE
Resolving environment file conda selector syntax

### DIFF
--- a/.github/actions/install-parcels/action.yml
+++ b/.github/actions/install-parcels/action.yml
@@ -2,14 +2,11 @@ name: Setup Conda and install parcels
 description: >
   In-repo composite action to setup Conda and install parcels. Installation of parcels relies on
   `setup.py` file being available in the root. For general setup of Anaconda environments, just use
-  the `mamba-org/setup-micromamba@v1` action (setting C variables as required), or the `conda-incubator/setup-miniconda` action.
+  the `conda-incubator/setup-miniconda` action (setting C variables as required).
 inputs:
   environment-file:
     description: Conda environment file to use.
     default: environment.yml
-  environment-name:
-    description: Name to use for the Conda environment
-    default: test
 runs:
   using: "composite"
   steps:
@@ -18,11 +15,10 @@ runs:
       uses: al-cheb/configure-pagefile-action@v1.3
       with:
         minimum-size: 8GB
-    - name: Install micromamba (${{ inputs.environment-file }})
-      uses: mamba-org/setup-micromamba@v1
+    - name: Install miniconda (${{ inputs.environment-file }})
+      uses: conda-incubator/setup-miniconda@v3
       with:
         environment-file: ${{ inputs.environment-file }}
-        environment-name: ${{ inputs.environment-name }}
         channels: conda-forge
         cache-environment: true
         cache-downloads: true

--- a/.github/actions/install-parcels/action.yml
+++ b/.github/actions/install-parcels/action.yml
@@ -26,6 +26,10 @@ runs:
         channels: conda-forge
         cache-environment: true
         cache-downloads: true
+    - name: MPI support
+      if: ${{ ! runner.os == 'Windows' }}
+      run: conda install -c conda forge mpich mpi4py
+      shell: bash -el {0}
     - name: Install parcels
       run: pip install .
       shell: bash -el {0}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,7 +37,6 @@ jobs:
         uses: ./.github/actions/install-parcels
         with:
           environment-file: environment.yml
-          environment-name: py3_parcels
       - name: Integration test
         run: |
           coverage run -m pytest -v -s --nbval-lax -k "not documentation" --html="${{ matrix.os }}_integration_test_report.html" --self-contained-html docs/examples

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,7 +36,6 @@ jobs:
         uses: ./.github/actions/install-parcels
         with:
           environment-file: environment.yml
-          environment-name: py3_parcels
       - name: Unit test
         run: |
           coverage run -m pytest -v -s --html=${{ matrix.os }}_unit_test_report.html --self-contained-html tests

--- a/docs/examples/documentation_MPI.ipynb
+++ b/docs/examples/documentation_MPI.ipynb
@@ -13,9 +13,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Parcels can be run in Parallel with MPI. To do this, you will need to also install the `mpich` and `mpi4py` packages (e.g. `conda install mpich mpi4py`). \n",
+    "Parcels can be run in Parallel with MPI. To do this, you will need to also install the `mpich` and `mpi4py` packages (i.e., `conda install -c conda forge mpich mpi4py`).\n",
     "\n",
-    "Note that these packages don't work on Windows, and that they have been installed if you followed the [Installation for Developers](https://docs.oceanparcels.org/en/latest/installation.html#installation-for-developers) instructions.\n"
+    "Note that MPI support is only for Linux and macOS. There is no Windows support.\n"
    ]
   },
   {

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,13 +62,9 @@ The steps below are the installation instructions for Linux, macOS and Windows.
 Installation for developers
 ===========================
 
-If you would prefer to have a development installation of Parcels (i.e., where the code can be actively edited), you can do so by cloning the Parcels repo, installing dependencies using the environment file, and then installing Parcels in an editable mode such that changes to the cloned code can be tested during development.
+If you would prefer to have a development installation of Parcels (i.e., where the code can be actively edited), you can do so by setting up Miniconda (as detailed in step 1 above), cloning the Parcels repo, installing dependencies using the environment file, and then installing Parcels in an editable mode such that changes to the cloned code can be tested during development.
 
-**Step 1:** Install `micromamba <https://mamba.readthedocs.io/en/latest/index.html>`_, a lightweight version of conda, following the instructions `here <https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html>`_.
-
-.. note::
-
-  If you prefer to work with Anaconda or Miniconda instead of Micromamba, you will have to remove the ``sel(unix):`` commands in the ``environment.yml`` file (or remove these lines altogether if you're on Windows), since conda does not (yet) support these `selectors`. After that, just replace ``micromamba`` with ``conda`` in the commands below.
+**Step 1:** *Same as step 1 above*
 
 **Step 2:** Clone the Parcels repo and create a new environment with the dependencies:
 
@@ -76,11 +72,11 @@ If you would prefer to have a development installation of Parcels (i.e., where t
 
   git clone https://github.com/OceanParcels/parcels.git
   cd parcels
-  micromamba env create -f environment.yml
+  conda env create -f environment.yml
 
 **Step 3:** Activate the environment and install Parcels in editable mode:
 
 .. code-block:: bash
 
-  micromamba activate parcels
+  conda activate parcels
   pip install --no-build-isolation --no-deps -e .

--- a/environment.yml
+++ b/environment.yml
@@ -8,8 +8,6 @@ dependencies:
   - git
   - jupyter
   - matplotlib-base>=2.0.2
-  - sel(unix): mpi4py
-  - sel(unix): mpich
   - netcdf4>=1.1.9
   - numpy>=1.9.1
   - platformdirs


### PR DESCRIPTION
Making MPI explicitly an optional dependency that users need to install will simplify dev installation, and mean we don't have to worry about platform specific installation.

Changes:
- Remove MPI packages from dev installation (ie, `environment.yml`)
- Update install instructions
- Update MPI documentation notebook
- Remove mamba from GHA testing to reflect new installation instructions

Supercedes #1471 and #1513