### PR TITLE
Update doc dep versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - numpy>=1.9.1
   - platformdirs
   - psutil
-  - py>=1.4.27
   - pymbolic
   - scipy>=0.16.0
   - tqdm
@@ -45,8 +44,8 @@ dependencies:
   - ipython
   - numpydoc
   - nbsphinx
-  - sphinx<6
-  - pandoc>1.12.1,<3
+  - sphinx
+  - pandoc
   - pydata-sphinx-theme
   - sphinx-autobuild
   - myst-parser


### PR DESCRIPTION
Remove redundant upper bounds, and py dep which isn't used.

Fixes #1755