### PR TITLE
Enable Bugbear and other rules in Ruff linting

### DIFF
--- a/docs/examples/example_dask_chunk_OCMs.py
+++ b/docs/examples/example_dask_chunk_OCMs.py
@@ -21,11 +21,11 @@ def compute_nemo_particle_advection(fieldset, mode):
         if particle.lon > 15.0:
             particle_dlon -= 15.0  # noqa
         if particle.lon < 0:
-            particle_dlon += 15.0  # noqa
+            particle_dlon += 15.0
         if particle.lat > 60.0:
             particle_dlat -= 11.0  # noqa
         if particle.lat < 49.0:
-            particle_dlat += 11.0  # noqa
+            particle_dlat += 11.0
 
     pset = parcels.ParticleSet.from_list(fieldset, ptype[mode], lon=lonp, lat=latp)
     kernels = pset.Kernel(parcels.AdvectionRK4) + periodicBC

--- a/docs/examples/example_mitgcm.py
+++ b/docs/examples/example_mitgcm.py
@@ -31,7 +31,7 @@ def run_mitgcm_zonally_reentrant(mode):
         if particle.lon < 0:
             particle_dlon += fieldset.domain_width  # noqa
         elif particle.lon > fieldset.domain_width:
-            particle_dlon -= fieldset.domain_width  # noqa
+            particle_dlon -= fieldset.domain_width
 
     # Release particles 5 cells away from the Eastern boundary
     pset = parcels.ParticleSet.from_line(

--- a/docs/examples/example_moving_eddies.py
+++ b/docs/examples/example_moving_eddies.py
@@ -273,11 +273,11 @@ def test_periodic_and_computeTimeChunk_eddies(mode):
         if particle.lon < fieldset.halo_west:
             particle_dlon += fieldset.halo_east - fieldset.halo_west  # noqa
         elif particle.lon > fieldset.halo_east:
-            particle_dlon -= fieldset.halo_east - fieldset.halo_west  # noqa
+            particle_dlon -= fieldset.halo_east - fieldset.halo_west
         if particle.lat < fieldset.halo_south:
             particle_dlat += fieldset.halo_north - fieldset.halo_south  # noqa
         elif particle.lat > fieldset.halo_north:
-            particle_dlat -= fieldset.halo_north - fieldset.halo_south  # noqa
+            particle_dlat -= fieldset.halo_north - fieldset.halo_south
 
     def slowlySouthWestward(particle, fieldset, time):
         particle_dlon -= 5 * particle.dt / 1e5  # noqa

--- a/parcels/__init__.py
+++ b/parcels/__init__.py
@@ -3,15 +3,15 @@ from ._version import version
 __version__ = version
 
 import parcels.rng as ParcelsRandom  # noqa
-from parcels.application_kernels import *  # noqa
-from parcels.compilation import *  # noqa
-from parcels.field import *  # noqa
-from parcels.fieldset import *  # noqa
-from parcels.grid import *  # noqa
-from parcels.gridset import *  # noqa
-from parcels.interaction import *  # noqa
-from parcels.kernel import *  # noqa
-from parcels.particle import *  # noqa
-from parcels.particlefile import *  # noqa
-from parcels.particleset import *  # noqa
-from parcels.tools import *  # noqa
+from parcels.application_kernels import *
+from parcels.compilation import *
+from parcels.field import *
+from parcels.fieldset import *
+from parcels.grid import *
+from parcels.gridset import *
+from parcels.interaction import *
+from parcels.kernel import *
+from parcels.particle import *
+from parcels.particlefile import *
+from parcels.particleset import *
+from parcels.tools import *

--- a/parcels/_version.py
+++ b/parcels/_version.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 
 try:
-    from parcels._version_setup import version  # noqa
+    from parcels._version_setup import version
 except ModuleNotFoundError:
     try:
         version = (

--- a/parcels/application_kernels/__init__.py
+++ b/parcels/application_kernels/__init__.py
@@ -1,3 +1,3 @@
-from .advection import *  # noqa
-from .advectiondiffusion import *  # noqa
-from .interaction import *  # noqa
+from .advection import *
+from .advectiondiffusion import *
+from .interaction import *

--- a/parcels/compilation/__init__.py
+++ b/parcels/compilation/__init__.py
@@ -1,2 +1,2 @@
-from .codecompiler import *  # noqa
-from .codegenerator import *  # noqa
+from .codecompiler import *
+from .codegenerator import *

--- a/parcels/compilation/codecompiler.py
+++ b/parcels/compilation/codecompiler.py
@@ -7,6 +7,7 @@ try:
 except ModuleNotFoundError:
     MPI = None
 
+_tmp_dir = os.getcwd()
 
 class Compiler_parameters:
     def __init__(self):
@@ -207,7 +208,9 @@ class CCompiler:
         A list of arguments to the linker (optional).
     """
 
-    def __init__(self, cc=None, cppargs=None, ldargs=None, incdirs=None, libdirs=None, libs=None, tmp_dir=os.getcwd()):
+    def __init__(self, cc=None, cppargs=None, ldargs=None, incdirs=None, libdirs=None, libs=None, tmp_dir=None):
+        if tmp_dir is None:
+            tmp_dir = _tmp_dir
         if cppargs is None:
             cppargs = []
         if ldargs is None:
@@ -249,7 +252,7 @@ class CCompiler:
 class CCompiler_SS(CCompiler):
     """Single-stage C-compiler; used for a SINGLE source file."""
 
-    def __init__(self, cc=None, cppargs=None, ldargs=None, incdirs=None, libdirs=None, libs=None, tmp_dir=os.getcwd()):
+    def __init__(self, cc=None, cppargs=None, ldargs=None, incdirs=None, libdirs=None, libs=None, tmp_dir=None):
         super().__init__(cc=cc, cppargs=cppargs, ldargs=ldargs, incdirs=incdirs, libdirs=libdirs, libs=libs, tmp_dir=tmp_dir)
 
     def __str__(self):
@@ -282,7 +285,7 @@ class GNUCompiler_SS(CCompiler_SS):
         A list of arguments to pass to the linker (optional).
     """
 
-    def __init__(self, cppargs=None, ldargs=None, incdirs=None, libdirs=None, libs=None, tmp_dir=os.getcwd()):
+    def __init__(self, cppargs=None, ldargs=None, incdirs=None, libdirs=None, libs=None, tmp_dir=None):
         c_params = GNU_parameters(cppargs, ldargs, incdirs, libdirs, libs)
         super().__init__(c_params.compiler, cppargs=c_params.cppargs, ldargs=c_params.ldargs, incdirs=c_params.incdirs, libdirs=c_params.libdirs, libs=c_params.libs, tmp_dir=tmp_dir)
         self._dynlib_ext = c_params.dynlib_ext

--- a/parcels/compilation/codecompiler.py
+++ b/parcels/compilation/codecompiler.py
@@ -79,15 +79,15 @@ class GNU_parameters(Compiler_parameters):
 
         Iflags = []
         if isinstance(incdirs, list):
-            for i, dir in enumerate(incdirs):
+            for dir in incdirs:
                 Iflags.append("-I"+dir)
         Lflags = []
         if isinstance(libdirs, list):
-            for i, dir in enumerate(libdirs):
+            for dir in libdirs:
                 Lflags.append("-L"+dir)
         lflags = []
         if isinstance(libs, list):
-            for i, lib in enumerate(libs):
+            for lib in libs:
                 lflags.append("-l" + lib)
 
         cc_env = os.getenv('CC')

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1269,8 +1269,8 @@ class Field:
         self.grid.load_chunk = np.zeros(npartitions, dtype=c_int, order='C')
         # self.grid.chunk_info format: number of dimensions (without tdim); number of chunks per dimensions;
         #      chunksizes (the 0th dim sizes for all chunk of dim[0], then so on for next dims
-        self.grid.chunk_info = [[len(self.nchunks)-1], list(self.nchunks[1:]), sum(list(list(ci) for ci in chunks[1:]), [])]
-        self.grid.chunk_info = sum(self.grid.chunk_info, [])
+        self.grid.chunk_info = [[len(self.nchunks)-1], list(self.nchunks[1:]), sum(list(list(ci) for ci in chunks[1:]), [])]  # noqa: RUF017 # TODO: Perhaps avoid quadratic list summation here
+        self.grid.chunk_info = sum(self.grid.chunk_info, [])  # noqa: RUF017
         self.chunk_set = True
 
     def chunk_data(self):

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -302,7 +302,7 @@ class FieldSet:
             paths = sorted(glob(str(paths)))
         if len(paths) == 0:
             notfound_paths = filenames[var] if isinstance(filenames, dict) and var in filenames else filenames
-            raise OSError(f"FieldSet files not found for variable {var}: {str(notfound_paths)}")
+            raise OSError(f"FieldSet files not found for variable {var}: {notfound_paths}")
         for fp in paths:
             if not os.path.exists(fp):
                 raise OSError(f"FieldSet file not found: {fp}")

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1145,7 +1145,7 @@ class FieldSet:
         """
         for grid in self.gridset.grids:
             grid.add_periodic_halo(zonal, meridional, halosize)
-        for attr, value in iter(self.__dict__.items()):
+        for value in self.__dict__.values():
             if isinstance(value, Field):
                 value.add_periodic_halo(zonal, meridional, halosize)
 

--- a/parcels/interaction/neighborsearch/__init__.py
+++ b/parcels/interaction/neighborsearch/__init__.py
@@ -1,12 +1,12 @@
-from parcels.interaction.neighborsearch.bruteforce import (  # noqa
+from parcels.interaction.neighborsearch.bruteforce import (
     BruteFlatNeighborSearch,
     BruteSphericalNeighborSearch,
 )
 from parcels.interaction.neighborsearch.hashflat import HashFlatNeighborSearch
-from parcels.interaction.neighborsearch.hashspherical import (  # noqa
+from parcels.interaction.neighborsearch.hashspherical import (
     HashSphericalNeighborSearch,
 )
-from parcels.interaction.neighborsearch.kdtreeflat import (  # noqa
+from parcels.interaction.neighborsearch.kdtreeflat import (
     KDTreeFlatNeighborSearch,
 )
 

--- a/parcels/particledata.py
+++ b/parcels/particledata.py
@@ -1,4 +1,3 @@
-from abc import ABC
 from ctypes import POINTER, Structure
 from operator import attrgetter
 
@@ -42,7 +41,7 @@ def partitionParticlesMPI_default(coords, mpi_size=1):
     return mpiProcs
 
 
-class ParticleData(ABC):
+class ParticleData:
 
     def __init__(self, pclass, lon, lat, depth, time, lonlatdepth_dtype, pid_orig, ngrid=1, **kwargs):
         """
@@ -361,7 +360,7 @@ class ParticleData(ABC):
             raise SyntaxError(f'Could not change the write status of {var}, because it is not a Variable name')
 
 
-class ParticleDataAccessor(ABC):
+class ParticleDataAccessor:
     """Wrapper that provides access to particle data, as if interacting with the particle itself.
 
     Parameters
@@ -438,7 +437,7 @@ class ParticleDataAccessor(ABC):
         self.state = StatusCode.Delete
 
 
-class ParticleDataIterator(ABC):
+class ParticleDataIterator:
     """Iterator for looping over the particles in the ParticleData.
 
     Parameters

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -1,6 +1,5 @@
 """Module controlling the writing of ParticleSets to Zarr file."""
 import os
-from abc import ABC
 from datetime import timedelta
 
 import numpy as np
@@ -26,7 +25,7 @@ def _set_calendar(origin_calendar):
         return origin_calendar
 
 
-class ParticleFile(ABC):
+class ParticleFile:
     """Initialise trajectory output.
 
     Parameters

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from abc import ABC
 from copy import copy
 from datetime import date, datetime, timedelta
 
@@ -49,7 +48,7 @@ def _convert_to_reltime(time):
     return False
 
 
-class ParticleSet(ABC):
+class ParticleSet:
     """Class for storing particle and executing kernel over them.
 
     Please note that this currently only supports fixed size particle sets, meaning that the particle set only

--- a/parcels/tools/__init__.py
+++ b/parcels/tools/__init__.py
@@ -1,7 +1,7 @@
-from .converters import *  # noqa
-from .exampledata_utils import *  # noqa
-from .global_statics import *  # noqa
-from .interpolation_utils import *  # noqa
-from .loggers import *  # noqa
-from .statuscodes import *  # noqa
-from .timer import *  # noqa
+from .converters import *
+from .exampledata_utils import *
+from .global_statics import *
+from .interpolation_utils import *
+from .loggers import *
+from .statuscodes import *
+from .timer import *

--- a/parcels/tools/statuscodes.py
+++ b/parcels/tools/statuscodes.py
@@ -25,7 +25,7 @@ class DaskChunkingError(RuntimeError):
     """Error indicating to the user that something with setting up Dask and chunked fieldsets went wrong."""
 
     def __init__(self, src_class_type, message):
-        msg = f"[{str(src_class_type)}]: {message}"
+        msg = f"[{src_class_type}]: {message}"
         super().__init__(msg)
 
 

--- a/parcels/tools/timer.py
+++ b/parcels/tools/timer.py
@@ -45,8 +45,7 @@ class Timer():
         if step == 0:
             root_time = time
         print(('(%3d%%)' % round(time/root_time*100)), end='')
-        for i in range(step+1):
-            print('  ', end='')
+        print('  ' * (step + 1), end='')
         if step > 0:
             print('(%3d%%) ' % round(time/parent_time*100), end='')
         t_str = '%1.3e s' % time if root_time < 300 else datetime.timedelta(seconds=time)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,6 @@ ignore = [
     "E722",
 
     # TODO: These bugbear issues are to be resolved
-    "B024", # ABC
-    "B027", # `ParticleData.__del__` is an empty method in an abstract base class, but has no abstract decorator
     "B007", # Loop control variable not used within the loop body
     "B008", # Do not perform function call `os.getcwd` in argument defaults;
     "B011", # Do not `assert False`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ ignore = [
     "E722",
 
     # TODO: These bugbear issues are to be resolved
-    "B008", # Do not perform function call `os.getcwd` in argument defaults;
     "B011", # Do not `assert False`
     "B016", # Cannot raise a literal. Did you intend to return it or raise an Exception?
     "B904", # Within an `except` clause, raise exceptions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ select = [
     "E",  # Error
     "F",  # pyflakes
     "I",  # isort
+    "B",  # Bugbear
     # "UP", # pyupgrade
 ]
 
@@ -96,6 +97,15 @@ ignore = [
     "D205",
     # do not use bare except, specify exception instead
     "E722",
+
+    # TODO: These bugbear issues are to be resolved
+    "B024", # ABC
+    "B027", # `ParticleData.__del__` is an empty method in an abstract base class, but has no abstract decorator
+    "B007", # Loop control variable not used within the loop body
+    "B008", # Do not perform function call `os.getcwd` in argument defaults;
+    "B011", # Do not `assert False`
+    "B016", # Cannot raise a literal. Did you intend to return it or raise an Exception?
+    "B904", # Within an `except` clause, raise exceptions
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ ignore = [
     "E722",
 
     # TODO: These bugbear issues are to be resolved
-    "B007", # Loop control variable not used within the loop body
     "B008", # Do not perform function call `os.getcwd` in argument defaults;
     "B011", # Do not `assert False`
     "B016", # Cannot raise a literal. Did you intend to return it or raise an Exception?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ select = [
     "I",  # isort
     "B",  # Bugbear
     # "UP", # pyupgrade
+    "LOG", # logging
+    "ICN", # import conventions
+    "G", # logging-format
+    "RUF", # ruff
 ]
 
 ignore = [
@@ -73,6 +77,13 @@ ignore = [
     "E501",
     # ‘from module import *’ used; unable to detect undefined names
     "F403",
+    # Mutable class attributes should be annotated with `typing.ClassVar`
+    "RUF012",
+    # Consider `(slice(2), *block)` instead of concatenation
+    "RUF005",
+    # Prefer `next(iter(variable.items()))` over single element slice
+    "RUF015",
+
 
     # TODO: ignore for now (requires more work). Remove ignore once fixed
     # Missing docstring in public module
@@ -97,6 +108,7 @@ ignore = [
     "D205",
     # do not use bare except, specify exception instead
     "E722",
+
 
     # TODO: These bugbear issues are to be resolved
     "B011", # Do not `assert False`

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -12,7 +12,7 @@ import psutil
 import pytest
 import xarray as xr
 
-from parcels import (  # noqa
+from parcels import (
     AdvectionRK4,
     AdvectionRK4_3D,
     FieldSet,
@@ -647,7 +647,7 @@ def test_fieldset_write(tmpdir):
     fieldset.U.to_write = True
 
     def UpdateU(particle, fieldset, time):
-        tmp1, tmp2 = fieldset.UV[particle]  # noqa
+        tmp1, tmp2 = fieldset.UV[particle]
         fieldset.U.data[particle.ti, particle.yi, particle.xi] += 1
         fieldset.U.grid.time[0] = time
 
@@ -693,11 +693,11 @@ def test_from_netcdf_memory_containment(mode, time_periodic, dt, chunksize, with
         while particle.lon > 180.:
             particle_dlon -= 360.  # noqa
         while particle.lon < -180.:
-            particle_dlon += 360.  # noqa
+            particle_dlon += 360.
         while particle.lat > 90.:
             particle_dlat -= 180.  # noqa
         while particle.lat < -90.:
-            particle_dlat += 180.  # noqa
+            particle_dlat += 180.
 
     process = psutil.Process(os.getpid())
     mem_0 = process.memory_info().rss

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -176,7 +176,7 @@ def test_multigrids_pointer(mode):
 
     pset = ParticleSet.from_list(fieldset, ptype[mode], lon=[0], lat=[0], depth=[1])
 
-    for i in range(10):
+    for _ in range(10):
         pset.execute(AdvectionRK4_3D, runtime=1000, dt=500)
 
 

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -275,7 +275,7 @@ def test_flat_update(test_class):
     ref_instance = ref_class(inter_dist_vert=0.3, inter_dist_horiz=0.3)
     test_instance = test_class(inter_dist_vert=0.3, inter_dist_horiz=0.3)
 
-    for i in range(1, n_active_mask):
+    for _ in range(1, n_active_mask):
         positions = create_flat_positions(n_particle) + 10*np.random.rand()
         active_mask = np.random.rand(n_particle) > 0.5
         ref_instance.update_values(positions, active_mask)

--- a/tests/test_kernel_execution.py
+++ b/tests/test_kernel_execution.py
@@ -43,7 +43,7 @@ def test_execution_order(mode, kernel_type):
     fieldset = FieldSet.from_data({'U': [[0, 1], [2, 3]], 'V': np.ones((2, 2))}, {'lon': [0, 2], 'lat': [0, 2]}, mesh='flat')
 
     def MoveLon_Update_Lon(particle, fieldset, time):
-       particle.lon += 0.2  # noqa
+       particle.lon += 0.2
 
     def MoveLon_Update_dlon(particle, fieldset, time):
        particle_dlon += 0.2  # noqa
@@ -130,7 +130,7 @@ def test_execution_fail_python_exception(fieldset, mode, npart=10):
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_execution_fail_out_of_bounds(fieldset, mode, npart=10):
     def MoveRight(particle, fieldset, time):
-        tmp1, tmp2 = fieldset.UV[time, particle.depth, particle.lat, particle.lon + 0.1, particle]  # noqa
+        tmp1, tmp2 = fieldset.UV[time, particle.depth, particle.lat, particle.lon + 0.1, particle]
         particle_dlon += 0.1  # noqa
 
     pset = ParticleSet(fieldset, pclass=ptype[mode],
@@ -145,7 +145,7 @@ def test_execution_fail_out_of_bounds(fieldset, mode, npart=10):
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_execution_recover_out_of_bounds(fieldset, mode, npart=2):
     def MoveRight(particle, fieldset, time):
-        tmp1, tmp2 = fieldset.UV[time, particle.depth, particle.lat, particle.lon + 0.1, particle]  # noqa
+        tmp1, tmp2 = fieldset.UV[time, particle.depth, particle.lat, particle.lon + 0.1, particle]
         particle_dlon += 0.1  # noqa
 
     def MoveLeft(particle, fieldset, time):
@@ -165,7 +165,7 @@ def test_execution_recover_out_of_bounds(fieldset, mode, npart=2):
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_execution_check_all_errors(fieldset, mode):
     def MoveRight(particle, fieldset, time):
-        tmp1, tmp2 = fieldset.UV[time, particle.depth, particle.lat, particle.lon, particle]  # noqa
+        tmp1, tmp2 = fieldset.UV[time, particle.depth, particle.lat, particle.lon, particle]
 
     def RecoverAllErrors(particle, fieldset, time):
         if particle.state > 4:
@@ -196,7 +196,7 @@ def test_execution_check_stopallexecution(fieldset, mode):
 @pytest.mark.parametrize('mode', ['scipy', 'jit'])
 def test_execution_delete_out_of_bounds(fieldset, mode, npart=10):
     def MoveRight(particle, fieldset, time):
-        tmp1, tmp2 = fieldset.UV[time, particle.depth, particle.lat, particle.lon + 0.1, particle]  # noqa
+        tmp1, tmp2 = fieldset.UV[time, particle.depth, particle.lat, particle.lon + 0.1, particle]
         particle_dlon += 0.1  # noqa
 
     def DeleteMe(particle, fieldset, time):

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -193,7 +193,7 @@ def test_varname_as_fieldname():
     pset = ParticleSet(fset, pclass=Particle, lon=0, lat=0)
 
     def kernel_particlename(particle, fieldset, time):
-        particle.speed = fieldset.speed[particle]  # noqa
+        particle.speed = fieldset.speed[particle]
 
     pset.execute(kernel_particlename, endtime=1, dt=1.)
     assert pset[0].speed == 10
@@ -210,7 +210,7 @@ def test_abs():
     pset = ParticleSet(fieldset(), pclass=JITParticle, lon=0, lat=0)
 
     def kernel_abs(particle, fieldset, time):
-        particle.lon = abs(3.1)  # noqa
+        particle.lon = abs(3.1)
 
     with pytest.raises(NotImplementedError):
         pset.execute(kernel_abs, endtime=1, dt=1.)

--- a/tests/test_particlefile.py
+++ b/tests/test_particlefile.py
@@ -224,7 +224,7 @@ def test_pset_repeated_release_delayed_adding_deleting(type, fieldset, mode, rep
         particle.sample_var += 1.
         if particle.sample_var > fieldset.maxvar:
             particle.delete()
-    for i in range(runtime):
+    for _ in range(runtime):
         pset.execute(IncrLon, dt=dt, runtime=1., output_file=pfile)
 
     ds = xr.open_zarr(outfilepath)
@@ -331,7 +331,7 @@ def test_write_xiyi(fieldset, mode, tmpdir):
 
 
 def test_set_calendar():
-    for calendar_name, cf_datetime in zip(_get_cftime_calendars(), _get_cftime_datetimes()):
+    for _calendar_name, cf_datetime in zip(_get_cftime_calendars(), _get_cftime_datetimes()):
         date = getattr(cftime, cf_datetime)(1990, 1, 1)
         assert _set_calendar(date.calendar) == date.calendar
     assert _set_calendar('np_datetime64') == 'standard'

--- a/tests/test_particlesets.py
+++ b/tests/test_particlesets.py
@@ -290,7 +290,7 @@ def test_pset_add_execute(fieldset, mode, npart=10):
         particle_dlat += 0.1  # noqa
 
     pset = ParticleSet(fieldset, lon=[], lat=[], pclass=ptype[mode])
-    for i in range(npart):
+    for _ in range(npart):
         pset += ParticleSet(pclass=ptype[mode], lon=0.1, lat=0.1, fieldset=fieldset)
     for _ in range(4):
         pset.execute(pset.Kernel(AddLat), runtime=1., dt=1.0)


### PR DESCRIPTION
Enables [Bugbear error codes in Ruff linting](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b).

> A plugin for finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle.

Leaving the codes B011, B016, B904 as I want to incorporate them into a larger PR at a later date looking at reworking the parcels error system (i.e., so we aren't raising Runtime and Assertion errors). Discussed in #1620

Also added in some other rules I thought would be good. Notably RUF100 which removes unused `# noqa` flags.

Contributes to #1620