### PR TITLE
Fixing bug when executing a breaking pset

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -840,6 +840,10 @@ class ParticleSet(ABC):
         delete_cfiles : bool
             Whether to delete the C-files after compilation in JIT mode (default is True)
         """
+        # check if particleset is empty. If so, return immediately
+        if len(self) == 0:
+            return
+
         # check if pyfunc has changed since last compile. If so, recompile
         if self.kernel is None or (self.kernel.pyfunc is not pyfunc and self.kernel is not pyfunc):
             # Generate and store Kernel

--- a/tests/test_particlesets.py
+++ b/tests/test_particlesets.py
@@ -53,6 +53,18 @@ def test_pset_create_line(fieldset, mode, lonlatdepth_dtype, npart=100):
 
 
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
+def test_create_empty_pset(fieldset, mode):
+    pset = ParticleSet(fieldset, pclass=ptype[mode])
+    assert pset.size == 0
+
+    def DoNothing(particle, fieldset, time):
+        pass
+
+    pset.execute(DoNothing, endtime=1., dt=1.)
+    assert pset.size == 0
+
+
+@pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_pset_create_list_with_customvariable(fieldset, mode, npart=100):
     lon = np.linspace(0, 1, npart, dtype=np.float32)
     lat = np.linspace(1, 0, npart, dtype=np.float32)


### PR DESCRIPTION
Previously, running a `pset.execute()` on an empty set returned an Error
```python
Traceback (most recent call last):
  File "/Users/erik/Codes/ParcelsCode/parcels/particleset.py", line 907, in execute
    min_rt = np.min(self.particledata.data['time_nextloop'])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/erik/anaconda3/envs/parcels/lib/python3.12/site-packages/numpy/core/fromnumeric.py", line 2953, in min
    return _wrapreduction(a, np.minimum, 'min', axis, None, out,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/erik/anaconda3/envs/parcels/lib/python3.12/site-packages/numpy/core/fromnumeric.py", line 88, in _wrapreduction
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: zero-size array to reduction operation minimum which has no identity
```

This PR fixes that Issue by gracefully returning from `pset.execute` when there are no particles to execute. This fixes #1629