### PR TITLE
Cleanup macOS debugging files

### DIFF
--- a/parcels/__init__.py
+++ b/parcels/__init__.py
@@ -2,7 +2,7 @@ from ._version import version
 
 __version__ = version
 
-import parcels.rng as ParcelsRandom  # noqa
+import parcels.rng as ParcelsRandom  # noqa: F401
 from parcels.application_kernels import *
 from parcels.field import *
 from parcels.fieldset import *

--- a/parcels/_version.py
+++ b/parcels/_version.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import warnings
 
 try:
     from parcels._version_setup import version
@@ -13,9 +14,11 @@ except ModuleNotFoundError:
             .decode("ascii")
             .strip()
         )
-    except subprocess.SubprocessError as e:
-        e.add_note(
+    except subprocess.SubprocessError:
+        warnings.warn(
             "Looks like you're trying to do a development install of parcels. "
             "This needs to be in a git repo so that version information is available. "
+            "Setting version to 'unknown'.",
+            stacklevel=2,
         )
-        raise e
+        version = "unknown"

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -439,14 +439,13 @@ class Kernel(BaseKernel):
             dyn_dir = get_cache_dir()
             basename = f"{cache_name}_0"
         lib_path = "lib" + basename
-        src_file_or_files = None
 
         assert isinstance(basename, str)
 
-        src_file_or_files = f"{os.path.join(dyn_dir, basename)}.c"
+        src_file = f"{os.path.join(dyn_dir, basename)}.c"
         lib_file = f"{os.path.join(dyn_dir, lib_path)}.{'dll' if sys.platform == 'win32' else 'so'}"
         log_file = f"{os.path.join(dyn_dir, basename)}.log"
-        return src_file_or_files, lib_file, log_file
+        return src_file, lib_file, log_file
 
     def compile(self, compiler):
         """Writes kernel code to file and compiles it."""

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -460,12 +460,8 @@ class Kernel(BaseKernel):
         src_file_or_files = None
 
         assert isinstance(basename, str)
-        if isinstance(basename, (list, dict, tuple, ndarray)):
-            src_file_or_files = [""] * len(basename)
-            for i, src_file in enumerate(basename):
-                src_file_or_files[i] = f"{os.path.join(dyn_dir, src_file)}.c"
-        else:
-            src_file_or_files = f"{os.path.join(dyn_dir, basename)}.c"
+
+        src_file_or_files = f"{os.path.join(dyn_dir, basename)}.c"
         lib_file = f"{os.path.join(dyn_dir, lib_path)}.{'dll' if sys.platform == 'win32' else 'so'}"
         log_file = f"{os.path.join(dyn_dir, basename)}.log"
         return src_file_or_files, lib_file, log_file

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -7,6 +7,7 @@ import inspect
 import math  # noqa: F401
 import os
 import random  # noqa: F401
+import shutil
 import sys
 import textwrap
 import types
@@ -531,14 +532,22 @@ class Kernel(BaseKernel):
         return functools.reduce(lambda x, y: x + y, pyfunc_list)
 
     @staticmethod
-    def cleanup_remove_files(lib_file, all_files: list[str], delete_cfiles) -> None:
-        if lib_file is not None:
-            if os.path.isfile(lib_file):  # and delete_cfiles
-                os.remove(lib_file)
-            if delete_cfiles:
-                for s in all_files:
-                    if os.path.exists(s):
-                        os.remove(s)
+    def cleanup_remove_files(lib_file: str | None, all_files: list[str], delete_cfiles: bool) -> None:
+        if lib_file is None:
+            return
+
+        # Remove compiled files
+        if os.path.isfile(lib_file):
+            os.remove(lib_file)
+
+        macos_debugging_files = f"{lib_file}.dSYM"
+        if os.path.isdir(macos_debugging_files):
+            shutil.rmtree(macos_debugging_files)
+
+        if delete_cfiles:
+            for s in all_files:
+                if os.path.exists(s):
+                    os.remove(s)
 
     @staticmethod
     def cleanup_unload_lib(lib):

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -272,20 +272,6 @@ class Kernel(BaseKernel):
 
             self.src_file, self.lib_file, self.log_file = self.get_kernel_compile_files()
 
-    def __del__(self):
-        # Clean-up the in-memory dynamic linked libraries.
-        # This is not really necessary, as these programs are not that large, but with the new random
-        # naming scheme which is required on Windows OS'es to deal with updates to a Parcels' kernel.
-        try:
-            self.remove_lib()
-        except:
-            pass
-        self._fieldset = None
-        self.field_args = None
-        self.const_args = None
-        self.funcvars = None
-        self.funccode = None
-
     @property
     def ptype(self):
         return self._ptype
@@ -411,7 +397,7 @@ class Kernel(BaseKernel):
             all_files.append(self.src_file)
         if self.log_file is not None:
             all_files.append(self.log_file)
-        if self.lib_file is not None and all_files is not None and self.delete_cfiles is not None:
+        if self.lib_file is not None:
             self.cleanup_remove_files(self.lib_file, all_files, self.delete_cfiles)
 
         # If file already exists, pull new names. This is necessary on a Windows machine, because

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -4,9 +4,9 @@ import ast
 import functools
 import hashlib
 import inspect
-import math  # noqa
+import math  # noqa: F401
 import os
-import random  # noqa
+import random  # noqa: F401
 import sys
 import textwrap
 import types
@@ -19,8 +19,8 @@ import numpy as np
 import numpy.ctypeslib as npct
 from numpy import ndarray
 
-import parcels.rng as ParcelsRandom  # noqa
-from parcels import rng  # noqa
+import parcels.rng as ParcelsRandom  # noqa: F401
+from parcels import rng  # noqa: F401
 from parcels._compat import MPI
 from parcels.application_kernels.advection import (
     AdvectionAnalytical,

--- a/parcels/tools/global_statics.py
+++ b/parcels/tools/global_statics.py
@@ -3,7 +3,9 @@ import os
 import sys
 from pathlib import Path
 from tempfile import gettempdir
+from typing import Literal
 
+USER_ID: int | Literal["tmp"]
 try:
     from os import getuid
 

--- a/parcels/tools/global_statics.py
+++ b/parcels/tools/global_statics.py
@@ -6,10 +6,11 @@ from tempfile import gettempdir
 
 try:
     from os import getuid
+
+    USER_ID = getuid()
 except:
-    # Windows does not have getuid(), so define to simply return 'tmp'
-    def getuid():  # type: ignore
-        return "tmp"
+    # Windows does not have getuid()
+    USER_ID = "tmp"
 
 
 __all__ = ["cleanup_remove_files", "cleanup_unload_lib", "get_package_dir", "get_cache_dir"]
@@ -34,6 +35,6 @@ def get_package_dir():
 
 
 def get_cache_dir():
-    directory = os.path.join(gettempdir(), f"parcels-{getuid()}")
+    directory = os.path.join(gettempdir(), f"parcels-{USER_ID}")
     Path(directory).mkdir(exist_ok=True)
     return directory

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -81,3 +81,7 @@ def create_fieldset_zeros_simple(xdim=40, ydim=100):
     data = {"U": np.array(U, dtype=np.float32), "V": np.array(V, dtype=np.float32)}
     dimensions = {"lat": lat, "lon": lon, "depth": depth}
     return FieldSet.from_data(data, dimensions)
+
+
+def assert_empty_folder(path: Path):
+    assert [p.name for p in path.iterdir()] == []


### PR DESCRIPTION
Files of `.so.dSYM extension` are debugging files creating during C compilation on MacOS systems. This PR checks for them and cleans them up if they exist. This PR also does some refactoring of dead code related to `Kernel.dyn_srcs`.

During my debugging in a Jupyter notebook, I did realise some erroneous `.so` files were left behind sometimes. A bit inconsistent, as these should have been garbage collected. Couldn't recreate in the tests though. Perhaps something to do with the Jupyter notebook environment and how items are garbage collected? Thoughts @erikvansebille ?

Fixes #1637 