### PR TITLE
Minor tutorial updates

### DIFF
--- a/docs/examples/tutorial_kernelloop.ipynb
+++ b/docs/examples/tutorial_kernelloop.ipynb
@@ -307,7 +307,7 @@
     "### 3. The last time is not written to file\n",
     "Because the location at the start of the loop is written at the end of the Kernel loop, the last `particle.time` of the particle is not written to file. This is similar behaviour to e.g. `np.arange(start, stop)`, which also doesn't include the `stop` value itself. \n",
     "\n",
-    "If you do want to write the last time to file, you can increase the `runtime` or `endtime` by `dt` (although this may cause a TimeExtrapolationError if your run was to the end of the available hydrodynamic data), or you can call `pfile.write_latest_locations(pset, time=endtime)`. Note that in the latter case, the particle locations (longitude, latitude and depth) will be updated, but other variables will _not_ be updated as the Kernels are not run again."
+    "If you do want to write the last time to file, you can increase the `runtime` or `endtime` by `dt` (although this may cause a TimeExtrapolationError if your run was to the end of the available hydrodynamic data), or you can call `pfile.write_latest_locations(pset, time=pset[0].time_nextloop)`. Note that in the latter case, the particle locations (longitude, latitude and depth) will be updated, but other variables will _not_ be updated as the Kernels are not run again."
    ]
   },
   {

--- a/docs/examples/tutorial_output.ipynb
+++ b/docs/examples/tutorial_output.ipynb
@@ -162,7 +162,7 @@
    "source": [
     "## Trajectory data structure\n",
     "\n",
-    "The data zarr file are organised according to the [CF-conventions](http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#discrete-sampling-geometries) implemented with the [NCEI trajectory template](https://www.nodc.noaa.gov/data/formats/netcdf/v2.0/trajectoryIncomplete.cdl). The data is stored in a **two-dimensional array** with the dimensions `traj` and `obs`. Each particle trajectory is essentially stored as a time series where the coordinate data (`lon`, `lat`, `time`) are a function of the observation (`obs`).\n",
+    "The data zarr file are organised according to the [CF-convention for trajectories data](http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#_multidimensional_array_representation_of_trajectories) implemented with the [NCEI trajectory template](https://www.ncei.noaa.gov/data/oceans/ncei/formats/netcdf/v2.0/trajectoryIncomplete.cdl). The data is stored in a **two-dimensional array** with the dimensions `traj` and `obs`. Each particle trajectory is essentially stored as a time series where the coordinate data (`lon`, `lat`, `time`) are a function of the observation (`obs`).\n",
     "\n",
     "The output dataset used here contains **10 particles** and **13 observations**. Not every particle has 13 observations however; since we released particles at different times some particle trajectories are shorter than others.\n"
    ]


### PR DESCRIPTION
Two minor updates to the text of tutorials:
1. [Fixing links to trajectory CF-convention pages](https://github.com/OceanParcels/parcels/commit/f9a950a2a3cb98009763df17df7a63c8d9cbc3ce) in tutorial_output
2. [Improving advice on how to call pfile.write_latest_locations()](https://github.com/OceanParcels/parcels/commit/227c0a2677ef457daeb9e70ce680bb8e56258f54) in tutorial_kernelloop