### PR TITLE
Clean top level `parcels` namespace

### DIFF
--- a/parcels/__init__.py
+++ b/parcels/__init__.py
@@ -4,7 +4,6 @@ __version__ = version
 
 import parcels.rng as ParcelsRandom  # noqa
 from parcels.application_kernels import *  # noqa
-from parcels.compilation import *  # noqa
 from parcels.field import *  # noqa
 from parcels.fieldset import *  # noqa
 from parcels.grid import *  # noqa

--- a/parcels/compilation/__init__.py
+++ b/parcels/compilation/__init__.py
@@ -1,2 +1,0 @@
-from .codecompiler import *  # noqa
-from .codegenerator import *  # noqa

--- a/parcels/tools/global_statics.py
+++ b/parcels/tools/global_statics.py
@@ -11,6 +11,7 @@ except:
     def getuid():
         return 'tmp'
 
+__all__ = ['cleanup_remove_files', 'cleanup_unload_lib', 'get_package_dir', 'get_cache_dir']
 
 def cleanup_remove_files(lib_file, log_file):
     if os.path.isfile(lib_file):

--- a/parcels/tools/interpolation_utils.py
+++ b/parcels/tools/interpolation_utils.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 import numpy as np
 
+__all__=[]
 
 def phi1D_lin(xsi):
     phi = [1-xsi,

--- a/parcels/tools/timer.py
+++ b/parcels/tools/timer.py
@@ -6,6 +6,7 @@ try:
 except ModuleNotFoundError:
     MPI = None
 
+__all__ = []
 
 class Timer():
     def __init__(self, name, parent=None, start=True):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,10 @@ ignore = [
 convention = "numpy"
 
 [tool.ruff.format]
-# List of files to ignore formatting (ordered by ascending line count)
 exclude = [
+  "parcels/tools/interpolation_utils.py",
+
+  # List of files to ignore formatting (ordered by ascending line count)
   "tests/test_mpirun.py",
   "parcels/tools/global_statics.py",
   "tests/test_tools.py",
@@ -117,7 +119,6 @@ exclude = [
   "tests/test_data/create_testfields.py",
   "tests/test_diffusion.py",
   "parcels/tools/exampledata_utils.py",
-  "parcels/tools/interpolation_utils.py",
   "parcels/interaction/neighborsearch/hashflat.py",
   "parcels/interaction/neighborsearch/hashspherical.py",
   "parcels/interaction/neighborsearch/basehash.py",


### PR DESCRIPTION
Since Parcels uses wildcard imports in `__init__.py` files to bring items up to the top level namespace, the `__all__` variable becomes important to limit what items are available at this level.

Some files which were wildcard imported didn't have this variable, leading to all variables not beginning with `_` to bubble up to the parcels namespace.

This PR adds these `__all__` variables where missing, choosing contents based on expected usecase. This PR also excludes code generation utilities from the top level namespace.

Now if we do `dir(parcels)` we get:

```
>>> dir(parcels) ['AdvectionAnalytical', 'AdvectionDiffusionEM',
'AdvectionDiffusionM1', 'AdvectionEE', 'AdvectionRK4', 'AdvectionRK45',
'AdvectionRK4_3D', 'AllParcelsErrorCodes', 'AsymmetricAttraction', 'BaseKernel',
'CGrid', 'CurvilinearSGrid', 'CurvilinearZGrid', 'DiffusionUniformKh', 'Field',
'FieldOutOfBoundError', 'FieldSamplingError', 'FieldSet', 'Geographic',
'GeographicPolar', 'GeographicPolarSquare', 'GeographicSquare', 'Grid',
'GridCode', 'GridSet', 'GridType', 'InteractionKernel', 'JITParticle', 'Kernel',
'KernelError', 'MergeWithNearestNeighbor', 'NearestNeighborWithinRange',
'NestedField', 'ParcelsRandom', 'ParticleFile', 'ParticleSet',
'RectilinearSGrid', 'RectilinearZGrid', 'ScipyInteractionParticle',
'ScipyParticle', 'StatusCode', 'TimeConverter', 'TimeExtrapolationError',
'UnitConverter', 'Variable', 'VectorField', 'XarrayDecodedFilter',
'__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__',
'__package__', '__path__', '__spec__', '__version__', '_version', 'advection',
'advectiondiffusion', 'application_kernels', 'cleanup_remove_files',
'cleanup_unload_lib', 'compilation', 'convert_to_flat_array',
'convert_xarray_time_units', 'converters', 'download_example_dataset',
'exampledata_utils', 'field', 'fieldfilebuffer', 'fieldset', 'get_cache_dir',
'get_data_home', 'get_package_dir', 'global_statics', 'grid', 'gridset',
'interaction', 'interactionkernel', 'interpolation_utils', 'kernel',
'list_example_datasets', 'logger', 'loggers', 'particle', 'particledata',
'particlefile', 'particleset', 'rng', 'statuscodes', 'timer', 'tools',
'unitconverters_map', 'version']
```


In v4 of parcels, we should consider whether to rework how we handle imports and what's available in this top level namespace (e.g., perhaps limiting whats available in the top level namespace to match how the tutorials use it).


Fixes #1643 