### PR TITLE
Support use of parcels.rng in Kernels

### DIFF
--- a/parcels/application_kernels/advectiondiffusion.py
+++ b/parcels/application_kernels/advectiondiffusion.py
@@ -4,7 +4,7 @@ See `this tutorial <../examples/tutorial_diffusion.ipynb>`__ for a detailed expl
 """
 import math
 
-import parcels.rng as ParcelsRandom
+import parcels
 
 __all__ = ['DiffusionUniformKh', 'AdvectionDiffusionM1', 'AdvectionDiffusionEM', ]
 
@@ -25,8 +25,8 @@ def AdvectionDiffusionM1(particle, fieldset, time):
     mean and a standard deviation of sqrt(dt).
     """
     # Wiener increment with zero mean and std of sqrt(dt)
-    dWx = ParcelsRandom.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
-    dWy = ParcelsRandom.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
+    dWx = parcels.rng.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
+    dWy = parcels.rng.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
 
     Kxp1 = fieldset.Kh_zonal[time, particle.depth, particle.lat, particle.lon + fieldset.dres]
     Kxm1 = fieldset.Kh_zonal[time, particle.depth, particle.lat, particle.lon - fieldset.dres]
@@ -60,8 +60,8 @@ def AdvectionDiffusionEM(particle, fieldset, time):
     mean and a standard deviation of sqrt(dt).
     """
     # Wiener increment with zero mean and std of sqrt(dt)
-    dWx = ParcelsRandom.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
-    dWy = ParcelsRandom.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
+    dWx = parcels.rng.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
+    dWy = parcels.rng.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
 
     u, v = fieldset.UV[time, particle.depth, particle.lat, particle.lon]
 
@@ -101,8 +101,8 @@ def DiffusionUniformKh(particle, fieldset, time):
     mean and a standard deviation of sqrt(dt).
     """
     # Wiener increment with zero mean and std of sqrt(dt)
-    dWx = ParcelsRandom.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
-    dWy = ParcelsRandom.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
+    dWx = parcels.rng.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
+    dWy = parcels.rng.normalvariate(0, math.sqrt(math.fabs(particle.dt)))
 
     bx = math.sqrt(2 * fieldset.Kh_zonal[particle])
     by = math.sqrt(2 * fieldset.Kh_meridional[particle])

--- a/parcels/compilation/codegenerator.py
+++ b/parcels/compilation/codegenerator.py
@@ -238,7 +238,7 @@ class IntrinsicTransformer(ast.NodeTransformer):
             node = StatusCodeNode(math, ccode='')
         elif node.id == 'math':
             node = MathNode(math, ccode='')
-        elif node.id == 'ParcelsRandom':
+        elif node.id in ['ParcelsRandom', 'rng']:
             node = RandomNode(math, ccode='')
         elif node.id == 'print':
             node = PrintNode()

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -23,6 +23,7 @@ except ModuleNotFoundError:
     MPI = None
 
 import parcels.rng as ParcelsRandom  # noqa
+from parcels import rng  # noqa
 from parcels.application_kernels.advection import (
     AdvectionAnalytical,
     AdvectionRK4_3D,
@@ -178,6 +179,7 @@ class Kernel(BaseKernel):
         else:
             self.funcvars = None
         self.funccode = funccode or inspect.getsource(pyfunc.__code__)
+        self.funccode = self.funccode.replace('parcels.', '')  # Remove parcels. prefix (see #1608)
         # Parse AST if it is not provided explicitly
         self.py_ast = py_ast or parse(BaseKernel.fix_indentation(self.funccode)).body[0]
         if pyfunc is None:
@@ -187,6 +189,7 @@ class Kernel(BaseKernel):
                 user_ctx = stack[-1][0].f_globals
                 user_ctx['math'] = globals()['math']
                 user_ctx['ParcelsRandom'] = globals()['ParcelsRandom']
+                user_ctx['rng'] = globals()['rng']
                 user_ctx['random'] = globals()['random']
                 user_ctx['StatusCode'] = globals()['StatusCode']
             except:


### PR DESCRIPTION
This PR fixes #1608. it supports using `parcels.rng` directly in Kernels (note, `parcels.ParcelsRandom` is also supported, but since the module itself it called `rng` better to use `parcels.rng` for traceability)