### PR TITLE
Benchmarking with asv

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,76 @@
+# This workflow was adapted from xarray. See licenses/XARRAY_LICENSE for license details.
+name: Benchmark
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+env:
+  PR_HEAD_LABEL: ${{ github.event.pull_request.head.label }}
+
+jobs:
+  benchmark:
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'run-benchmark') && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    name: Linux
+    runs-on: ubuntu-20.04
+    env:
+      ASV_DIR: "./asv_bench"
+      CONDA_ENV_FILE: environment.yml
+
+    steps:
+      # We need the full repo to avoid this issue
+      # https://github.com/actions/checkout/issues/23
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up conda environment
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: ${{env.CONDA_ENV_FILE}}
+          environment-name: xarray-tests
+          cache-environment: true
+          cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}-benchmark"
+          # add "build" because of https://github.com/airspeed-velocity/asv/issues/1385
+          create-args: >-
+            python-build
+            mamba
+
+      - name: Run benchmarks
+        shell: bash -l {0}
+        id: benchmark
+        env:
+          OPENBLAS_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          OMP_NUM_THREADS: 1
+          ASV_FACTOR: 1.5
+          ASV_SKIP_SLOW: 1
+        run: |
+          set -x
+          # ID this runner
+          asv machine --yes
+          echo "Baseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
+          echo "Contender: ${GITHUB_SHA} ($PR_HEAD_LABEL)"
+          # Run benchmarks for current commit against base
+          ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR"
+          asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
+              | sed "/Traceback \|failed$\|PERFORMANCE DECREASED/ s/^/::error::/" \
+              | tee benchmarks.log
+          # Report and export results for subsequent steps
+          if grep "Traceback \|failed\|PERFORMANCE DECREASED" benchmarks.log > /dev/null ; then
+              exit 1
+          fi
+        working-directory: ${{ env.ASV_DIR }}
+
+      - name: Add instructions to artifact
+        if: always()
+        run: |
+          cp benchmarks/README_CI.md benchmarks.log .asv/results/
+        working-directory: ${{ env.ASV_DIR }}
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: asv-benchmark-results-${{ runner.os }}
+          path: ${{ env.ASV_DIR }}/.asv/results

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,14 +28,16 @@ jobs:
       - name: Set up conda environment
         uses: mamba-org/setup-micromamba@v2
         with:
+          micromamba-version: "1.5.10-0"
           environment-file: ${{env.CONDA_ENV_FILE}}
-          environment-name: xarray-tests
+          environment-name: parcels-dev
           cache-environment: true
           cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}-benchmark"
           # add "build" because of https://github.com/airspeed-velocity/asv/issues/1385
           create-args: >-
             python-build
-            mamba
+            asv
+            mamba<=1.5.10
 
       - name: Run benchmarks
         shell: bash -l {0}

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ dist/parcels*.egg
 parcels/examples/particle*.png
 parcels/_version_setup.py
 /.pytest_cache/
+.asv

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ lib/
 bin/
 parcels_examples
 
+# asv environments
+asv_bench/.asv
+asv_bench/pkgs
+
 *.so
 *.log
 *.nc
@@ -31,4 +35,3 @@ dist/parcels*.egg
 parcels/examples/particle*.png
 parcels/_version_setup.py
 /.pytest_cache/
-.asv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: check-json
         types: [text]
         files: \.(json|ipynb)$
