### PR TITLE
Update smagdiff function

### DIFF
--- a/docs/examples/tutorial_diffusion.ipynb
+++ b/docs/examples/tutorial_diffusion.ipynb
@@ -479,8 +479,8 @@
     "        2 * math.fabs(particle.dt) * Kh\n",
     "    )\n",
     "\n",
-    "    particle_dlat += dlat\n",
-    "    particle_dlon += dlon"
+    "    particle.lat += dlat\n",
+    "    particle.lon += dlon"
    ]
   },
   {


### PR DESCRIPTION
The Smagdiff function didn't update the particle's position because it didn't modify the lat and lon attributes of the "particle" object. This problem has now been solved.