### PR TITLE
API changes: `Field` and `FieldSet`

### DIFF
--- a/docs/examples/example_nemo_curvilinear.py
+++ b/docs/examples/example_nemo_curvilinear.py
@@ -108,7 +108,7 @@ def test_nemo_3D_samegrid():
 
     fieldset = parcels.FieldSet.from_nemo(filenames, variables, dimensions)
 
-    assert fieldset.U.dataFiles is not fieldset.W.dataFiles
+    assert fieldset.U._dataFiles is not fieldset.W._dataFiles
 
 
 def main(args=None):

--- a/parcels/_typing.py
+++ b/parcels/_typing.py
@@ -61,7 +61,7 @@ def assert_valid_interp_method(value: Any):
     _validate_against_pure_literal(value, InterpMethodOption)
 
 
-def assert_valid_mesh(value: Any) -> Mesh:
+def assert_valid_mesh(value: Any):
     _validate_against_pure_literal(value, Mesh)
 
 

--- a/parcels/_typing.py
+++ b/parcels/_typing.py
@@ -10,7 +10,7 @@ import ast
 import datetime
 import os
 from collections.abc import Callable
-from typing import Literal
+from typing import Any, Literal, get_args
 
 
 class ParcelsAST(ast.AST):
@@ -37,10 +37,33 @@ PathLike = str | os.PathLike
 Mesh = Literal["spherical", "flat"]  # corresponds with `mesh`
 VectorType = Literal["3D", "2D"] | None  # corresponds with `vector_type`
 ChunkMode = Literal["auto", "specific", "failsafe"]  # corresponds with `chunk_mode`
-GridIndexingType = Literal["pop", "mom5", "mitgcm", "nemo"]  # corresponds with `grid_indexing_type`
+GridIndexingType = Literal["pop", "mom5", "mitgcm", "nemo"]  # corresponds with `gridindexingtype`
 UpdateStatus = Literal["not_updated", "first_updated", "updated"]  # corresponds with `update_status`
 TimePeriodic = float | datetime.timedelta | Literal[False]  # corresponds with `update_status`
 NetcdfEngine = Literal["netcdf4", "xarray", "scipy"]
 
 
 KernelFunction = Callable[..., None]
+
+
+def _validate_against_pure_literal(value, typing_literal):
+    """Uses a Literal type alias to validate.
+
+    Can't be used with ``Literal[...] | None`` etc. as its not a pure literal.
+    """
+    if value not in get_args(typing_literal):
+        msg = f"Invalid value {value!r}. Valid options are {get_args(typing_literal)!r}"
+        raise ValueError(msg)
+
+
+# Assertion functions to clean user input
+def assert_valid_interp_method(value: Any):
+    _validate_against_pure_literal(value, InterpMethodOption)
+
+
+def assert_valid_mesh(value: Any) -> Mesh:
+    _validate_against_pure_literal(value, Mesh)
+
+
+def assert_valid_gridindexingtype(value: Any):
+    _validate_against_pure_literal(value, GridIndexingType)

--- a/parcels/application_kernels/advection.py
+++ b/parcels/application_kernels/advection.py
@@ -125,14 +125,14 @@ def AdvectionAnalytical(particle, fieldset, time):
     direction = 1.0 if particle.dt > 0 else -1.0
     withW = True if "W" in [f.name for f in fieldset.get_fields()] else False
     withTime = True if len(fieldset.U.grid.time_full) > 1 else False
-    ti = fieldset.U.time_index(time)[0]
+    ti = fieldset.U._time_index(time)[0]
     ds_t = particle.dt
     if withTime:
         tau = (time - fieldset.U.grid.time[ti]) / (fieldset.U.grid.time[ti + 1] - fieldset.U.grid.time[ti])
         time_i = np.linspace(0, fieldset.U.grid.time[ti + 1] - fieldset.U.grid.time[ti], I_s)
         ds_t = min(ds_t, time_i[np.where(time - fieldset.U.grid.time[ti] < time_i)[0][0]])
 
