### PR TITLE
Patch Ruff config (isort in notebooks)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,11 @@ repos:
     rev: v0.7.4
     hooks:
       - id: ruff
+        name: ruff lint (.py)
         args: [--fix, --show-fixes]
+        types_or: [python]
       - id: ruff
-        name: ruff (isort jupyter)
+        name: ruff isort (.ipynb)
         args: [--select, I, --fix]
         types_or: [jupyter]
       - id: ruff-format

--- a/docs/examples/documentation_indexing.ipynb
+++ b/docs/examples/documentation_indexing.ipynb
@@ -54,9 +54,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import warnings\n",
     "from glob import glob\n",
     "from os import path\n",
-    "import warnings\n",
     "\n",
     "import numpy as np\n",
     "\n",

--- a/docs/examples/example_brownian.py
+++ b/docs/examples/example_brownian.py
@@ -1,8 +1,9 @@
 from datetime import timedelta
 
 import numpy as np
-import parcels
 import pytest
+
+import parcels
 
 ptype = {"scipy": parcels.ScipyParticle, "jit": parcels.JITParticle}
 

--- a/docs/examples/example_dask_chunk_OCMs.py
+++ b/docs/examples/example_dask_chunk_OCMs.py
@@ -4,8 +4,9 @@ from glob import glob
 
 import dask
 import numpy as np
-import parcels
 import pytest
+
+import parcels
 from parcels.tools.statuscodes import DaskChunkingError
 
 ptype = {"scipy": parcels.ScipyParticle, "jit": parcels.JITParticle}

--- a/docs/examples/example_decaying_moving_eddy.py
+++ b/docs/examples/example_decaying_moving_eddy.py
@@ -1,8 +1,9 @@
 from datetime import timedelta
 
 import numpy as np
-import parcels
 import pytest
+
+import parcels
 
 ptype = {"scipy": parcels.ScipyParticle, "jit": parcels.JITParticle}
 

--- a/docs/examples/example_globcurrent.py
+++ b/docs/examples/example_globcurrent.py
@@ -2,9 +2,10 @@ from datetime import timedelta
 from glob import glob
 
 import numpy as np
-import parcels
 import pytest
 import xarray as xr
+
+import parcels
 
 ptype = {"scipy": parcels.ScipyParticle, "jit": parcels.JITParticle}
 

--- a/docs/examples/example_mitgcm.py
+++ b/docs/examples/example_mitgcm.py
@@ -3,8 +3,9 @@ from pathlib import Path
 from typing import Literal
 
 import numpy as np
-import parcels
 import xarray as xr
+
+import parcels
 
 ptype = {"scipy": parcels.ScipyParticle, "jit": parcels.JITParticle}
 

--- a/docs/examples/example_moving_eddies.py
+++ b/docs/examples/example_moving_eddies.py
@@ -4,8 +4,9 @@ from argparse import ArgumentParser
 from datetime import timedelta
 
 import numpy as np
-import parcels
 import pytest
+
+import parcels
 
 ptype = {"scipy": parcels.ScipyParticle, "jit": parcels.JITParticle}
 method = {

--- a/docs/examples/example_nemo_curvilinear.py
+++ b/docs/examples/example_nemo_curvilinear.py
@@ -5,8 +5,9 @@ from datetime import timedelta
 from glob import glob
 
 import numpy as np
-import parcels
 import pytest
+
+import parcels
 
 ptype = {"scipy": parcels.ScipyParticle, "jit": parcels.JITParticle}
 advection = {"RK4": parcels.AdvectionRK4, "AA": parcels.AdvectionAnalytical}

--- a/docs/examples/example_ofam.py
+++ b/docs/examples/example_ofam.py
@@ -2,9 +2,10 @@ import gc
 from datetime import timedelta
 
 import numpy as np
-import parcels
 import pytest
 import xarray as xr
+
+import parcels
 
 ptype = {"scipy": parcels.ScipyParticle, "jit": parcels.JITParticle}
 

--- a/docs/examples/example_peninsula.py
+++ b/docs/examples/example_peninsula.py
@@ -4,8 +4,9 @@ from argparse import ArgumentParser
 from datetime import timedelta
 
 import numpy as np
-import parcels
 import pytest
+
+import parcels
 
 ptype = {"scipy": parcels.ScipyParticle, "jit": parcels.JITParticle}
 method = {

--- a/docs/examples/example_radial_rotation.py
+++ b/docs/examples/example_radial_rotation.py
@@ -2,8 +2,9 @@ import math
 from datetime import timedelta
 
 import numpy as np
-import parcels
 import pytest
+
+import parcels
 
 ptype = {"scipy": parcels.ScipyParticle, "jit": parcels.JITParticle}
 

--- a/docs/examples/example_stommel.py
+++ b/docs/examples/example_stommel.py
@@ -3,8 +3,9 @@ from argparse import ArgumentParser
 from datetime import timedelta
 
 import numpy as np
-import parcels
 import pytest
+
+import parcels
 
 ptype = {"scipy": parcels.ScipyParticle, "jit": parcels.JITParticle}
 method = {

--- a/docs/examples/tutorial_croco_3D.ipynb
+++ b/docs/examples/tutorial_croco_3D.ipynb
@@ -35,10 +35,12 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import parcels\n",
-    "import numpy as np\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "import xarray as xr\n",
+    "\n",
+    "import parcels\n",
     "\n",
     "example_dataset_folder = parcels.download_example_dataset(\"CROCOidealized_data\")\n",
     "file = os.path.join(example_dataset_folder, \"CROCO_idealized.nc\")"

--- a/docs/examples/tutorial_nemo_3D.ipynb
+++ b/docs/examples/tutorial_nemo_3D.ipynb
@@ -54,9 +54,9 @@
     }
    ],
    "source": [
+    "import warnings\n",
     "from datetime import timedelta\n",
     "from glob import glob\n",
-    "import warnings\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import xarray as xr\n",

--- a/docs/examples/tutorial_timestamps.ipynb
+++ b/docs/examples/tutorial_timestamps.ipynb
@@ -14,8 +14,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from glob import glob\n",
     "import warnings\n",
+    "from glob import glob\n",
     "\n",
     "import numpy as np\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,6 @@ filterwarnings = [
 line-length = 120
 
 [tool.ruff.lint]
-exclude = ["*.ipynb"]
-
 select = [
     "D",  # pydocstyle
     "E",  # Error
@@ -131,6 +129,9 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.ruff.lint.isort]
+known-first-party = ["parcels"]
 
 [tool.mypy]
 files = [


### PR DESCRIPTION
While looking at #1769 I realised that our Ruff tooling wasn't working as expected.

Changes:
- `.ipynb` files no longer ignored (only linting done on these is `isort`)
- `parcels` is now explicitly flagged as a first party package, correcting import ordering