### PR TITLE
API changes: `particlefile.py` and other touchups

### DIFF
--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -279,19 +279,6 @@ class Grid:
             )
         return self._cstruct
 
-    def lon_grid_to_target(self):
-        if self.lon_remapping:
-            self._lon = self.lon_remapping.to_target(self.lon)
-
-    def lon_grid_to_source(self):
-        if self.lon_remapping:
-            self._lon = self.lon_remapping.to_source(self.lon)
-
-    def lon_particle_to_target(self, lon):
-        if self.lon_remapping:
-            return self.lon_remapping.particle_to_target(lon)
-        return lon
-
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
     def check_zonal_periodic(self, *args, **kwargs):
         return self._check_zonal_periodic(*args, **kwargs)

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -367,7 +367,7 @@ class Kernel(BaseKernel):
                     )
             elif pyfunc is AdvectionAnalytical:
                 if self.fieldset.particlefile is not None:
-                    self.fieldset.particlefile._analytical = True
+                    self.fieldset.particlefile._is_analytical = True
                 if self._ptype.uses_jit:
                     raise NotImplementedError("Analytical Advection only works in Scipy mode")
                 if self._fieldset.U.interp_method != "cgrid_velocity":

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -367,7 +367,7 @@ class Kernel(BaseKernel):
                     )
             elif pyfunc is AdvectionAnalytical:
                 if self.fieldset.particlefile is not None:
-                    self.fieldset.particlefile.analytical = True
+                    self.fieldset.particlefile._analytical = True
                 if self._ptype.uses_jit:
                     raise NotImplementedError("Analytical Advection only works in Scipy mode")
                 if self._fieldset.U.interp_method != "cgrid_velocity":

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -29,10 +29,18 @@ class Variable:
     """
 
     def __init__(self, name, dtype=np.float32, initial=0, to_write: bool | Literal["once"] = True):
-        self.name = name
+        self._name = name
         self.dtype = dtype
         self.initial = initial
-        self.to_write = to_write
+        self._to_write = to_write
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def to_write(self):
+        return self._to_write
 
     def __get__(self, instance, cls):
         if instance is None:

--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -32,15 +32,11 @@ class Variable:
         self._name = name
         self.dtype = dtype
         self.initial = initial
-        self._to_write = to_write
+        self.to_write = to_write
 
     @property
     def name(self):
         return self._name
-
-    @property
-    def to_write(self):
-        return self._to_write
 
     def __get__(self, instance, cls):
         if instance is None:

--- a/parcels/particledata.py
+++ b/parcels/particledata.py
@@ -5,6 +5,7 @@ from operator import attrgetter
 import numpy as np
 
 from parcels._compat import MPI, KMeans
+from parcels.tools._helpers import deprecated
 from parcels.tools.statuscodes import StatusCode
 
 
@@ -228,12 +229,15 @@ class ParticleData:
         """Return the length, in terms of 'number of elements, of a ParticleData instance."""
         return self._ncount
 
+    @deprecated(
+        "Use iter(...) instead, or just use the object in an iterator context (e.g. for p in particledata: ...)."
+    )  # TODO: Remove 6 months after v3.1.0 (or 9 months; doesn't contribute to code debt)
     def iterator(self):
-        return ParticleDataIterator(self)
+        return iter(self)
 
     def __iter__(self):
         """Return an Iterator that allows for forward iteration over the elements in the ParticleData (e.g. `for p in pset:`)."""
-        return self.iterator()
+        return ParticleDataIterator(self)
 
     def __getitem__(self, index):
         """Get a particle object from the ParticleData instance based on its index."""

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -54,12 +54,11 @@ class ParticleFile:
         self.parcels_mesh = "spherical"
         if self.particleset.fieldset is not None:
             self.parcels_mesh = self.particleset.fieldset.gridset.grids[0].mesh
-        self.time_origin = self.particleset.time_origin
         self.lonlatdepth_dtype = self.particleset.particledata.lonlatdepth_dtype
         self.maxids = 0
         self.pids_written = {}
         self._create_new_zarrfile = create_new_zarrfile
-        self.vars_to_write = {}
+        self._vars_to_write = {}
         for var in self.particleset.particledata.ptype.variables:
             if var.to_write:
                 self.vars_to_write[var.name] = var.dtype
@@ -136,6 +135,14 @@ class ParticleFile:
     @property
     def fname(self):
         return self._fname
