### PR TITLE
Documenting use of interp_method freeslip for B-grids

### DIFF
--- a/docs/examples/documentation_unstuck_Agrid.ipynb
+++ b/docs/examples/documentation_unstuck_Agrid.ipynb
@@ -1314,6 +1314,11 @@
     "\n",
     "The reason trajectories do not neatly follow the coast in A grid velocity fields is that the lack of staggering causes both velocity components to go to zero in the same way towards the cell edge. This no-slip condition can be turned into a free-slip or partial-slip condition by separately considering the cross-shore and along-shore velocity components as in [a staggered C-grid](https://docs.oceanparcels.org/en/latest/examples/documentation_stuck_particles.html#2.-C-grids). Each interpolation of the velocity field must then be corrected with a factor depending on the direction of the boundary.\n",
     "\n",
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "__Note__ that while the code below has been developed for A-grids, we have experience that it can also work well with B-grids. So if you encounter stuck particles in a B-grid model then it might be worth to use the `interp_method=partialslip` or `interp_method=freeslip` solutions described below.\n",
+    "</div>\n",
+    "\n",
     "These boundary conditions have been implemented in Parcels as `interp_method=partialslip` and `interp_method=freeslip`, which we will show in the plot below\n"
    ]
   },


### PR DESCRIPTION
This PR adds a note to the unstuck particles documentation notebook that the `interp_method=partialslip` or `interp_method=freeslip` solutions might also work on B-grid data; as discussed with @sruehs, @ezekiel-lemur and @michaeldenes 