+        exclude: ^asv_bench/asv\.conf\.json$
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.2
     hooks:

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -1,0 +1,206 @@
+{
+  // The version of the config file format.  Do not change, unless
+  // you know what you are doing.
+  "version": 1,
+
+  // The name of the project being benchmarked
+  "project": "parcels",
+
+  // The project's homepage
+  "project_url": "http://docs.oceanparcels.org/",
+
+  // The URL or local path of the source code repository for the
+  // project being benchmarked
+  "repo": "..",
+
+  // The Python project's subdirectory in your repo.  If missing or
+  // the empty string, the project is assumed to be located at the root
+  // of the repository.
+  // "repo_subdir": "",
+
+  // Customizable commands for building, installing, and
+  // uninstalling the project. See asv.conf.json documentation.
+  //
+  // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+  // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+  // fix for bad builds
+  // https://github.com/airspeed-velocity/asv/issues/1389#issuecomment-2076131185
+  "build_command": [
+    "python -m build",
+    "python -mpip wheel --no-deps --no-build-isolation --no-index -w {build_cache_dir} {build_dir}"
+  ],
+  // List of branches to benchmark. If not provided, defaults to "master"
+  // (for git) or "default" (for mercurial).
+  // "branches": ["master"], // for git
+  // "branches": ["default"],    // for mercurial
+
+  // The DVCS being used.  If not set, it will be automatically
+  // determined from "repo" by looking at the protocol in the URL
+  // (if remote), or by looking for special directories, such as
+  // ".git" (if local).
+  "dvcs": "git",
+
+  // The tool to use to create environments.  May be "conda",
+  // "virtualenv" or other value depending on the plugins in use.
+  // If missing or the empty string, the tool will be automatically
+  // determined by looking for tools on the PATH environment
+  // variable.
+  "environment_type": "mamba",
+  "conda_channels": ["conda-forge"],
+
+  // timeout in seconds for installing any dependencies in environment
+  // defaults to 10 min
+  "install_timeout": 600,
+
+  // the base URL to show a commit for the project.
+  "show_commit_url": "https://github.com/oceanparcels/parcels/commit/",
+
+  // The Pythons you'd like to test against.  If not provided, defaults
+  // to the current version of Python used to run `asv`.
+  "pythons": ["3.11"],
+
+  // The list of conda channel names to be searched for benchmark
+  // dependency packages in the specified order
+  // "conda_channels": ["conda-forge", "defaults"],
+
+  // A conda environment file that is used for environment creation.
+  // "conda_environment_file": "environment.yml",
+
+  // The matrix of dependencies to test.  Each key of the "req"
+  // requirements dictionary is the name of a package (in PyPI) and
+  // the values are version numbers.  An empty list or empty string
+  // indicates to just test against the default (latest)
+  // version. null indicates that the package is to not be
+  // installed. If the package to be tested is only available from
+  // PyPi, and the 'environment_type' is conda, then you can preface
+  // the package name by 'pip+', and the package will be installed
+  // via pip (with all the conda available packages installed first,
+  // followed by the pip installed packages).
+  //
+  // The ``@env`` and ``@env_nobuild`` keys contain the matrix of
+  // environment variables to pass to build and benchmark commands.
+  // An environment will be created for every combination of the
+  // cartesian product of the "@env" variables in this matrix.
+  // Variables in "@env_nobuild" will be passed to every environment
+  // during the benchmark phase, but will not trigger creation of
+  // new environments.  A value of ``null`` means that the variable
+  // will not be set for the current combination.
+  //
+  // "matrix": {
+  //     "req": {
+  //         "numpy": ["1.6", "1.7"],
+  //         "six": ["", null],  // test with and without six installed
+  //         "pip+emcee": [""]   // emcee is only available for install with pip.
+  //     },
+  //     "env": {"ENV_VAR_1": ["val1", "val2"]},
+  //     "env_nobuild": {"ENV_VAR_2": ["val3", null]},
+  // },
+
+  // using dependencies listed in parcels feedstock
+  "matrix": {
+    "setuptools_scm": [""],
+    "cftime": [""],
+    "cgen": [""],
+    "dask": [""],
+    "matplotlib-base": [""],
+    "netcdf4": [""],
+    "numpy": [""],
+    "platformdirs": [""],
+    "psutil": [""],
+    "pymbolic": [""],
+    "pytest": [""],
+    "scipy": [""],
+    "trajan": [""],
+    "tqdm": [""],
+    "xarray": [""],
+    "zarr": [""]
+  },
+
+  // Combinations of libraries/python versions can be excluded/included
+  // from the set to test. Each entry is a dictionary containing additional
+  // key-value pairs to include/exclude.
+  //
+  // An exclude entry excludes entries where all values match. The
+  // values are regexps that should match the whole string.
+  //
+  // An include entry adds an environment. Only the packages listed
+  // are installed. The 'python' key is required. The exclude rules
+  // do not apply to includes.
+  //
+  // In addition to package names, the following keys are available:
+  //
+  // - python
+  //     Python version, as in the *pythons* variable above.
+  // - environment_type
+  //     Environment type, as above.
+  // - sys_platform
+  //     Platform, as in sys.platform. Possible values for the common
+  //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+  // - req
+  //     Required packages
+  // - env
+  //     Environment variables
+  // - env_nobuild
+  //     Non-build environment variables
+  //
+  // "exclude": [
+  //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+  //     {"environment_type": "conda", "req": {"six": null}}, // don't run without six on conda
+  //     {"env": {"ENV_VAR_1": "val2"}}, // skip val2 for ENV_VAR_1
+  // ],
+  //
+  // "include": [
+  //     // additional env for python2.7
+  //     {"python": "2.7", "req": {"numpy": "1.8"}, "env_nobuild": {"FOO": "123"}},
+  //     // additional env if run on windows+conda
+  //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "req": {"libpython": ""}},
+  // ],
+
+  // The directory (relative to the current directory) that benchmarks are
+  // stored in.  If not provided, defaults to "benchmarks"
+  // "benchmark_dir": "benchmarks",
+
+  // The directory (relative to the current directory) to cache the Python
+  // environments in.  If not provided, defaults to "env"
+  "env_dir": ".asv/env",
+
+  // The directory (relative to the current directory) that raw benchmark
+  // results are stored in.  If not provided, defaults to "results".
+  "results_dir": ".asv/results",
+
+  // The directory (relative to the current directory) that the html tree
+  // should be written to.  If not provided, defaults to "html".
+  "html_dir": ".asv/html"
+
+  // The number of characters to retain in the commit hashes.
+  // "hash_length": 8,
+
+  // `asv` will cache results of the recent builds in each
+  // environment, making them faster to install next time.  This is
+  // the number of builds to keep, per environment.
+  // "build_cache_size": 2,
+
+  // The commits after which the regression search in `asv publish`
+  // should start looking for regressions. Dictionary whose keys are
+  // regexps matching to benchmark names, and values corresponding to
+  // the commit (exclusive) after which to start looking for
+  // regressions.  The default is to start from the first commit
+  // with results. If the commit is `null`, regression detection is
+  // skipped for the matching benchmark.
+  //
+  // "regressions_first_commits": {
+  //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+  //    "another_benchmark": null,   // Skip regression detection altogether
+  // },
+
+  // The thresholds for relative change in results, after which `asv
+  // publish` starts reporting regressions. Dictionary of the same
+  // form as in ``regressions_first_commits``, with values
+  // indicating the thresholds.  If multiple entries match, the
+  // maximum is taken. If no entry matches, the default is 5%.
+  //
+  // "regressions_thresholds": {
+  //    "some_benchmark": 0.01,     // Threshold of 1%
+  //    "another_benchmark": 0.5,   // Threshold of 50%
+  // },
+}

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -31,7 +31,7 @@
   ],
   // List of branches to benchmark. If not provided, defaults to "master"
   // (for git) or "default" (for mercurial).