-    xsi, eta, zeta, xi, yi, zi = fieldset.U.search_indices(
+    xsi, eta, zeta, xi, yi, zi = fieldset.U._search_indices(
         particle.lon, particle.lat, particle.depth, particle=particle
     )
     if withW:

--- a/parcels/compilation/codegenerator.py
+++ b/parcels/compilation/codegenerator.py
@@ -819,14 +819,14 @@ class KernelGenerator(ABC, ast.NodeVisitor):
         self.visit(node.field)
         self.visit(node.args)
         args = self._check_FieldSamplingArguments(node.args.ccode)
-        ccode_eval = node.field.obj.ccode_eval(node.var, *args)
+        ccode_eval = node.field.obj._ccode_eval(node.var, *args)
         stmts = [
             c.Assign("parcels_interp_state", ccode_eval),
             c.Assign("particles->state[pnum]", "max(particles->state[pnum], parcels_interp_state)"),
         ]
 
         if node.convert:
-            ccode_conv = node.field.obj.ccode_convert(*args)
+            ccode_conv = node.field.obj._ccode_convert(*args)
             conv_stat = c.Statement(f"{node.var} *= {ccode_conv}")
             stmts += [conv_stat]
 
@@ -836,17 +836,17 @@ class KernelGenerator(ABC, ast.NodeVisitor):
         self.visit(node.field)
         self.visit(node.args)
         args = self._check_FieldSamplingArguments(node.args.ccode)
-        ccode_eval = node.field.obj.ccode_eval(
+        ccode_eval = node.field.obj._ccode_eval(
             node.var, node.var2, node.var3, node.field.obj.U, node.field.obj.V, node.field.obj.W, *args
         )
         if node.convert and node.field.obj.U.interp_method != "cgrid_velocity":
-            ccode_conv1 = node.field.obj.U.ccode_convert(*args)
-            ccode_conv2 = node.field.obj.V.ccode_convert(*args)
+            ccode_conv1 = node.field.obj.U._ccode_convert(*args)
+            ccode_conv2 = node.field.obj.V._ccode_convert(*args)
             statements = [c.Statement(f"{node.var} *= {ccode_conv1}"), c.Statement(f"{node.var2} *= {ccode_conv2}")]
         else:
             statements = []
         if node.convert and node.field.obj.vector_type == "3D":
-            ccode_conv3 = node.field.obj.W.ccode_convert(*args)
+            ccode_conv3 = node.field.obj.W._ccode_convert(*args)
             statements.append(c.Statement(f"{node.var3} *= {ccode_conv3}"))
         conv_stat = c.Block(statements)
         node.ccode = c.Block(
@@ -864,8 +864,8 @@ class KernelGenerator(ABC, ast.NodeVisitor):
         cstat = []
         args = self._check_FieldSamplingArguments(node.args.ccode)
         for fld in node.fields.obj:
-            ccode_eval = fld.ccode_eval(node.var, *args)
-            ccode_conv = fld.ccode_convert(*args)
+            ccode_eval = fld._ccode_eval(node.var, *args)
+            ccode_conv = fld._ccode_convert(*args)
             conv_stat = c.Statement(f"{node.var} *= {ccode_conv}")
             cstat += [
                 c.Assign("particles->state[pnum]", ccode_eval),
@@ -884,15 +884,15 @@ class KernelGenerator(ABC, ast.NodeVisitor):
         cstat = []
         args = self._check_FieldSamplingArguments(node.args.ccode)
         for fld in node.fields.obj:
-            ccode_eval = fld.ccode_eval(node.var, node.var2, node.var3, fld.U, fld.V, fld.W, *args)
+            ccode_eval = fld._ccode_eval(node.var, node.var2, node.var3, fld.U, fld.V, fld.W, *args)
             if fld.U.interp_method != "cgrid_velocity":
-                ccode_conv1 = fld.U.ccode_convert(*args)
-                ccode_conv2 = fld.V.ccode_convert(*args)
+                ccode_conv1 = fld.U._ccode_convert(*args)
+                ccode_conv2 = fld.V._ccode_convert(*args)
                 statements = [c.Statement(f"{node.var} *= {ccode_conv1}"), c.Statement(f"{node.var2} *= {ccode_conv2}")]
             else:
                 statements = []
             if fld.vector_type == "3D":
-                ccode_conv3 = fld.W.ccode_convert(*args)
+                ccode_conv3 = fld.W._ccode_convert(*args)
                 statements.append(c.Statement(f"{node.var3} *= {ccode_conv3}"))
             cstat += [
                 c.Assign("particles->state[pnum]", ccode_eval),

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -19,6 +19,7 @@ from parcels._typing import (
     TimePeriodic,
     VectorType,
     assert_valid_gridindexingtype,
+    assert_valid_interp_method,
 )
 from parcels.tools._helpers import deprecated_made_private
 from parcels.tools.converters import (
@@ -209,11 +210,11 @@ class Field:
         self.timestamps = timestamps
         if isinstance(interp_method, dict):
             if self.name in interp_method:
-                self._interp_method = interp_method[self.name]
+                self.interp_method = interp_method[self.name]
             else:
                 raise RuntimeError(f"interp_method is a dictionary but {name} is not in it")
         else:
-            self._interp_method = interp_method
+            self.interp_method = interp_method
         assert_valid_gridindexingtype(gridindexingtype)
         self._gridindexingtype = gridindexingtype
         if self.interp_method in ["bgrid_velocity", "bgrid_w_velocity", "bgrid_tracer"] and self.grid.gtype in [
@@ -336,6 +337,11 @@ class Field:
     @property
     def interp_method(self):
         return self._interp_method
+
+    @interp_method.setter
+    def interp_method(self, value):
+        assert_valid_interp_method(value)
+        self._interp_method = value
 
     @property
     def gridindexingtype(self):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -287,7 +287,7 @@ class Field:
         if self.grid._add_last_periodic_data_timestep and self.dataFiles is not None:
             self.dataFiles = np.append(self.dataFiles, self.dataFiles[0])
         self._field_fb_class = kwargs.pop("FieldFileBuffer", None)
-        self.netcdf_engine = kwargs.pop("netcdf_engine", "netcdf4")
+        self._netcdf_engine = kwargs.pop("netcdf_engine", "netcdf4")
         self.loaded_time_indices: Iterable[int] = []  # type: ignore
         self.creation_log = kwargs.pop("creation_log", "")
         self.chunksize = kwargs.pop("chunksize", None)
@@ -350,6 +350,10 @@ class Field:
     @property
     def cast_data_dtype(self):
         return self._cast_data_dtype
+
+    @property
+    def netcdf_engine(self):
+        return self._netcdf_engine
 
     @classmethod
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -13,6 +13,7 @@ import xarray as xr
 
 import parcels.tools.interpolation_utils as i_u
 from parcels._typing import GridIndexingType, InterpMethod, Mesh, TimePeriodic, VectorType
+from parcels.tools._helpers import deprecated_made_private
 from parcels.tools.converters import (
     Geographic,
     GeographicPolar,
@@ -337,7 +338,12 @@ class Field:
         return self._cast_data_dtype
 
     @classmethod
-    def get_dim_filenames(cls, filenames, dim):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def get_dim_filenames(cls, *args, **kwargs):
+        return cls._get_dim_filenames(*args, **kwargs)
+
+    @classmethod
+    def _get_dim_filenames(cls, filenames, dim):
         if isinstance(filenames, str) or not isinstance(filenames, collections.abc.Iterable):
             return [filenames]
         elif isinstance(filenames, dict):
@@ -351,7 +357,12 @@ class Field:
             return filenames
 
     @staticmethod
-    def collect_timeslices(
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def collect_timeslices(*args, **kwargs):
+        return Field._collect_timeslices(*args, **kwargs)
+
+    @staticmethod
+    def _collect_timeslices(
         timestamps, data_filenames, _grid_fb_class, dimensions, indices, netcdf_engine, netcdf_decodewarning=None
     ):
         if netcdf_decodewarning is not None:
@@ -500,17 +511,17 @@ class Field:
             len(variable) == 2
         ), "The variable tuple must have length 2. Use FieldSet.from_netcdf() for multiple variables"
 
-        data_filenames = cls.get_dim_filenames(filenames, "data")
-        lonlat_filename = cls.get_dim_filenames(filenames, "lon")
+        data_filenames = cls._get_dim_filenames(filenames, "data")
+        lonlat_filename = cls._get_dim_filenames(filenames, "lon")
         if isinstance(filenames, dict):
             assert len(lonlat_filename) == 1
-        if lonlat_filename != cls.get_dim_filenames(filenames, "lat"):
+        if lonlat_filename != cls._get_dim_filenames(filenames, "lat"):
             raise NotImplementedError(
                 "longitude and latitude dimensions are currently processed together from one single file"
             )
         lonlat_filename = lonlat_filename[0]
         if "depth" in dimensions:
-            depth_filename = cls.get_dim_filenames(filenames, "depth")
+            depth_filename = cls._get_dim_filenames(filenames, "depth")
             if isinstance(filenames, dict) and len(depth_filename) != 1:
                 raise NotImplementedError("Vertically adaptive meshes not implemented for from_netcdf()")
             depth_filename = depth_filename[0]
@@ -573,7 +584,7 @@ class Field:
         if grid is None:
             # Concatenate time variable to determine overall dimension
             # across multiple files
-            time, time_origin, timeslices, dataFiles = cls.collect_timeslices(
+            time, time_origin, timeslices, dataFiles = cls._collect_timeslices(
                 timestamps, data_filenames, _grid_fb_class, dimensions, indices, netcdf_engine
             )
             grid = Grid.create_grid(lon, lat, depth, time, time_origin=time_origin, mesh=mesh)
@@ -582,7 +593,7 @@ class Field:
         elif grid is not None and ("dataFiles" not in kwargs or kwargs["dataFiles"] is None):
             # ==== means: the field has a shared grid, but may have different data files, so we need to collect the
             # ==== correct file time series again.
-            _, _, _, dataFiles = cls.collect_timeslices(
+            _, _, _, dataFiles = cls._collect_timeslices(
                 timestamps, data_filenames, _grid_fb_class, dimensions, indices, netcdf_engine
             )
             kwargs["dataFiles"] = dataFiles
@@ -836,7 +847,11 @@ class Field:
         if self.grid != field.grid:
             field.grid.depth_field = field
 
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
     def calc_cell_edge_sizes(self):
+        return self._calc_cell_edge_sizes()
+
+    def _calc_cell_edge_sizes(self):
         """Method to calculate cell sizes based on numpy.gradient method.
 
         Currently only works for Rectilinear Grids
@@ -865,10 +880,14 @@ class Field:
         Currently only works for Rectilinear Grids
         """
         if not self.grid.cell_edge_sizes:
-            self.calc_cell_edge_sizes()
+            self._calc_cell_edge_sizes()
         return self.grid.cell_edge_sizes["x"] * self.grid.cell_edge_sizes["y"]
 
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
     def search_indices_vertical_z(self, z):
+        return self._search_indices_vertical_z(z)
+
+    def _search_indices_vertical_z(self, z):
         grid = self.grid
         z = np.float32(z)
         if grid.depth[-1] > grid.depth[0]:
@@ -898,7 +917,11 @@ class Field:
         zeta = (z - grid.depth[zi]) / (grid.depth[zi + 1] - grid.depth[zi])
         return (zi, zeta)
 
-    def search_indices_vertical_s(
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def search_indices_vertical_s(self, *args, **kwargs):
+        return self._search_indices_vertical_s(*args, **kwargs)
+
+    def _search_indices_vertical_s(
         self, x: float, y: float, z: float, xi: int, yi: int, xsi: float, eta: float, ti: int, time: float
     ):
         grid = self.grid
@@ -957,7 +980,11 @@ class Field:
         zeta = (z - depth_vector[zi]) / (depth_vector[zi + 1] - depth_vector[zi])
         return (zi, zeta)
 
-    def reconnect_bnd_indices(self, xi, yi, xdim, ydim, sphere_mesh):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def reconnect_bnd_indices(self, *args, **kwargs):
+        return self._reconnect_bnd_indices(*args, **kwargs)
+
+    def _reconnect_bnd_indices(self, xi, yi, xdim, ydim, sphere_mesh):
         if xi < 0:
             if sphere_mesh:
                 xi = xdim - 2
@@ -976,7 +1003,11 @@ class Field:
                 xi = xdim - xi
         return xi, yi
 
-    def search_indices_rectilinear(self, x: float, y: float, z: float, ti=-1, time=-1, particle=None, search2D=False):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def search_indices_rectilinear(self, *args, **kwargs):
+        return self._search_indices_rectilinear(*args, **kwargs)
+
+    def _search_indices_rectilinear(self, x: float, y: float, z: float, ti=-1, time=-1, particle=None, search2D=False):
         grid = self.grid
 
         if grid.xdim > 1 and (not grid.zonal_periodic):
@@ -1043,13 +1074,13 @@ class Field:
             if grid.gtype == GridType.RectilinearZGrid:
                 # Never passes here, because in this case, we work with scipy
                 try:
-                    (zi, zeta) = self.search_indices_vertical_z(z)
+                    (zi, zeta) = self._search_indices_vertical_z(z)
                 except FieldOutOfBoundError:
                     raise FieldOutOfBoundError(x, y, z, field=self)
                 except FieldOutOfBoundSurfaceError:
                     raise FieldOutOfBoundSurfaceError(x, y, z, field=self)
             elif grid.gtype == GridType.RectilinearSGrid:
-                (zi, zeta) = self.search_indices_vertical_s(x, y, z, xi, yi, xsi, eta, ti, time)
+                (zi, zeta) = self._search_indices_vertical_s(x, y, z, xi, yi, xsi, eta, ti, time)
         else:
             zi, zeta = -1, 0
 
@@ -1063,7 +1094,11 @@ class Field:
 
         return (xsi, eta, zeta, xi, yi, zi)
 
-    def search_indices_curvilinear(self, x, y, z, ti=-1, time=-1, particle=None, search2D=False):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def search_indices_curvilinear(self, *args, **kwargs):
+        return self._search_indices_curvilinear(*args, **kwargs)
+
+    def _search_indices_curvilinear(self, x, y, z, ti=-1, time=-1, particle=None, search2D=False):
         if particle:
             xi = particle.xi[self.igrid]
             yi = particle.yi[self.igrid]
@@ -1122,7 +1157,7 @@ class Field:
                 yi -= 1
             elif eta > 1 + tol:
                 yi += 1
-            (xi, yi) = self.reconnect_bnd_indices(xi, yi, grid.xdim, grid.ydim, grid.mesh)
+            (xi, yi) = self._reconnect_bnd_indices(xi, yi, grid.xdim, grid.ydim, grid.mesh)
             it += 1
             if it > maxIterSearch:
                 print("Correct cell not found after %d iterations" % maxIterSearch)
@@ -1135,11 +1170,11 @@ class Field:
         if grid.zdim > 1 and not search2D:
             if grid.gtype == GridType.CurvilinearZGrid:
                 try:
-                    (zi, zeta) = self.search_indices_vertical_z(z)
+                    (zi, zeta) = self._search_indices_vertical_z(z)
                 except FieldOutOfBoundError:
                     raise FieldOutOfBoundError(x, y, z, field=self)
             elif grid.gtype == GridType.CurvilinearSGrid:
-                (zi, zeta) = self.search_indices_vertical_s(x, y, z, xi, yi, xsi, eta, ti, time)
+                (zi, zeta) = self._search_indices_vertical_s(x, y, z, xi, yi, xsi, eta, ti, time)
         else:
             zi = -1
             zeta = 0
@@ -1154,14 +1189,22 @@ class Field:
 
         return (xsi, eta, zeta, xi, yi, zi)
 
-    def search_indices(self, x, y, z, ti=-1, time=-1, particle=None, search2D=False):
-        if self.grid.gtype in [GridType.RectilinearSGrid, GridType.RectilinearZGrid]:
-            return self.search_indices_rectilinear(x, y, z, ti, time, particle=particle, search2D=search2D)
-        else:
-            return self.search_indices_curvilinear(x, y, z, ti, time, particle=particle, search2D=search2D)
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def search_indices(self, *args, **kwargs):
+        return self._search_indices(*args, **kwargs)
 
-    def interpolator2D(self, ti, z, y, x, particle=None):
-        (xsi, eta, _, xi, yi, _) = self.search_indices(x, y, z, particle=particle)
+    def _search_indices(self, x, y, z, ti=-1, time=-1, particle=None, search2D=False):
+        if self.grid.gtype in [GridType.RectilinearSGrid, GridType.RectilinearZGrid]:
+            return self._search_indices_rectilinear(x, y, z, ti, time, particle=particle, search2D=search2D)
+        else:
+            return self._search_indices_curvilinear(x, y, z, ti, time, particle=particle, search2D=search2D)
+
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def interpolator2D(self, *args, **kwargs):
+        return self._interpolator2D(*args, **kwargs)
+
+    def _interpolator2D(self, ti, z, y, x, particle=None):
+        (xsi, eta, _, xi, yi, _) = self._search_indices(x, y, z, particle=particle)
         if self.interp_method == "nearest":
             xii = xi if xsi <= 0.5 else xi + 1
             yii = yi if eta <= 0.5 else yi + 1
@@ -1211,8 +1254,12 @@ class Field:
         else:
             raise RuntimeError(self.interp_method + " is not implemented for 2D grids")
 
-    def interpolator3D(self, ti, z, y, x, time, particle=None):
-        (xsi, eta, zeta, xi, yi, zi) = self.search_indices(x, y, z, ti, time, particle=particle)
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def interpolator3D(self, *args, **kwargs):
+        return self._interpolator3D(*args, **kwargs)
+
+    def _interpolator3D(self, ti, z, y, x, time, particle=None):
+        (xsi, eta, zeta, xi, yi, zi) = self._search_indices(x, y, z, ti, time, particle=particle)
         if self.interp_method == "nearest":
             xii = xi if xsi <= 0.5 else xi + 1
             yii = yi if eta <= 0.5 else yi + 1
@@ -1321,12 +1368,16 @@ class Field:
             f1 = self.data[ti + 1, :]
             return f0 + (f1 - f0) * ((time - t0) / (t1 - t0))
 
-    def spatial_interpolation(self, ti, z, y, x, time, particle=None):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def spatial_interpolation(self, *args, **kwargs):
+        return self._spatial_interpolation(*args, **kwargs)
+
+    def _spatial_interpolation(self, ti, z, y, x, time, particle=None):
         """Interpolate horizontal field values using a SciPy interpolator."""
         if self.grid.zdim == 1:
-            val = self.interpolator2D(ti, z, y, x, particle=particle)
+            val = self._interpolator2D(ti, z, y, x, particle=particle)
         else:
-            val = self.interpolator3D(ti, z, y, x, time, particle=particle)
+            val = self._interpolator3D(ti, z, y, x, time, particle=particle)
         if np.isnan(val):
             # Detect Out-of-bounds sampling and raise exception
             raise FieldOutOfBoundError(x, y, z, field=self)
@@ -1335,7 +1386,11 @@ class Field:
                 val = val.compute()
             return val
 
-    def time_index(self, time):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def time_index(self, *args, **kwargs):
+        return self._time_index(*args, **kwargs)
+
+    def _time_index(self, time):
         """Find the index in the time array associated with a given time.
 
         Note that we normalize to either the first or the last index
@@ -1398,11 +1453,11 @@ class Field:
         conversion to the result. Note that we defer to
         scipy.interpolate to perform spatial interpolation.
         """
-        (ti, periods) = self.time_index(time)
+        (ti, periods) = self._time_index(time)
         time -= periods * (self.grid.time_full[-1] - self.grid.time_full[0])
         if ti < self.grid.tdim - 1 and time > self.grid.time[ti]:
-            f0 = self.spatial_interpolation(ti, z, y, x, time, particle=particle)
-            f1 = self.spatial_interpolation(ti + 1, z, y, x, time, particle=particle)
+            f0 = self._spatial_interpolation(ti, z, y, x, time, particle=particle)
+            f1 = self._spatial_interpolation(ti + 1, z, y, x, time, particle=particle)
             t0 = self.grid.time[ti]
             t1 = self.grid.time[ti + 1]
             value = f0 + (f1 - f0) * ((time - t0) / (t1 - t0))
@@ -1410,28 +1465,48 @@ class Field:
             # Skip temporal interpolation if time is outside
             # of the defined time range or if we have hit an
             # exact value in the time array.
-            value = self.spatial_interpolation(ti, z, y, x, self.grid.time[ti], particle=particle)
+            value = self._spatial_interpolation(ti, z, y, x, self.grid.time[ti], particle=particle)
 
         if applyConversion:
             return self.units.to_target(value, x, y, z)
         else:
             return value
 
-    def ccode_eval(self, var, t, z, y, x):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def ccode_eval(self, *args, **kwargs):
+        return self._ccode_eval(*args, **kwargs)
+
+    def _ccode_eval(self, var, t, z, y, x):
         self._check_velocitysampling()
         ccode_str = f"temporal_interpolation({x}, {y}, {z}, {t}, {self.ccode_name}, &particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], &{var}, {self.interp_method.upper()}, {self.gridindexingtype.upper()})"
         return ccode_str
 
-    def ccode_convert(self, _, z, y, x):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def ccode_convert(self, *args, **kwargs):
+        return self._ccode_convert(*args, **kwargs)
+
+    def _ccode_convert(self, _, z, y, x):
         return self.units.ccode_to_target(x, y, z)
 
-    def get_block_id(self, block):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def get_block_id(self, *args, **kwargs):
+        return self._get_block_id(*args, **kwargs)
+
+    def _get_block_id(self, block):
         return np.ravel_multi_index(block, self.nchunks)
 
-    def get_block(self, bid):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def get_block(self, *args, **kwargs):
+        return self._get_block(*args, **kwargs)
+
+    def _get_block(self, bid):
         return np.unravel_index(bid, self.nchunks[1:])
 
-    def chunk_setup(self):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def chunk_setup(self, *args, **kwargs):
+        return self._chunk_setup(*args, **kwargs)
+
+    def _chunk_setup(self):
         if isinstance(self.data, da.core.Array):
             chunks = self.data.chunks
             self.nchunks = self.data.numblocks
@@ -1461,9 +1536,13 @@ class Field:
         self.grid.chunk_info = sum(self.grid.chunk_info, [])  # noqa: RUF017
         self.chunk_set = True
 
-    def chunk_data(self):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def chunk_data(self, *args, **kwargs):
+        return self._chunk_data(*args, **kwargs)
+
+    def _chunk_data(self):
         if not self.chunk_set:
-            self.chunk_setup()
+            self._chunk_setup()
         g = self.grid
         if isinstance(self.data, da.core.Array):
             for block_id in range(len(self.grid.load_chunk)):
@@ -1472,7 +1551,7 @@ class Field:
                     or g.load_chunk[block_id] in g.chunk_loaded
                     and self.data_chunks[block_id] is None
                 ):
-                    block = self.get_block(block_id)
+                    block = self._get_block(block_id)
                     self.data_chunks[block_id] = np.array(self.data.blocks[(slice(self.grid.tdim),) + block], order="C")
                 elif g.load_chunk[block_id] == g.chunk_not_loaded:
                     if isinstance(self.data_chunks, list):
@@ -1631,7 +1710,11 @@ class Field:
         )
         dset.to_netcdf(filepath, unlimited_dims="time_counter")
 
-    def rescale_and_set_minmax(self, data):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def rescale_and_set_minmax(self, *args, **kwargs):
+        return self._rescale_and_set_minmax(*args, **kwargs)
+
+    def _rescale_and_set_minmax(self, data):
         data[np.isnan(data)] = 0
         if self._scaling_factor:
             data *= self._scaling_factor
@@ -1641,7 +1724,11 @@ class Field:
             data[data > self.vmax] = 0
         return data
 
-    def data_concatenate(self, data, data_to_concat, tindex):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def data_concatenate(self, *args, **kwargs):
+        return self._data_concatenate(*args, **kwargs)
+
+    def _data_concatenate(self, data, data_to_concat, tindex):
         if data[tindex] is not None:
             if isinstance(data, np.ndarray):
                 data[tindex] = None
@@ -1667,7 +1754,7 @@ class Field:
                 ti = g.ti + tindex
             timestamp = self.timestamps[np.where(ti < summedlen)[0][0]]
 
-        rechunk_callback_fields = self.chunk_setup if isinstance(tindex, list) else None
+        rechunk_callback_fields = self._chunk_setup if isinstance(tindex, list) else None
         filebuffer = self._field_fb_class(
             self.dataFiles[g.ti + tindex],
             self.dimensions,
@@ -1707,7 +1794,7 @@ class Field:
                     (),
                 ),
             )
-        data = self.data_concatenate(data, buffer_data, tindex)
+        data = self._data_concatenate(data, buffer_data, tindex)
         self.filebuffers[tindex] = filebuffer
         return data
 
@@ -1772,7 +1859,7 @@ class VectorField:
 
     def spatial_c_grid_interpolation2D(self, ti, z, y, x, time, particle=None, applyConversion=True):
         grid = self.U.grid
-        (xsi, eta, zeta, xi, yi, zi) = self.U.search_indices(x, y, z, ti, time, particle=particle)
+        (xsi, eta, zeta, xi, yi, zi) = self.U._search_indices(x, y, z, ti, time, particle=particle)
 
         if grid.gtype in [GridType.RectilinearSGrid, GridType.RectilinearZGrid]:
             px = np.array([grid.lon[xi], grid.lon[xi + 1], grid.lon[xi + 1], grid.lon[xi]])
@@ -1844,7 +1931,7 @@ class VectorField:
 
     def spatial_c_grid_interpolation3D_full(self, ti, z, y, x, time, particle=None):
         grid = self.U.grid
-        (xsi, eta, zet, xi, yi, zi) = self.U.search_indices(x, y, z, ti, time, particle=particle)
+        (xsi, eta, zet, xi, yi, zi) = self.U._search_indices(x, y, z, ti, time, particle=particle)
 
         if grid.gtype in [GridType.RectilinearSGrid, GridType.RectilinearZGrid]:
             px = np.array([grid.lon[xi], grid.lon[xi + 1], grid.lon[xi + 1], grid.lon[xi]])
@@ -2085,7 +2172,7 @@ class VectorField:
                 return True
 
     def spatial_slip_interpolation(self, ti, z, y, x, time, particle=None, applyConversion=True):
-        (xsi, eta, zeta, xi, yi, zi) = self.U.search_indices(x, y, z, ti, time, particle=particle)
+        (xsi, eta, zeta, xi, yi, zi) = self.U._search_indices(x, y, z, ti, time, particle=particle)
         di = ti if self.U.grid.zdim == 1 else zi  # general third dimension
 
         f_u, f_v, f_w = 1, 1, 1
@@ -2209,7 +2296,7 @@ class VectorField:
                 "freeslip": {"2D": self.spatial_slip_interpolation, "3D": self.spatial_slip_interpolation},
             }
             grid = self.U.grid
-            (ti, periods) = self.U.time_index(time)
+            (ti, periods) = self.U._time_index(time)
             time -= periods * (grid.time_full[-1] - grid.time_full[0])
             if ti < grid.tdim - 1 and time > grid.time[ti]:
                 t0 = grid.time[ti]

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -2344,7 +2344,11 @@ class VectorField:
         except tuple(AllParcelsErrorCodes.keys()) as error:
             return _deal_with_errors(error, key, vector_type=self.vector_type)
 
-    def ccode_eval(self, varU, varV, varW, U, V, W, t, z, y, x):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def ccode_eval(self, *args, **kwargs):
+        return self._ccode_eval(*args, **kwargs)
+
+    def _ccode_eval(self, varU, varV, varW, U, V, W, t, z, y, x):
         ccode_str = ""
         if self.vector_type == "3D":
             ccode_str = (

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -281,7 +281,7 @@ class Field:
         self._scaling_factor = None
 
         # Variable names in JIT code
-        self.dimensions = kwargs.pop("dimensions", None)
+        self._dimensions = kwargs.pop("dimensions", None)
         self.indices = kwargs.pop("indices", None)
         self._dataFiles = kwargs.pop("dataFiles", None)
         if self.grid._add_last_periodic_data_timestep and self._dataFiles is not None:
@@ -340,6 +340,10 @@ class Field:
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
     def loaded_time_indices(self):
         return self._loaded_time_indices
+
+    @property
+    def dimensions(self):
+        return self._dimensions
 
     @property
     def grid(self):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -12,7 +12,14 @@ import numpy as np
 import xarray as xr
 
 import parcels.tools.interpolation_utils as i_u
-from parcels._typing import GridIndexingType, InterpMethod, Mesh, TimePeriodic, VectorType
+from parcels._typing import (
+    GridIndexingType,
+    InterpMethod,
+    Mesh,
+    TimePeriodic,
+    VectorType,
+    assert_valid_gridindexingtype,
+)
 from parcels.tools._helpers import deprecated_made_private
 from parcels.tools.converters import (
     Geographic,
@@ -207,6 +214,7 @@ class Field:
                 raise RuntimeError(f"interp_method is a dictionary but {name} is not in it")
         else:
             self._interp_method = interp_method
+        assert_valid_gridindexingtype(gridindexingtype)
         self._gridindexingtype = gridindexingtype
         if self.interp_method in ["bgrid_velocity", "bgrid_w_velocity", "bgrid_tracer"] and self.grid.gtype in [
             GridType.RectilinearSGrid,

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -39,7 +39,7 @@ class FieldSet:
     def __init__(self, U: Field | NestedField | None, V: Field | NestedField | None, fields=None):
         self.gridset = GridSet()
         self.completed: bool = False
-        self.particlefile: ParticleFile | None = None
+        self._particlefile: ParticleFile | None = None
         if U:
             self.add_field(U, "U")
             # see #1663 for type-ignore reason
@@ -54,6 +54,10 @@ class FieldSet:
 
         self.compute_on_defer = None
         self.add_UVfield()
+
+    @property
+    def particlefile(self):
+        return self._particlefile
 
     @staticmethod
     def checkvaliddimensionsdict(dims):

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -54,7 +54,7 @@ class FieldSet:
                 self.add_field(field, name)
 
         self.compute_on_defer = None
-        self.add_UVfield()
+        self._add_UVfield()
 
     @property
     def particlefile(self):
@@ -245,7 +245,11 @@ class FieldSet:
             for f in vfield:
                 f.fieldset = self
 
-    def add_UVfield(self):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def add_UVfield(self, *args, **kwargs):
+        return self._add_UVfield(*args, **kwargs)
+
+    def _add_UVfield(self):
         if not hasattr(self, "UV") and hasattr(self, "U") and hasattr(self, "V"):
             if isinstance(self.U, NestedField):
                 self.add_vector_field(NestedField("UV", self.U, self.V))
@@ -313,7 +317,7 @@ class FieldSet:
             if g.defer_load:
                 g.time_full = g.time_full + self.time_origin.reltime(g.time_origin)
             g.time_origin = self.time_origin
-        self.add_UVfield()
+        self._add_UVfield()
 
         ccode_fieldnames = []
         counter = 1

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -343,7 +343,12 @@ class FieldSet:
         self._completed = True
 
     @classmethod
-    def parse_wildcards(cls, paths, filenames, var):
+    @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
+    def parse_wildcards(self, *args, **kwargs):
+        return self._parse_wildcards(*args, **kwargs)
+
+    @classmethod
+    def _parse_wildcards(cls, paths, filenames, var):
         if not isinstance(paths, list):
             paths = sorted(glob(str(paths)))
         if len(paths) == 0:
@@ -469,10 +474,10 @@ class FieldSet:
             # Resolve all matching paths for the current variable
             paths = filenames[var] if type(filenames) is dict and var in filenames else filenames
             if type(paths) is not dict:
-                paths = cls.parse_wildcards(paths, filenames, var)
+                paths = cls._parse_wildcards(paths, filenames, var)
             else:
                 for dim, p in paths.items():
-                    paths[dim] = cls.parse_wildcards(p, filenames, var)
+                    paths[dim] = cls._parse_wildcards(p, filenames, var)
 
             # Use dimensions[var] and indices[var] if either of them is a dict of dicts
             dims = dimensions[var] if var in dimensions else dimensions

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1332,7 +1332,7 @@ class FieldSet:
             raise OSError(f"Module {filename}.{modulename} does not return a FieldSet object")
         return fieldset
 
-    def get_fields(self):
+    def get_fields(self) -> list[Field | VectorField]:
         """Returns a list of all the :class:`parcels.field.Field` and :class:`parcels.field.VectorField`
         objects associated with this FieldSet.
         """
@@ -1468,13 +1468,13 @@ class FieldSet:
                             fb.close()
                         fb = None
                     data = f.computeTimeChunk(data, tind)
-                data = f.rescale_and_set_minmax(data)
+                data = f._rescale_and_set_minmax(data)
 
                 if isinstance(f.data, DeferredArray):
                     f.data = DeferredArray()
                 f.data = f.reshape(data)
                 if not f.chunk_set:
-                    f.chunk_setup()
+                    f._chunk_setup()
                 if len(g.load_chunk) > g.chunk_not_loaded:
                     g.load_chunk = np.where(
                         g.load_chunk == g.chunk_loaded_touched, g.chunk_loading_requested, g.load_chunk
@@ -1504,7 +1504,7 @@ class FieldSet:
                         f.filebuffers[1] = None
                     f.filebuffers[1] = f.filebuffers[0]
                     data = f.computeTimeChunk(data, 0)
-                data = f.rescale_and_set_minmax(data)
+                data = f._rescale_and_set_minmax(data)
                 if signdt >= 0:
                     data = f.reshape(data)[1, :]
                     if lib is da:

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
-from parcels._typing import Mesh, UpdateStatus
+from parcels._typing import Mesh, UpdateStatus, assert_valid_mesh
 from parcels.tools.converters import TimeConverter
 from parcels.tools.warnings import FieldSetWarning
 
@@ -79,6 +79,7 @@ class Grid:
         self.time_full = self.time  # needed for deferred_loaded Fields
         self.time_origin = TimeConverter() if time_origin is None else time_origin
         assert isinstance(self.time_origin, TimeConverter), "time_origin needs to be a TimeConverter object"
+        assert_valid_mesh(mesh)
         self.mesh = mesh
         self.cstruct = None
         self.cell_edge_sizes: dict[str, npt.NDArray] = {}

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -2,7 +2,6 @@ import functools
 import warnings
 from ctypes import POINTER, Structure, c_double, c_float, c_int, c_void_p, cast, pointer
 from enum import IntEnum
-from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
@@ -10,9 +9,6 @@ import numpy.typing as npt
 from parcels._typing import Mesh, UpdateStatus, assert_valid_mesh
 from parcels.tools.converters import TimeConverter
 from parcels.tools.warnings import FieldSetWarning
-
-if TYPE_CHECKING:
-    from parcels.field import Field
 
 __all__ = [
     "GridType",
@@ -243,7 +239,7 @@ class Grid:
                 )
                 assert self.depth.shape[2] == self.ydim, "Third dim must be y."
 
-    def computeTimeChunk(self, f: "Field", time, signdt):
+    def computeTimeChunk(self, f, time, signdt):
         nextTime_loc = np.inf if signdt >= 0 else -np.inf
         periods = self.periods.value if isinstance(self.periods, c_int) else self.periods
         prev_time_indices = self.time

--- a/parcels/gridset.py
+++ b/parcels/gridset.py
@@ -36,7 +36,7 @@ class GridSet:
 
             if sameGrid:
                 existing_grid = True
-                field.grid = g
+                field._grid = g  # TODO: Is this even necessary?
                 break
 
         if not existing_grid:

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -585,7 +585,7 @@ class Kernel(BaseKernel):
                 if f.data.dtype != np.float32:
                     raise RuntimeError(f"Field {f.name} data needs to be float32 in JIT mode")
                 if f in self.field_args.values():
-                    f.chunk_data()
+                    f._chunk_data()
                 else:
                     for block_id in range(len(f.data_chunks)):
                         f.data_chunks[block_id] = None

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -344,14 +344,14 @@ class Kernel(BaseKernel):
                 warning = False
                 if (
                     isinstance(self._fieldset.W, Field)
-                    and self._fieldset.W.creation_log != "from_nemo"
+                    and self._fieldset.W._creation_log != "from_nemo"
                     and self._fieldset.W._scaling_factor is not None
                     and self._fieldset.W._scaling_factor > 0
                 ):
                     warning = True
                 if isinstance(self._fieldset.W, NestedField):
                     for f in self._fieldset.W:
-                        if f.creation_log != "from_nemo" and f._scaling_factor is not None and f._scaling_factor > 0:
+                        if f._creation_log != "from_nemo" and f._scaling_factor is not None and f._scaling_factor > 0:
                             warning = True
                 if warning:
                     warnings.warn(
@@ -587,9 +587,9 @@ class Kernel(BaseKernel):
                 if f in self.field_args.values():
                     f._chunk_data()
                 else:
-                    for block_id in range(len(f.data_chunks)):
-                        f.data_chunks[block_id] = None
-                        f.c_data_chunks[block_id] = None
+                    for block_id in range(len(f._data_chunks)):
+                        f._data_chunks[block_id] = None
+                        f._c_data_chunks[block_id] = None
 
             for g in pset.fieldset.gridset.grids:
                 g.load_chunk = np.where(g.load_chunk == g.chunk_loading_requested, g.chunk_loaded_touched, g.load_chunk)

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -69,7 +69,7 @@ class ParticleFile:
             if var.to_write:
                 self.vars_to_write[var.name] = var.dtype
         self.mpi_rank = MPI.COMM_WORLD.Get_rank() if MPI else 0
-        self.particleset.fieldset.particlefile = self
+        self.particleset.fieldset._particlefile = self
         self.analytical = False  # Flag to indicate if ParticleFile is used for analytical trajectories
 
         # Reset obs_written of each particle, in case new ParticleFile created for a ParticleSet

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -108,7 +108,7 @@ class ParticleSet:
         self.interaction_kernel = None
 
         self.fieldset = fieldset
-        self.fieldset.check_complete()
+        self.fieldset._check_complete()
         self.time_origin = fieldset.time_origin
 
         # ==== first: create a new subclass of the pclass that includes the required variables ==== #

--- a/parcels/tools/_helpers.py
+++ b/parcels/tools/_helpers.py
@@ -49,5 +49,5 @@ def deprecated_made_private(func: Callable) -> Callable:
     return deprecated(
         "It has moved to the internal API as it is not expected to be directly used by "
         "the end-user. If you feel that you use this code directly in your scripts, please "
-        "comment on our tracking issue at <>.",  # TODO: Add tracking issue
+        "comment on our tracking issue at https://github.com/OceanParcels/Parcels/issues/1695.",
     )(func)

--- a/parcels/tools/_helpers.py
+++ b/parcels/tools/_helpers.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 PACKAGE = "Parcels"
 
 
-def deprecated(msg: str = "", stacklevel: int = 2) -> Callable:
+def deprecated(msg: str = "") -> Callable:
     """Decorator marking a function as being deprecated
 
     Parameters
@@ -37,7 +37,7 @@ def deprecated(msg: str = "", stacklevel: int = 2) -> Callable:
                 f"`{func.__qualname__}` is deprecated and will be removed in a future release of {PACKAGE}.{msg}"
             )
 
-            warnings.warn(msg_formatted, category=DeprecationWarning, stacklevel=stacklevel)
+            warnings.warn(msg_formatted, category=DeprecationWarning, stacklevel=3)
             return func(*args, **kwargs)
 
         return wrapper
@@ -50,5 +50,4 @@ def deprecated_made_private(func: Callable) -> Callable:
         "It has moved to the internal API as it is not expected to be directly used by "
         "the end-user. If you feel that you use this code directly in your scripts, please "
         "comment on our tracking issue at <>.",  # TODO: Add tracking issue
-        stacklevel=3,
     )(func)

--- a/parcels/tools/_helpers.py
+++ b/parcels/tools/_helpers.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 PACKAGE = "Parcels"
 
 
-def deprecated(msg: str = "") -> Callable:
+def deprecated(msg: str = "", stacklevel: int = 2) -> Callable:
     """Decorator marking a function as being deprecated
 
     Parameters
@@ -37,7 +37,7 @@ def deprecated(msg: str = "") -> Callable:
                 f"`{func.__qualname__}` is deprecated and will be removed in a future release of {PACKAGE}.{msg}"
             )
 
-            warnings.warn(msg_formatted, category=DeprecationWarning, stacklevel=2)
+            warnings.warn(msg_formatted, category=DeprecationWarning, stacklevel=stacklevel)
             return func(*args, **kwargs)
 
         return wrapper
@@ -49,5 +49,6 @@ def deprecated_made_private(func: Callable) -> Callable:
     return deprecated(
         "It has moved to the internal API as it is not expected to be directly used by "
         "the end-user. If you feel that you use this code directly in your scripts, please "
-        "comment on our tracking issue at <>."  # TODO: Add tracking issue
+        "comment on our tracking issue at <>.",  # TODO: Add tracking issue
+        stacklevel=3,
     )(func)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ local_scheme = "no-local-version"
 
 [tool.pytest.ini_options]
 python_files = ["test_*.py", "example_*.py", "*tutorial*"]
-filterwarnings = ["error::DeprecationWarning"]
+filterwarnings = [
+  "error:.*removed in a future release of Parcels.*:DeprecationWarning", # Have Parcels DeprecationWarnings fail CI (prevents deprecated items being used in internal code)
+  ]
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ local_scheme = "no-local-version"
 
 [tool.pytest.ini_options]
 python_files = ["test_*.py", "example_*.py", "*tutorial*"]
+filterwarnings = ["error::DeprecationWarning"]
 
 [tool.ruff]
 line-length = 120

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -79,7 +79,7 @@ def test_advection_zonal(lon, lat, depth, mode, npart=10):
     }
     dimensions = {"lon": lon, "lat": lat}
     fieldset2D = FieldSet.from_data(data2D, dimensions, mesh="spherical", transpose=True)
-    assert fieldset2D.U.creation_log == "from_data"
+    assert fieldset2D.U._creation_log == "from_data"
 
     pset2D = ParticleSet(fieldset2D, pclass=ptype[mode], lon=np.zeros(npart) + 20.0, lat=np.linspace(0, 80, npart))
     pset2D.execute(AdvectionRK4, runtime=timedelta(hours=2), dt=timedelta(seconds=30))

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -27,7 +27,7 @@ def test_private_attribute_field(private_attribute):
     with pytest.raises(DeprecationWarning):
         assert hasattr(field, attribute)
         assert hasattr(field, private_attribute)
-        assert getattr(field, attribute) == getattr(field, private_attribute)
+        assert getattr(field, attribute) is getattr(field, private_attribute)
 
 
 @pytest.mark.parametrize("private_attribute", private_fieldset_attrs)
@@ -38,4 +38,4 @@ def test_private_attribute_fieldset(private_attribute):
     with pytest.raises(DeprecationWarning):
         assert hasattr(fieldset, attribute)
         assert hasattr(fieldset, private_attribute)
-        assert getattr(fieldset, attribute) == getattr(fieldset, private_attribute)
+        assert getattr(fieldset, attribute) is getattr(fieldset, private_attribute)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,41 @@
+import pytest
+
+from tests.utils import create_fieldset_unit_mesh
+
+fieldset = create_fieldset_unit_mesh()
+field = fieldset.U
+
+private_field_attrs = [
+    "_dataFiles",
+    "_loaded_time_indices",
+    "_creation_log",
+    "_data_chunks",
+    "_c_data_chunks",
+    "_chunk_set",
+]
+
+private_fieldset_attrs = [
+    "_completed",
+]
+
+
+@pytest.mark.parametrize("private_attribute", private_field_attrs)
+def test_private_attribute_field(private_attribute):
+    assert private_attribute.startswith("_")
+    attribute = private_attribute.lstrip("_")
+
+    with pytest.raises(DeprecationWarning):
+        assert hasattr(field, attribute)
+        assert hasattr(field, private_attribute)
+        assert getattr(field, attribute) == getattr(field, private_attribute)
+
+
+@pytest.mark.parametrize("private_attribute", private_fieldset_attrs)
+def test_private_attribute_fieldset(private_attribute):
+    assert private_attribute.startswith("_")
+    attribute = private_attribute.lstrip("_")
+
+    with pytest.raises(DeprecationWarning):
+        assert hasattr(fieldset, attribute)
+        assert hasattr(fieldset, private_attribute)
+        assert getattr(fieldset, attribute) == getattr(fieldset, private_attribute)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,5 +1,8 @@
+import inspect
+
 import pytest
 
+from parcels import Field, FieldSet
 from tests.utils import create_fieldset_unit_mesh
 
 fieldset = create_fieldset_unit_mesh()
@@ -14,28 +17,96 @@ private_field_attrs = [
     "_chunk_set",
 ]
 
-private_fieldset_attrs = [
-    "_completed",
-]
+
+class FieldPrivate:
+    attributes = [
+        "_dataFiles",
+        "_loaded_time_indices",
+        "_creation_log",
+        "_data_chunks",
+        "_c_data_chunks",
+        "_chunk_set",
+    ]
+    methods = [
+        "_get_dim_filenames",
+        "_collect_timeslices",
+        "_reshape",
+        "_calc_cell_edge_sizes",
+        "_search_indices_vertical_z",
+        "_search_indices_vertical_s",
+        "_reconnect_bnd_indices",
+        "_search_indices_rectilinear",
+        "_search_indices_curvilinear",
+        "_search_indices",
+        "_interpolator2D",
+        "_interpolator3D",
+        "_ccode_eval",
+        "_ccode_convert",
+        "_get_block_id",
+        "_get_block",
+        "_chunk_setup",
+        "_chunk_data",
+        "_rescale_and_set_minmax",
+        "_data_concatenate",
+        "_spatial_interpolation",
+        "_time_index",
+    ]
 
 
-@pytest.mark.parametrize("private_attribute", private_field_attrs)
+class FieldSetPrivate:
+    attributes = [
+        "_completed",
+    ]
+    methods = [
+        "_add_UVfield",
+        "_parse_wildcards",
+        "_check_complete",
+    ]
+
+
+def assert_private_public_attribute_equiv(obj, private_attribute: str):
+    assert private_attribute.startswith("_")
+    attribute = private_attribute.lstrip("_")
+
+    with pytest.raises(DeprecationWarning):
+        assert hasattr(obj, attribute)
+        assert hasattr(obj, private_attribute)
+        assert getattr(obj, attribute) is getattr(obj, private_attribute)
+
+
+def assert_public_method_calls_private(type_, private_method):
+    """Looks at the source code to ensure that `public_method` calls `private_method`.
+
+    Looks for the string `.{method_name}(` in the source code of `public_method`.
+    """
+    assert private_method.startswith("_")
+    public_method_str = private_method.lstrip("_")
+    private_method_str = private_method
+
+    public_method = getattr(type_, public_method_str)
+    private_method = getattr(type_, private_method_str)
+
+    assert callable(public_method)
+    assert callable(private_method)
+
+    assert f".{private_method_str}(" in inspect.getsource(public_method)
+
+
+@pytest.mark.parametrize("private_attribute", FieldPrivate.attributes)
 def test_private_attribute_field(private_attribute):
-    assert private_attribute.startswith("_")
-    attribute = private_attribute.lstrip("_")
-
-    with pytest.raises(DeprecationWarning):
-        assert hasattr(field, attribute)
-        assert hasattr(field, private_attribute)
-        assert getattr(field, attribute) is getattr(field, private_attribute)
+    assert_private_public_attribute_equiv(field, private_attribute)
 
 
-@pytest.mark.parametrize("private_attribute", private_fieldset_attrs)
+@pytest.mark.parametrize("private_attribute", FieldSetPrivate.attributes)
 def test_private_attribute_fieldset(private_attribute):
-    assert private_attribute.startswith("_")
-    attribute = private_attribute.lstrip("_")
+    assert_private_public_attribute_equiv(fieldset, private_attribute)
 
-    with pytest.raises(DeprecationWarning):
-        assert hasattr(fieldset, attribute)
-        assert hasattr(fieldset, private_attribute)
-        assert getattr(fieldset, attribute) is getattr(fieldset, private_attribute)
+
+@pytest.mark.parametrize("private_method", FieldPrivate.methods)
+def test_private_method_field(private_method):
+    assert_public_method_calls_private(Field, private_method)
+
+
+@pytest.mark.parametrize("private_method", FieldSetPrivate.methods)
+def test_private_method_fieldset(private_method):
+    assert_public_method_calls_private(FieldSet, private_method)

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -509,7 +509,7 @@ def test_fieldset_celledgesizes(mesh):
     data, dimensions = generate_fieldset(10, 7)
     fieldset = FieldSet.from_data(data, dimensions, mesh=mesh)
 
-    fieldset.U.calc_cell_edge_sizes()
+    fieldset.U._calc_cell_edge_sizes()
     D_meridional = fieldset.U.cell_edge_sizes["y"]
     D_zonal = fieldset.U.cell_edge_sizes["x"]
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -201,7 +201,7 @@ def test_field_from_netcdf(with_timestamps):
 def test_fieldset_from_modulefile():
     data_path = os.path.join(os.path.dirname(__file__), "test_data/")
     fieldset = FieldSet.from_modulefile(data_path + "fieldset_nemo.py")
-    assert fieldset.U.creation_log == "from_nemo"
+    assert fieldset.U._creation_log == "from_nemo"
 
     indices = {"lon": range(6, 10)}
     fieldset = FieldSet.from_modulefile(data_path + "fieldset_nemo.py", indices=indices)
@@ -382,7 +382,7 @@ def test_add_duplicate_field(dupobject):
 def test_add_field_after_pset(fieldtype):
     data, dimensions = generate_fieldset(100, 100)
     fieldset = FieldSet.from_data(data, dimensions)
-    pset = ParticleSet(fieldset, ScipyParticle, lon=0, lat=0)  # noqa ; to trigger fieldset.check_complete
+    pset = ParticleSet(fieldset, ScipyParticle, lon=0, lat=0)  # noqa ; to trigger fieldset._check_complete
     field1 = Field("field1", fieldset.U.data, lon=fieldset.U.lon, lat=fieldset.U.lat)
     field2 = Field("field2", fieldset.U.data, lon=fieldset.U.lon, lat=fieldset.U.lat)
     vfield = VectorField("vfield", field1, field2)
@@ -428,7 +428,7 @@ def test_fieldset_dimlength1_cgrid(gridtype):
         fieldset.U.interp_method = "cgrid_velocity"
         fieldset.V.interp_method = "cgrid_velocity"
     try:
-        fieldset.check_complete()
+        fieldset._check_complete()
         success = True if gridtype == "A" else False
     except NotImplementedError:
         success = True if gridtype == "C" else False
@@ -544,7 +544,7 @@ def test_fieldset_write_curvilinear(tmpdir):
     variables = {"dx": "e1u"}
     dimensions = {"lon": "glamu", "lat": "gphiu"}
     fieldset = FieldSet.from_nemo(filenames, variables, dimensions)
-    assert fieldset.dx.creation_log == "from_nemo"
+    assert fieldset.dx._creation_log == "from_nemo"
 
     newfile = tmpdir.join("curv_field")
     fieldset.write(newfile)
@@ -554,7 +554,7 @@ def test_fieldset_write_curvilinear(tmpdir):
         variables={"dx": "dx"},
         dimensions={"time": "time_counter", "depth": "depthdx", "lon": "nav_lon", "lat": "nav_lat"},
     )
-    assert fieldset2.dx.creation_log == "from_netcdf"
+    assert fieldset2.dx._creation_log == "from_netcdf"
 
     for var in ["lon", "lat", "data"]:
         assert np.allclose(getattr(fieldset2.dx, var), getattr(fieldset.dx, var))
@@ -951,7 +951,7 @@ def test_fieldset_defer_loading_with_diff_time_origin(tmpdir, fail, filename="te
     fieldset_out.add_field(fieldW)
     fieldset_out.write(filepath)
     fieldset = FieldSet.from_parcels(filepath, extra_fields={"W": "W"})
-    assert fieldset.U.creation_log == "from_parcels"
+    assert fieldset.U._creation_log == "from_parcels"
     pset = ParticleSet.from_list(
         fieldset, pclass=JITParticle, lon=[0.5], lat=[0.5], depth=[0.5], time=[datetime.datetime(2018, 4, 20, 1)]
     )
@@ -986,11 +986,12 @@ def test_fieldset_defer_loading_function(zdim, scale_fac, tmpdir, filename="test
 
     def compute(fieldset):
         # Calculating vertical weighted average
+        f: Field
         for f in [fieldset.U, fieldset.V]:
-            for tind in f.loaded_time_indices:
+            for tind in f._loaded_time_indices:
                 data = da.sum(f.data[tind, :] * DZ, axis=0) / sum(dz)
                 data = da.broadcast_to(data, (1, f.grid.zdim, f.grid.ydim, f.grid.xdim))
-                f.data = f.data_concatenate(f.data, data, tind)
+                f.data = f._data_concatenate(f.data, data, tind)
 
     fieldset.compute_on_defer = compute
     fieldset.computeTimeChunk(1, 1)
@@ -1075,7 +1076,7 @@ def test_fieldset_from_xarray(tdim):
     else:
         dimensions = {"lat": "lat", "lon": "lon", "depth": "depth"}
     fieldset = FieldSet.from_xarray_dataset(ds, variables, dimensions, mesh="flat")
-    assert fieldset.U.creation_log == "from_xarray_dataset"
+    assert fieldset.U._creation_log == "from_xarray_dataset"
 
     pset = ParticleSet(fieldset, JITParticle, 0, 0, depth=20)
 

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -288,7 +288,7 @@ def test_inversedistance_nearland(mode, withDepth, arrtype, k_sample_p, npart=81
     success = False
     try:
         fieldset.U.interp_method = "linear_invdist_land_tracer"
-        fieldset.check_complete()
+        fieldset._check_complete()
     except NotImplementedError:
         success = True
     assert success
@@ -794,7 +794,7 @@ def test_multiple_grid_addlater_error():
     )
     fieldset = FieldSet(U, V)
 
-    pset = ParticleSet(fieldset, pclass=pclass("jit"), lon=[0.8], lat=[0.9])  # noqa ; to trigger fieldset.check_complete
+    pset = ParticleSet(fieldset, pclass=pclass("jit"), lon=[0.8], lat=[0.9])  # noqa ; to trigger fieldset._check_complete
 
     P = Field(
         "P",

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,31 @@
+import pytest
+
+from parcels._typing import (
+    assert_valid_gridindexingtype,
+    assert_valid_interp_method,
+    assert_valid_mesh,
+)
+
+validators = (
+    assert_valid_interp_method,
+    assert_valid_mesh,
+    assert_valid_gridindexingtype,
+)
+
+
+@pytest.mark.parametrize("validator", validators)
+def test_invalid_option(validator):
+    with pytest.raises(ValueError):
+        validator("invalid option")
+
+
+validation_mapping = [
+    (assert_valid_interp_method, "nearest"),
+    (assert_valid_mesh, "spherical"),
+    (assert_valid_gridindexingtype, "pop"),
+]
+
+
+@pytest.mark.parametrize("validator, value", validation_mapping)
+def test_valid_option(validator, value):
+    validator(value)


### PR DESCRIPTION
Contributes to #1695 

This PR makes many of the names in `Field` and `FieldSet`:
- private - in the case where users are not expected to use them (attributes and methods), and
- read only where edits to said variables would provide unexpected behaviour/side effects (attributes)
 
All privatisations are done in a non-breaking way, raising a deprecation warning. I have also updated `conftest.py` such that any deprecation warnings raised by Parcels result in a failure (meaning we don't accidentally call deprecated methods internally)

There is some testing of these API changes (checking that calls to old attributes names return the privatised attribute, checking of the source code so that old calls now direct to the private versions). Methods aren't actually called as that would require designing test cases for each item.

The method/attributes affected are:

| class    | name               | action |
| -------- | ---------------------------- | ------------------ |
| Field    | data                         | read_only          |
| Field    | grid                         | read_only          |
| Field    | lon                          | read_only          |
| Field    | lat                          | read_only          |
| Field    | depth                        | read_only          |
| Field    | gridindexingtype             | read_only          |
| Field    | cast_data_dtype              | read_only          |
| Field    | dimensions                   | read_only          |
| Field    | dataFiles                    | make_private       |
| Field    | netcdf_engine                | read_only          |
| Field    | loaded_time_indices          | make_private       |
| Field    | creation_log                 | make_private       |
| Field    | data_chunks                  | make_private       |
| Field    | c_data_chunks                | make_private       |
| Field    | chunk_set                    | make_private       |
| Field    | cell_edge_sizes              | read_only          |
| Field    | get_dim_filenames()          | make_private       |
| Field    | collect_timeslices()         | make_private       |
| Field    | reshape()                    | make_private       |
| Field    | calc_cell_edge_sizes()       | make_private       |
| Field    | search_indices_vertical_z()  | make_private       |
| Field    | search_indices_vertical_s()  | make_private       |
| Field    | reconnect_bnd_indices()      | make_private       |
| Field    | search_indices_rectilinear() | make_private       |
| Field    | search_indices_curvilinear() | make_private       |
| Field    | search_indices()             | make_private       |
| Field    | interpolator2D()             | make_private       |
| Field    | interpolator3D()             | make_private       |
| Field    | spatial_interpolation()      | make_private       |
| Field    | time_index()                 | make_private       |
| Field    | ccode_eval()                 | make_private       |
| Field    | ccode_convert()              | make_private       |
| Field    | get_block_id()               | make_private       |
| Field    | get_block()                  | make_private       |
| Field    | chunk_setup()                | make_private       |
| Field    | chunk_data()                 | make_private       |
| Field    | rescale_and_set_minmax()     | make_private       |
| Field    | data_concatenate()           | make_private       |
| FieldSet | completed                    | make_private       |
| FieldSet | particlefile                 | read_only          |
| FieldSet | add_UVfield()                | make_private       |
| FieldSet | check_complete()             | make_private       |
| FieldSet | parse_wildcards()            | make_private       |

Other changes:
- simple error checking for user provided inputs