+
+    @property
+    def vars_to_write(self):
+        return self._vars_to_write
+
+    @property
+    def time_origin(self):
+        return self.particleset.time_origin
 
     def _create_variables_attribute_dict(self):
         """Creates the dictionary with variable attributes.

--- a/parcels/particlefile.py
+++ b/parcels/particlefile.py
@@ -64,7 +64,7 @@ class ParticleFile:
                 self.vars_to_write[var.name] = var.dtype
         self._mpi_rank = MPI.COMM_WORLD.Get_rank() if MPI else 0
         self.particleset.fieldset._particlefile = self
-        self._analytical = False  # Flag to indicate if ParticleFile is used for analytical trajectories
+        self._is_analytical = False  # Flag to indicate if ParticleFile is used for analytical trajectories
 
         # Reset obs_written of each particle, in case new ParticleFile created for a ParticleSet
         particleset.particledata.setallvardata("obs_written", 0)
@@ -172,7 +172,7 @@ class ParticleFile:
     @property
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
     def analytical(self):
-        return self._analytical
+        return self._is_analytical
 
     def _create_variables_attribute_dict(self):
         """Creates the dictionary with variable attributes.

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -26,7 +26,7 @@ from parcels.kernel import Kernel
 from parcels.particle import JITParticle, Variable
 from parcels.particledata import ParticleData, ParticleDataIterator
 from parcels.particlefile import ParticleFile
-from parcels.tools._helpers import deprecated_made_private
+from parcels.tools._helpers import deprecated, deprecated_made_private
 from parcels.tools.converters import _get_cftime_calendars, convert_to_flat_array
 from parcels.tools.global_statics import get_package_dir
 from parcels.tools.loggers import logger
@@ -330,12 +330,14 @@ class ParticleSet:
             del self.particledata
         self.particledata = None
 
+    @deprecated(
+        "Use iter(pset) instead, or just use the object in an iterator context (e.g. for p in pset: ...)."
+    )  # TODO: Remove 6 months after v3.1.0 (or 9 months; doesn't contribute to code debt)
     def iterator(self):
-        return self.particledata.iterator()
+        return iter(self)
 
     def __iter__(self):
