### PR TITLE
Adding support for grid.negate_depth() method

### DIFF
--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -114,7 +114,7 @@ class Grid:
     def depth(self):
         return self._depth
 
-    def negate_depth(self):
+    def negate_depth(self) -> None:
         self._depth = -self._depth
 
     @property

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -114,6 +114,9 @@ class Grid:
     def depth(self):
         return self._depth
 
+    def negate_depth(self):
+        self._depth = -self._depth
+
     @property
     def mesh(self):
         return self._mesh

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -115,6 +115,10 @@ class Grid:
         return self._depth
 
     def negate_depth(self) -> None:
+        """Method to flip the sign of the depth dimension of a Grid.
+        Note that this method does _not_ change the direction of the vertical velocity;
+        for that users need to add a fieldset.W.set_scaling_factor(-1.0)
+        """
         self._depth = -self._depth
 
     @property

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -114,7 +114,7 @@ class Grid:
     def depth(self):
         return self._depth
 
-    def negate_depth(self) -> None:
+    def negate_depth(self):
         """Method to flip the sign of the depth dimension of a Grid.
         Note that this method does _not_ change the direction of the vertical velocity;
         for that users need to add a fieldset.W.set_scaling_factor(-1.0)

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -112,6 +112,16 @@ def test_time_format_in_grid():
         RectilinearZGrid(lon, lat, time=time)
 
 
+def test_negate_depth():
+    depth = np.linspace(0, 5, 10, dtype=np.float32)
+    fieldset = FieldSet.from_data(
+        {"U": np.zeros((10, 1, 1)), "V": np.zeros((10, 1, 1))}, {"lon": [0], "lat": [0], "depth": depth}
+    )
+    assert np.all(fieldset.gridset.grids[0].depth == depth)
+    fieldset.U.grid.negate_depth()
+    assert np.all(fieldset.gridset.grids[0].depth == -depth)
+
+
 def test_avoid_repeated_grids():
     lon_g0 = np.linspace(0, 1000, 11, dtype=np.float32)
     lat_g0 = np.linspace(0, 1000, 11, dtype=np.float32)


### PR DESCRIPTION
This PR adds a `grid.negate_depth()` method, which can be useful when the depth needs to be flipped from positive to negative values. This is the case for example in the `VirtualShip` package:
https://github.com/OceanParcels/virtualship/blob/44eae19e55545166c446e8eabe7c76ab13d7344b/src/virtualship/expedition/input_data.py#L98-L100

Note that this method does _not_ change the direction of the vertical velocity; for that users need to add a `fieldset.W.set_scaling_factor(-1.0)`

This fixes #1746 