-  // "branches": ["master"], // for git
+  "branches": ["master"], // for git
   // "branches": ["default"],    // for mercurial
 
   // The DVCS being used.  If not set, it will be automatically

--- a/asv_bench/benchmarks/README_CI.md
+++ b/asv_bench/benchmarks/README_CI.md
@@ -1,0 +1,122 @@
+# Benchmark CI
+
+<!-- Author: @jaimergp -->
+<!-- Last updated: 2021.07.06 -->
+<!-- Describes the work done as part of https://github.com/scikit-image/scikit-image/pull/5424 -->
+
+## How it works
+
+The `asv` suite can be run for any PR on GitHub Actions (check workflow `.github/workflows/benchmarks.yml`) by adding a `run-benchmark` label to said PR. This will trigger a job that will run the benchmarking suite for the current PR head (merged commit) against the PR base (usually `main`).
+
+We use `asv continuous` to run the job, which runs a relative performance measurement. This means that there's no state to be saved and that regressions are only caught in terms of performance ratio (absolute numbers are available but they are not useful since we do not use stable hardware over time). `asv continuous` will:
+
+- Compile `scikit-image` for _both_ commits. We use `ccache` to speed up the process, and `mamba` is used to create the build environments.
+- Run the benchmark suite for both commits, _twice_ (since `processes=2` by default).
+- Generate a report table with performance ratios:
+  - `ratio=1.0` -> performance didn't change.
+  - `ratio<1.0` -> PR made it slower.
+  - `ratio>1.0` -> PR made it faster.
+
+Due to the sensitivity of the test, we cannot guarantee that false positives are not produced. In practice, values between `(0.7, 1.5)` are to be considered part of the measurement noise. When in doubt, running the benchmark suite one more time will provide more information about the test being a false positive or not.
+
+## Running the benchmarks on GitHub Actions
+
+1. On a PR, add the label `run-benchmark`.
+2. The CI job will be started. Checks will appear in the usual dashboard panel above the comment box.
+3. If more commits are added, the label checks will be grouped with the last commit checks _before_ you added the label.
+4. Alternatively, you can always go to the `Actions` tab in the repo and [filter for `workflow:Benchmark`](https://github.com/scikit-image/scikit-image/actions?query=workflow%3ABenchmark). Your username will be assigned to the `actor` field, so you can also filter the results with that if you need it.
+
+## The artifacts
+
+The CI job will also generate an artifact. This is the `.asv/results` directory compressed in a zip file. Its contents include:
+
+- `fv-xxxxx-xx/`. A directory for the machine that ran the suite. It contains three files:
+  - `<baseline>.json`, `<contender>.json`: the benchmark results for each commit, with stats.
+  - `machine.json`: details about the hardware.
+- `benchmarks.json`: metadata about the current benchmark suite.
+- `benchmarks.log`: the CI logs for this run.
+- This README.
+
+## Re-running the analysis
+
+Although the CI logs should be enough to get an idea of what happened (check the table at the end), one can use `asv` to run the analysis routines again.
+
+1. Uncompress the artifact contents in the repo, under `.asv/results`. This is, you should see `.asv/results/benchmarks.log`, not `.asv/results/something_else/benchmarks.log`. Write down the machine directory name for later.
+2. Run `asv show` to see your available results. You will see something like this:
+
+```
+$> asv show
+
+Commits with results:
+
+Machine    : Jaimes-MBP
+Environment: conda-py3.9-cython-numpy1.20-scipy
+
+    00875e67
+
+Machine    : fv-az95-499
+Environment: conda-py3.7-cython-numpy1.17-pooch-scipy
+
+    8db28f02
+    3a305096
+```
+
+3. We are interested in the commits for `fv-az95-499` (the CI machine for this run). We can compare them with `asv compare` and some extra options. `--sort ratio` will show largest ratios first, instead of alphabetical order. `--split` will produce three tables: improved, worsened, no changes. `--factor 1.5` tells `asv` to only complain if deviations are above a 1.5 ratio. `-m` is used to indicate the machine ID (use the one you wrote down in step 1). Finally, specify your commit hashes: baseline first, then contender!
+
+```
+$> asv compare --sort ratio --split --factor 1.5 -m fv-az95-499 8db28f02 3a305096
+
+Benchmarks that have stayed the same:
+
+       before           after         ratio
+     [8db28f02]       [3a305096]
+     <ci-benchmark-check~9^2>
+              n/a              n/a      n/a  benchmark_restoration.RollingBall.time_rollingball_ndim
+      1.23±0.04ms       1.37±0.1ms     1.12  benchmark_transform_warp.WarpSuite.time_to_float64(<class 'numpy.float64'>, 128, 3)
+       5.07±0.1μs       5.59±0.4μs     1.10  benchmark_transform_warp.ResizeLocalMeanSuite.time_resize_local_mean(<class 'numpy.float32'>, (192, 192, 192), (192, 192, 192))
+      1.23±0.02ms       1.33±0.1ms     1.08  benchmark_transform_warp.WarpSuite.time_same_type(<class 'numpy.float32'>, 128, 3)
+       9.45±0.2ms       10.1±0.5ms     1.07  benchmark_rank.Rank3DSuite.time_3d_filters('majority', (32, 32, 32))
+       23.0±0.9ms         24.6±1ms     1.07  benchmark_interpolation.InterpolationResize.time_resize((80, 80, 80), 0, 'symmetric', <class 'numpy.float64'>, True)
+         38.7±1ms         41.1±1ms     1.06  benchmark_transform_warp.ResizeLocalMeanSuite.time_resize_local_mean(<class 'numpy.float32'>, (2048, 2048), (192, 192, 192))
+       4.97±0.2μs       5.24±0.2μs     1.05  benchmark_transform_warp.ResizeLocalMeanSuite.time_resize_local_mean(<class 'numpy.float32'>, (2048, 2048), (2048, 2048))
+       4.21±0.2ms       4.42±0.3ms     1.05  benchmark_rank.Rank3DSuite.time_3d_filters('gradient', (32, 32, 32))
+
+...
+```
+
+If you want more details on a specific test, you can use `asv show`. Use `-b pattern` to filter which tests to show, and then specify a commit hash to inspect:
+
+```
+$> asv show -b time_to_float64 8db28f02
+
+Commit: 8db28f02 <ci-benchmark-check~9^2>
+
+benchmark_transform_warp.WarpSuite.time_to_float64 [fv-az95-499/conda-py3.7-cython-numpy1.17-pooch-scipy]
+  ok
+  =============== ============= ========== ============= ========== ============ ========== ============ ========== ============
+  --                                                                N / order
+  --------------- --------------------------------------------------------------------------------------------------------------
+      dtype_in       128 / 0     128 / 1      128 / 3     1024 / 0    1024 / 1    1024 / 3    4096 / 0    4096 / 1    4096 / 3
+  =============== ============= ========== ============= ========== ============ ========== ============ ========== ============
+    numpy.uint8    2.56±0.09ms   523±30μs   1.28±0.05ms   130±3ms     28.7±2ms    81.9±3ms   2.42±0.01s   659±5ms    1.48±0.01s
+    numpy.uint16   2.48±0.03ms   530±10μs   1.28±0.02ms   130±1ms    30.4±0.7ms   81.1±2ms    2.44±0s     653±3ms    1.47±0.02s
+   numpy.float32    2.59±0.1ms   518±20μs   1.27±0.01ms   127±3ms     26.6±1ms    74.8±2ms   2.50±0.01s   546±10ms   1.33±0.02s
+   numpy.float64   2.48±0.04ms   513±50μs   1.23±0.04ms   134±3ms     30.7±2ms    85.4±2ms   2.55±0.01s   632±4ms    1.45±0.01s
+  =============== ============= ========== ============= ========== ============ ========== ============ ========== ============
+  started: 2021-07-06 06:14:36, duration: 1.99m
+```
+
+## Other details
+
+### Skipping slow or demanding tests
+
+To minimize the time required to run the full suite, we trimmed the parameter matrix in some cases and, in others, directly skipped tests that ran for too long or require too much memory. Unlike `pytest`, `asv` does not have a notion of marks. However, you can `raise NotImplementedError` in the setup step to skip a test. In that vein, a new private function is defined at `benchmarks.__init__`: `_skip_slow`. This will check if the `ASV_SKIP_SLOW` environment variable has been defined. If set to `1`, it will raise `NotImplementedError` and skip the test. To implement this behavior in other tests, you can add the following attribute:
+
+```python
+from . import _skip_slow  # this function is defined in benchmarks.__init__
+
+def time_something_slow():
+    pass
+
+time_something.setup = _skip_slow
+```

--- a/asv_bench/benchmarks/__init__.py
+++ b/asv_bench/benchmarks/__init__.py
@@ -1,0 +1,19 @@
+import os
+
+
+def _skip_slow():
+    """
+    Use this function to skip slow or highly demanding tests.
+
+    Use it as a `Class.setup` method or a `function.setup` attribute.
+
+    Examples
+    --------
+    >>> from . import _skip_slow
+    >>> def time_something_slow():
+    ...     pass
+    ...
+    >>> time_something.setup = _skip_slow
+    """
+    if os.environ.get("ASV_SKIP_SLOW", "0") == "1":
+        raise NotImplementedError("Skipping this test...")

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1,0 +1,34 @@
+# Write the benchmarking functions here.
+# See "Writing benchmarks" in the asv docs for more information.
+
+# TODO: Write some benchmarks for parcels
+
+
+class ExampleTimeSuite:
+    """
+    An example benchmark that times the performance of various kinds
+    of iterating over dictionaries in Python.
+    """
+
+    def setup(self):
+        self.d = {}
+        for x in range(500):
+            self.d[x] = None
+
+    def time_keys(self):
+        for _ in self.d.keys():
+            pass
+
+    def time_values(self):
+        for _ in self.d.values():
+            pass
+
+    def time_range(self):
+        d = self.d
+        for key in range(500):
+            _ = d[key]
+
+
+class ExampleMemSuite:
+    def mem_list(self):
+        return [0] * 256

--- a/docs/community/benchmarking.md
+++ b/docs/community/benchmarking.md
@@ -1,0 +1,22 @@
+# Benchmarking
+
+Parcels comes with an [asv](https://asv.readthedocs.io/en/latest/) benchmarking suite to monitor the performance of the project over it's lifespan.
+
+The benchmarking is run in CI using GitHub Actions (similar to other projects like xarray, scikit-image, and pandas), using a ratio to determine performance regressions instead of raw outputs. More on the reliability of benchmarking in CI can be seen at [this blog post](https://labs.quansight.org/blog/2021/08/github-actions-benchmarks). Due to the reliance of CI for benchmarking, the benchmarks are small such that they test the core functionality of Parcels. Large scale simulation benchmarking is an avenue for future development.
+
+## Setup
+
+The asv benchmarks require these dependencies:
+
+`conda install -c conda-forge asv>0.6 libmambapy<2 conda-build`
+
+Progress on compatibility of asv with libmambapy 2 is documented at [this issue](https://github.com/airspeed-velocity/asv/issues/1438).
+
+## Running the benchmarks
+
+The benchmarks can be run locally using the following command:
+
+```bash
+asv run
+
+```

--- a/docs/community/contributing.rst
+++ b/docs/community/contributing.rst
@@ -74,7 +74,18 @@ From there:
 - create a git branch, implement, commit, and push your changes
 - `create a pull request <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`_ (PR) into ``master`` of the original repo making sure to link to the issue that you are working on. Not yet finished with your feature but still want feedback on how you're going? Then mark it as "draft" and ``@ping`` a maintainer. See our `maintainer notes <maintainer.md>`_ to see our PR review workflow.
 
-If you made changes to the documentation, and want to render a local version, you can run the command ``sphinx-autobuild --ignore "*.zip" docs docs/_build`` to create a server to automatically rebuild the documentation when you make changes.
+Here is a short overview of a few different commands that we use during development:
+
+.. code-block:: bash
+   # Run unit-tests
+   pytest
+
+   # Run typechecking
+   mypy
+
+   # Build the documentation. This launches a server, automatically rebuilt when changes are made
+   sphinx-autobuild --ignore "*.zip" docs docs/_build
+
 
 Code guidelines
 ~~~~~~~~~~~~~~~

--- a/docs/community/index.rst
+++ b/docs/community/index.rst
@@ -18,3 +18,4 @@ See the sections in the primary sidebar and below to explore.
     :maxdepth: 1
 
     maintainer
+    benchmarks

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: parcels
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10
+  - python=3.10
   - cgen
   - ffmpeg>=3.2.3
   - git


### PR DESCRIPTION
This PR introduces benchmarking infrastructure to the project via [asv](https://asv.readthedocs.io/en/latest/). Benchmarks can be run on a pull request by adding the `run-benchmarks` label to it. Two environments will be created in the CI runner with the prior and proposed changes, and both suites of benchmarks will be run and compared against each other.

Note that this PR only has example benchmarks for the timebeing until we can discuss benchmarks of interest.

The running of the benchmarks in CI is only one aspect of the benchmarking (ie, only for core parcels functionality). Using asv, we can create different suites of benchmarks (e.g., one for CI, and one for more heavy simulations). The benefit of using asv is everything else that comes out of the box with it, some being:

- being able to run benchmarks easily across several commits, visualising them in a dashboard
- easily create and manage these benchmarking environments
- profiling support to dive into locations of slowdowns
- community support

Changes:
- asv configuration (conf file, benchmarks folder, and CI workflow)
- asv documentation (available via the community page in the maintainer section)

---

I have done some testing of the PR label workflow in https://github.com/VeckoTheGecko/parcels/pull/10 . We can only test this for PRs in OceanParcels/parcels when its in master