-        """Allows for more intuitive iteration over a particleset, while in reality iterating over the particles in the ParticleData instance."""
-        return self.iterator()
+        return iter(self.particledata)
 
     def __getattr__(self, name):
         """

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -1188,7 +1188,7 @@ class ParticleSet:
 
             if abs(time - next_output) < tol:
                 if output_file:
-                    if output_file.analytical:  # output analytical solution at later time
+                    if output_file._analytical:  # output analytical solution at later time
                         output_file.write_latest_locations(self, time)
                     else:
                         output_file.write(self, time_at_startofloop)

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -1188,7 +1188,7 @@ class ParticleSet:
 
             if abs(time - next_output) < tol:
                 if output_file:
-                    if output_file._analytical:  # output analytical solution at later time
+                    if output_file._is_analytical:  # output analytical solution at later time
                         output_file.write_latest_locations(self, time)
                     else:
                         output_file.write(self, time_at_startofloop)

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -1046,7 +1046,7 @@ class ParticleSet:
                 )
                 self._kernel.load_lib()
         if output_file:
-            output_file.add_metadata("parcels_kernels", self._kernel.name)
+            output_file.metadata["parcels_kernels"] = self._kernel.name
 
         # Set up the interaction kernel(s) if not set and given.
         if self._interaction_kernel is None and pyfunc_inter is not None:

--- a/parcels/tools/_helpers.py
+++ b/parcels/tools/_helpers.py
@@ -40,6 +40,7 @@ def deprecated(msg: str = "") -> Callable:
             warnings.warn(msg_formatted, category=DeprecationWarning, stacklevel=3)
             return func(*args, **kwargs)
 
+        patch_docstring(wrapper, f"\n\n.. deprecated:: {msg}")
         return wrapper
 
     return decorator
@@ -51,3 +52,7 @@ def deprecated_made_private(func: Callable) -> Callable:
         "the end-user. If you feel that you use this code directly in your scripts, please "
         "comment on our tracking issue at https://github.com/OceanParcels/Parcels/issues/1695.",
     )(func)
+
+
+def patch_docstring(obj: Callable, extra: str) -> None:
+    obj.__doc__ = f"{obj.__doc__ or ''}{extra}".strip()

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -168,6 +168,7 @@ actions = [
     Action("Grid",             "lat_flipped",                    "make_private"  ),
     Action("Grid",             "defer_load",                     "read_only"     ),
     Action("Grid",             "lonlat_minmax",                  "read_only"     ),
+    Action("RectilinearGrid",  "lonlat_minmax",                  "read_only"     ),
     Action("Grid",             "load_chunk",                     "make_private"  ),
     Action("Grid",             "cgrid",                          "make_private"  ),
     Action("Grid",             "child_ctypes_struct",            "make_private"  ),
@@ -222,6 +223,10 @@ actions = [
     Action("CurvilinearSGrid", "z4d",                            "make_private"  ),
     Action("CurvilinearSGrid", "xdim",                           "read_only"     ),
     Action("CurvilinearSGrid", "ydim",                           "read_only"     ),
+
+    # 1727
+    Action("ParticleSet",      "iterator()",                     "remove"        ),
+    Action("ParticleData",     "iterator()",                     "remove"        ),
 ]
 # fmt: on
 assert len({str(a) for a in actions}) == len(actions)  # Check that all actions are unique

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -244,6 +244,12 @@ actions = [
     Action("ParticleData",     "iterator()",                     "remove"        ),
     Action("ParticleFile",     "add_metadata()",                 "remove"        ),
     Action("ParticleFile",     "write_once()",                   "make_private"  ),
+    Action("ParticleFile",     "create_new_zarrfile",            "read_only"     ),
+    Action("ParticleFile",     "outputdt",                       "read_only"     ),
+    Action("ParticleFile",     "chunks",                         "read_only"     ),
+    Action("ParticleFile",     "particleset",                    "read_only"     ),
+    Action("ParticleFile",     "fname",                          "read_only"     ),
+
 
 
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -249,9 +249,8 @@ actions = [
     Action("ParticleFile",     "chunks",                         "read_only"     ),
     Action("ParticleFile",     "particleset",                    "read_only"     ),
     Action("ParticleFile",     "fname",                          "read_only"     ),
-
-
-
+    Action("ParticleFile",     "vars_to_write",                  "read_only"     ),
+    Action("ParticleFile",     "time_origin",                    "read_only"     ),
 
 
 ]

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -4,7 +4,7 @@ from typing import Literal
 import numpy as np
 import pytest
 
-from parcels import Field, FieldSet, JITParticle, ParticleSet
+from parcels import Field, FieldSet, JITParticle, ParticleFile, ParticleSet
 from parcels.grid import (
     CurvilinearGrid,
     CurvilinearSGrid,
@@ -16,13 +16,28 @@ from parcels.grid import (
 )
 from tests.utils import create_fieldset_unit_mesh
 
+Classes = Literal[
+    "Field",
+    "FieldSet",
+    "ParticleSet",
+    "Grid",
+    "RectilinearGrid",
+    "RectilinearZGrid",
+    "RectilinearSGrid",
+    "CurvilinearGrid",
+    "CurvilinearZGrid",
+    "CurvilinearSGrid",
+    "ParticleData",
+    "ParticleFile",
+]
+
 
 class Action:
     """Utility class to help manage, document, and test deprecations."""
 
     def __init__(
         self,
-        class_: Literal["Field", "FieldSet"],
+        class_: Classes,
         name: str,
         type_: Literal["read_only", "make_private", "remove"],
         *,
@@ -227,6 +242,12 @@ actions = [
     # 1727
     Action("ParticleSet",      "iterator()",                     "remove"        ),
     Action("ParticleData",     "iterator()",                     "remove"        ),
+    Action("ParticleFile",     "add_metadata()",                 "remove"        ),
+    Action("ParticleFile",     "write_once()",                   "make_private"  ),
+
+
+
+
 ]
 # fmt: on
 assert len({str(a) for a in actions}) == len(actions)  # Check that all actions are unique
@@ -251,6 +272,8 @@ def create_test_data():
     lat_g0 = np.linspace(0, 1000, 11, dtype=np.float32)
     time_g0 = np.linspace(0, 1000, 2, dtype=np.float64)
     grid = RectilinearZGrid(lon_g0, lat_g0, time=time_g0)
+
+    pfile = ParticleFile("test.zarr", pset, outputdt=1)
 
     return {
         "Field": {
@@ -292,6 +315,10 @@ def create_test_data():
         "CurvilinearSGrid": {
             "class": CurvilinearSGrid,
             "object": grid,  # not exactly right but good enough
+        },
+        "ParticleFile": {
+            "class": ParticleFile,
+            "object": pfile,
         },
     }
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -4,7 +4,7 @@ from typing import Literal
 import numpy as np
 import pytest
 
-from parcels import Field, FieldSet, JITParticle, ParticleFile, ParticleSet
+from parcels import Field, FieldSet, JITParticle, ParticleFile, ParticleSet, Variable
 from parcels.grid import (
     CurvilinearGrid,
     CurvilinearSGrid,
@@ -261,6 +261,8 @@ actions = [
     Action("Grid",             "lon_remapping",                  "remove"        ),
     Action("Grid",             "lon_grid_to_source()",           "remove"        ),
     Action("Grid",             "lon_particle_to_target()",       "remove"        ),
+    Action("Variable",         "name",                           "read_only"     ),
+    Action("Variable",         "to_write",                       "read_only"     ),
     ]
 # fmt: on
 assert len({str(a) for a in actions}) == len(actions)  # Check that all actions are unique
@@ -332,6 +334,10 @@ def create_test_data():
         "ParticleFile": {
             "class": ParticleFile,
             "object": pfile,
+        },
+        "Variable": {
+            "class": Variable,
+            "object": Variable("test"),
         },
     }
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -256,7 +256,7 @@ actions = [
     Action("ParticleFile",     "pids_written",                   "make_private"  ),
     Action("ParticleFile",     "mpi_rank",                       "make_private"  ),
     Action("ParticleFile",     "fill_value_map",                 "make_private"  ),
-    Action("ParticleFile",     "analytical",                     "make_private"  ),
+    Action("ParticleFile",     "analytical",                     "make_private"  , skip_reason = "Was also renamed"),
     Action("Grid",             "lon_grid_to_target()",           "remove"        ),
     Action("Grid",             "lon_remapping",                  "remove"        ),
     Action("Grid",             "lon_grid_to_source()",           "remove"        ),

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -251,8 +251,12 @@ actions = [
     Action("ParticleFile",     "fname",                          "read_only"     ),
     Action("ParticleFile",     "vars_to_write",                  "read_only"     ),
     Action("ParticleFile",     "time_origin",                    "read_only"     ),
-
-
+    Action("ParticleFile",     "parcels_mesh",                   "make_private"  ),
+    Action("ParticleFile",     "maxids",                         "make_private"  ),
+    Action("ParticleFile",     "pids_written",                   "make_private"  ),
+    Action("ParticleFile",     "mpi_rank",                       "make_private"  ),
+    Action("ParticleFile",     "fill_value_map",                 "make_private"  ),
+    Action("ParticleFile",     "analytical",                     "make_private"  ),
 ]
 # fmt: on
 assert len({str(a) for a in actions}) == len(actions)  # Check that all actions are unique

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -257,7 +257,11 @@ actions = [
     Action("ParticleFile",     "mpi_rank",                       "make_private"  ),
     Action("ParticleFile",     "fill_value_map",                 "make_private"  ),
     Action("ParticleFile",     "analytical",                     "make_private"  ),
-]
+    Action("Grid",             "lon_grid_to_target()",           "remove"        ),
+    Action("Grid",             "lon_remapping",                  "remove"        ),
+    Action("Grid",             "lon_grid_to_source()",           "remove"        ),
+    Action("Grid",             "lon_particle_to_target()",       "remove"        ),
+    ]
 # fmt: on
 assert len({str(a) for a in actions}) == len(actions)  # Check that all actions are unique
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -262,7 +262,6 @@ actions = [
     Action("Grid",             "lon_grid_to_source()",           "remove"        ),
     Action("Grid",             "lon_particle_to_target()",       "remove"        ),
     Action("Variable",         "name",                           "read_only"     ),
-    Action("Variable",         "to_write",                       "read_only"     ),
     ]
 # fmt: on
 assert len({str(a) for a in actions}) == len(actions)  # Check that all actions are unique

--- a/tests/tools/test_helpers.py
+++ b/tests/tools/test_helpers.py
@@ -51,3 +51,5 @@ def test_deprecated_made_private():
 
     with pytest.warns(DeprecationWarning):
         some_function(1, 2)
+
+    assert "deprecated::" in some_function.__doc__


### PR DESCRIPTION
Contributes to #1695

## Changes

- API changes

---

This PR makes many of the names in `particlefile.py` (and some other files):

- private - in the case where users are not expected to use them (attributes and methods),
- read only where edits to said variables would provide unexpected behaviour/side effects (attributes), or
- removed (where they are either legacy code, or there are better mechanisms to achieve the same result)

All privatisations/removals are done in a non-breaking way, raising a deprecation warning.

The method/attributes affected are:

| Class         | Method/Attribute                 | Action         |
|---------------|----------------------------------|----------------|
| ParticleSet   | iterator()                       | remove         |
| ParticleData  | iterator()                       | remove         |
| ParticleFile  | add_metadata()                   | remove         |
| ParticleFile  | write_once()                     | make_private   |
| ParticleFile  | create_new_zarrfile              | read_only      |
| ParticleFile  | outputdt                         | read_only      |
| ParticleFile  | chunks                           | read_only      |
| ParticleFile  | particleset                      | read_only      |
| ParticleFile  | fname                            | read_only      |
| ParticleFile  | vars_to_write                    | read_only      |
| ParticleFile  | time_origin                      | read_only      |
| ParticleFile  | parcels_mesh                     | make_private   |
| ParticleFile  | maxids                           | make_private   |
| ParticleFile  | pids_written                     | make_private   |
| ParticleFile  | mpi_rank                         | make_private   |
| ParticleFile  | fill_value_map                   | make_private   |
| ParticleFile  | analytical                       | make_private (+rename)   |
| Grid          | lon_grid_to_target()             | remove         |
| Grid          | lon_remapping                    | remove         |
| Grid          | lon_grid_to_source()             | remove         |
| Grid          | lon_particle_to_target()         | remove         |
| Variable      | name                             | read_only      |