### PR TITLE
Adding warning particlestartime outputdt multiple

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -1077,6 +1077,13 @@ class ParticleSet:
         outputdt = output_file.outputdt if output_file else np.inf
         if isinstance(outputdt, timedelta):
             outputdt = outputdt.total_seconds()
+        if outputdt and np.any([t / outputdt % 1 != 0 for t in self.particledata.data["time_nextloop"]]):
+            warnings.warn(
+                "Some of the particles have a start time that is not a multiple of outputdt. "
+                "This could cause the first output to be at a different time than expected.",
+                FileWarning,
+                stacklevel=2,
+            )
         if isinstance(callbackdt, timedelta):
             callbackdt = callbackdt.total_seconds()
 

--- a/tests/tools/test_warnings.py
+++ b/tests/tools/test_warnings.py
@@ -4,10 +4,12 @@ import numpy as np
 import pytest
 
 from parcels import (
+    AdvectionRK4,
     AdvectionRK4_3D,
     AdvectionRK45,
     FieldSet,
     FieldSetWarning,
+    FileWarning,
     KernelWarning,
     ParticleSet,
     ScipyParticle,
@@ -52,6 +54,17 @@ def test_fieldset_warnings():
     with pytest.warns(FieldSetWarning):
         # timestamps with time in file warning
         fieldset = FieldSet.from_pop(filenames, variables, dimensions, mesh="flat", timestamps=[0, 1, 2, 3])
+
+
+def test_file_warnings(tmpdir):
+    outfilepath = tmpdir.join("test_file_warnings.zarr")
+    fieldset = FieldSet.from_data(
+        data={"U": np.zeros((1, 1)), "V": np.zeros((1, 1))}, dimensions={"lon": [0], "lat": [0]}
+    )
+    pset = ParticleSet(fieldset=fieldset, pclass=ScipyParticle, lon=[0, 0], lat=[0, 0], time=[0, 1])
+    pfile = pset.ParticleFile(name=outfilepath, outputdt=2)
+    with pytest.warns(FileWarning):
+        pset.execute(AdvectionRK4, runtime=3, dt=1, output_file=pfile)
 
 
 def test_kernel_warnings():


### PR DESCRIPTION
As found by @sruehs, creating a ParticleSet where not all starttimes of particles are a multiple of `outputdt` resulted in the zarr file to not write out the start location. 

While in some cases this would be fine for users, this PR now throws a warning