### PR TITLE
Refactor `filenames` handling in `Field.from_netcdf` 

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -2576,15 +2576,11 @@ class NestedField(list):
 
 def _get_dim_filenames(filenames: str | Path | Any | dict[str, str | Any], dim: str) -> Any:
     """Get's the relevant filenames for a given dimension."""
-    if isinstance(filenames, str) or not isinstance(filenames, Iterable):
-        return [filenames]
-    elif isinstance(filenames, dict):
-        assert dim in filenames.keys(), "filename dimension keys must be lon, lat, depth or data"
-        filename = filenames[dim]
-        if not isinstance(filename, Iterable):
-            return [filename]
-        else:
-            return filename
+    if isinstance(filenames, list):
+        return filenames
+
+    if isinstance(filenames, dict):
+        return filenames[dim]
 
     raise ValueError("Filenames must be a string, pathlib.Path, or a dictionary")
 

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -2577,7 +2577,7 @@ def _get_dim_filenames(filenames: str | Path | Any | dict[str, str | Any], dim: 
     elif isinstance(filenames, dict):
         assert dim in filenames.keys(), "filename dimension keys must be lon, lat, depth or data"
         filename = filenames[dim]
-        if isinstance(filename, str):
+        if not isinstance(filename, Iterable):
             return [filename]
         else:
             return filename

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1,10 +1,9 @@
-import collections
 import math
 import warnings
 from collections.abc import Iterable
 from ctypes import POINTER, Structure, c_float, c_int, pointer
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import dask.array as da
 import numpy as np
@@ -2572,8 +2571,8 @@ class NestedField(list):
             return val
 
 
-def _get_dim_filenames(filenames, dim):
-    if isinstance(filenames, str) or not isinstance(filenames, collections.abc.Iterable):
+def _get_dim_filenames(filenames: str | Path | Any | dict[str, str | Any], dim: str) -> Any:
+    if isinstance(filenames, str) or not isinstance(filenames, Iterable):
         return [filenames]
     elif isinstance(filenames, dict):
         assert dim in filenames.keys(), "filename dimension keys must be lon, lat, depth or data"
@@ -2582,5 +2581,5 @@ def _get_dim_filenames(filenames, dim):
             return [filename]
         else:
             return filename
-    else:
-        raise ValueError("Filenames must be a string, pathlib.Path, a list or a dictionary")
+
+    raise ValueError("Filenames must be a string, pathlib.Path, or a dictionary")

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -426,22 +426,8 @@ class Field:
 
     @classmethod
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
-    def get_dim_filenames(cls, *args, **kwargs):
-        return cls._get_dim_filenames(*args, **kwargs)
-
-    @classmethod
-    def _get_dim_filenames(cls, filenames, dim):
-        if isinstance(filenames, str) or not isinstance(filenames, collections.abc.Iterable):
-            return [filenames]
-        elif isinstance(filenames, dict):
-            assert dim in filenames.keys(), "filename dimension keys must be lon, lat, depth or data"
-            filename = filenames[dim]
-            if isinstance(filename, str):
-                return [filename]
-            else:
-                return filename
-        else:
-            return filenames
+    def get_dim_filenames(*args, **kwargs):
+        return _get_dim_filenames(*args, **kwargs)
 
     @staticmethod
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
@@ -598,17 +584,17 @@ class Field:
             len(variable) == 2
         ), "The variable tuple must have length 2. Use FieldSet.from_netcdf() for multiple variables"
 
-        data_filenames = cls._get_dim_filenames(filenames, "data")
-        lonlat_filename = cls._get_dim_filenames(filenames, "lon")
+        data_filenames = _get_dim_filenames(filenames, "data")
+        lonlat_filename = _get_dim_filenames(filenames, "lon")
         if isinstance(filenames, dict):
             assert len(lonlat_filename) == 1
-        if lonlat_filename != cls._get_dim_filenames(filenames, "lat"):
+        if lonlat_filename != _get_dim_filenames(filenames, "lat"):
             raise NotImplementedError(
                 "longitude and latitude dimensions are currently processed together from one single file"
             )
         lonlat_filename = lonlat_filename[0]
         if "depth" in dimensions:
-            depth_filename = cls._get_dim_filenames(filenames, "depth")
+            depth_filename = _get_dim_filenames(filenames, "depth")
             if isinstance(filenames, dict) and len(depth_filename) != 1:
                 raise NotImplementedError("Vertically adaptive meshes not implemented for from_netcdf()")
             depth_filename = depth_filename[0]
@@ -2584,3 +2570,17 @@ class NestedField(list):
                     else:
                         pass
             return val
+
+
+def _get_dim_filenames(filenames, dim):
+    if isinstance(filenames, str) or not isinstance(filenames, collections.abc.Iterable):
+        return [filenames]
+    elif isinstance(filenames, dict):
+        assert dim in filenames.keys(), "filename dimension keys must be lon, lat, depth or data"
+        filename = filenames[dim]
+        if isinstance(filename, str):
+            return [filename]
+        else:
+            return filename
+    else:
+        raise ValueError("Filenames must be a string, pathlib.Path, a list or a dictionary")

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -52,7 +52,8 @@ if TYPE_CHECKING:
 
     from parcels.fieldset import FieldSet
 
-    T_SanitizedFilenames = list[str] | dict[str, list[str]]
+    T_Dimensions = Literal["lon", "lat", "depth", "data"]
+    T_SanitizedFilenames = list[str] | dict[T_Dimensions, list[str]]
 
 __all__ = ["Field", "NestedField", "VectorField"]
 
@@ -600,10 +601,10 @@ class Field:
             )
         lonlat_filename = lonlat_filename_lst[0]
         if "depth" in dimensions:
-            depth_filename = _get_dim_filenames(filenames, "depth")
-            if isinstance(filenames, dict) and len(depth_filename) != 1:
+            depth_filename_lst = _get_dim_filenames(filenames, "depth")
+            if isinstance(filenames, dict) and len(depth_filename_lst) != 1:
                 raise NotImplementedError("Vertically adaptive meshes not implemented for from_netcdf()")
-            depth_filename = depth_filename[0]
+            depth_filename = depth_filename_lst[0]
 
         netcdf_engine = kwargs.pop("netcdf_engine", "netcdf4")
         gridindexingtype = kwargs.get("gridindexingtype", "nemo")
@@ -2578,7 +2579,7 @@ class NestedField(list):
             return val
 
 
-def _get_dim_filenames(filenames: T_SanitizedFilenames, dim: str) -> list[str]:
+def _get_dim_filenames(filenames: T_SanitizedFilenames, dim: T_Dimensions) -> list[str]:
     """Get's the relevant filenames for a given dimension."""
     if isinstance(filenames, list):
         return filenames

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -348,19 +348,7 @@ class FieldSet:
     @classmethod
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
     def parse_wildcards(cls, *args, **kwargs):
-        return cls._parse_wildcards(*args, **kwargs)
-
-    @classmethod
-    def _parse_wildcards(cls, paths, filenames, var):
-        if not isinstance(paths, list):
-            paths = sorted(glob(str(paths)))
-        if len(paths) == 0:
-            notfound_paths = filenames[var] if isinstance(filenames, dict) and var in filenames else filenames
-            raise OSError(f"FieldSet files not found for variable {var}: {notfound_paths}")
-        for fp in paths:
-            if not os.path.exists(fp):
-                raise OSError(f"FieldSet file not found: {fp}")
-        return paths
+        return _parse_wildcards(*args, **kwargs)
 
     @classmethod
     def from_netcdf(
@@ -477,10 +465,10 @@ class FieldSet:
             # Resolve all matching paths for the current variable
             paths = filenames[var] if type(filenames) is dict and var in filenames else filenames
             if type(paths) is not dict:
-                paths = cls._parse_wildcards(paths, filenames, var)
+                paths = _parse_wildcards(paths, filenames, var)
             else:
                 for dim, p in paths.items():
-                    paths[dim] = cls._parse_wildcards(p, filenames, var)
+                    paths[dim] = _parse_wildcards(p, filenames, var)
 
             # Use dimensions[var] and indices[var] if either of them is a dict of dicts
             dims = dimensions[var] if var in dimensions else dimensions
@@ -1689,3 +1677,15 @@ class FieldSet:
                 return nextTime
             else:
                 return time + nSteps * dt
+
+
+def _parse_wildcards(paths, filenames, var):
+    if not isinstance(paths, list):
+        paths = sorted(glob(str(paths)))
+    if len(paths) == 0:
+        notfound_paths = filenames[var] if isinstance(filenames, dict) and var in filenames else filenames
+        raise OSError(f"FieldSet files not found for variable {var}: {notfound_paths}")
+    for fp in paths:
+        if not os.path.exists(fp):
+            raise OSError(f"FieldSet file not found: {fp}")
+    return paths

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1684,8 +1684,8 @@ def _parse_wildcards(paths, filenames, var):
         paths = sorted(glob(str(paths)))
     if len(paths) == 0:
         notfound_paths = filenames[var] if isinstance(filenames, dict) and var in filenames else filenames
-        raise OSError(f"FieldSet files not found for variable {var}: {notfound_paths}")
+        raise FileNotFoundError(f"FieldSet files not found for variable {var}: {notfound_paths}")
     for fp in paths:
         if not os.path.exists(fp):
-            raise OSError(f"FieldSet file not found: {fp}")
+            raise FileNotFoundError(f"FieldSet file not found: {fp}")
     return paths

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -73,7 +73,6 @@ def test_advection_zonal(lon, lat, depth, mode):
     }
     dimensions = {"lon": lon, "lat": lat}
     fieldset2D = FieldSet.from_data(data2D, dimensions, mesh="spherical", transpose=True)
-    assert fieldset2D.U._creation_log == "from_data"
 
     pset2D = ParticleSet(fieldset2D, pclass=ptype[mode], lon=np.zeros(npart) + 20.0, lat=np.linspace(0, 80, npart))
     pset2D.execute(AdvectionRK4, runtime=timedelta(hours=2), dt=timedelta(seconds=30))

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -148,7 +148,7 @@ actions = [
     Action("FieldSet",        "particlefile",                    "read_only"     ),
     Action("FieldSet",        "add_UVfield()",                   "make_private"  ),
     Action("FieldSet",        "check_complete()",                "make_private"  ),
-    Action("FieldSet",        "parse_wildcards()",               "make_private"  ),
+    Action("FieldSet",        "parse_wildcards()",               "make_private"  , skip_reason="Moved underlying function."),
 
     # 1713
     Action("ParticleSet",      "repeat_starttime",               "make_private"  ),

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -122,7 +122,7 @@ actions = [
     Action("Field",           "c_data_chunks",                   "make_private"  ),
     Action("Field",           "chunk_set",                       "make_private"  ),
     Action("Field",           "cell_edge_sizes",                 "read_only"     ),
-    Action("Field",           "get_dim_filenames()",             "make_private"  ),
+    Action("Field",           "get_dim_filenames()",             "make_private"  , skip_reason="Moved underlying function."),
     Action("Field",           "collect_timeslices()",            "make_private"  ),
     Action("Field",           "reshape()",                       "make_private"  ),
     Action("Field",           "calc_cell_edge_sizes()",          "make_private"  ),

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,0 +1,70 @@
+import cftime
+import numpy as np
+import pytest
+import xarray as xr
+
+from parcels import Field
+from parcels.tools.converters import (
+    _get_cftime_calendars,
+    _get_cftime_datetimes,
+)
+from tests.utils import TEST_DATA
+
+
+def test_field_from_netcdf_variables():
+    filename = str(TEST_DATA / "perlinfieldsU.nc")
+    dims = {"lon": "x", "lat": "y"}
+
+    variable = "vozocrtx"
+    f1 = Field.from_netcdf(filename, variable, dims)
+    variable = ("U", "vozocrtx")
+    f2 = Field.from_netcdf(filename, variable, dims)
+    variable = {"U": "vozocrtx"}
+    f3 = Field.from_netcdf(filename, variable, dims)
+
+    assert np.allclose(f1.data, f2.data, atol=1e-12)
+    assert np.allclose(f1.data, f3.data, atol=1e-12)
+
+    with pytest.raises(AssertionError):
+        variable = {"U": "vozocrtx", "nav_lat": "nav_lat"}  # multiple variables will fail
+        f3 = Field.from_netcdf(filename, variable, dims)
+
+
+@pytest.mark.parametrize("with_timestamps", [True, False])
+def test_field_from_netcdf(with_timestamps):
+    filenames = {
+        "lon": str(TEST_DATA / "mask_nemo_cross_180lon.nc"),
+        "lat": str(TEST_DATA / "mask_nemo_cross_180lon.nc"),
+        "data": str(TEST_DATA / "Uu_eastward_nemo_cross_180lon.nc"),
+    }
+    variable = "U"
+    dimensions = {"lon": "glamf", "lat": "gphif"}
+    if with_timestamps:
+        timestamp_types = [[[2]], [[np.datetime64("2000-01-01")]]]
+        for timestamps in timestamp_types:
+            Field.from_netcdf(filenames, variable, dimensions, interp_method="cgrid_velocity", timestamps=timestamps)
+    else:
+        Field.from_netcdf(filenames, variable, dimensions, interp_method="cgrid_velocity")
+
+
+@pytest.mark.parametrize(
+    "calendar, cftime_datetime", zip(_get_cftime_calendars(), _get_cftime_datetimes(), strict=True)
+)
+def test_field_nonstandardtime(calendar, cftime_datetime, tmpdir):
+    xdim = 4
+    ydim = 6
+    filepath = tmpdir.join("test_nonstandardtime.nc")
+    dates = [getattr(cftime, cftime_datetime)(1, m, 1) for m in range(1, 13)]
+    da = xr.DataArray(
+        np.random.rand(12, xdim, ydim), coords=[dates, range(xdim), range(ydim)], dims=["time", "lon", "lat"], name="U"
+    )
+    da.to_netcdf(str(filepath))
+
+    dims = {"lon": "lon", "lat": "lat", "time": "time"}
+    try:
+        field = Field.from_netcdf(filepath, "U", dims)
+    except NotImplementedError:
+        field = None
+
+    if field is not None:
+        assert field.grid.time_origin.calendar == calendar

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -51,6 +51,25 @@ def test_field_from_netcdf(with_timestamps):
 
 
 @pytest.mark.parametrize(
+    "f",
+    [
+        pytest.param(lambda x: x, id="Path"),
+        pytest.param(lambda x: str(x), id="str"),
+    ],
+)
+def test_from_netcdf_path_object(f):
+    filenames = {
+        "lon": f(TEST_DATA / "mask_nemo_cross_180lon.nc"),
+        "lat": f(TEST_DATA / "mask_nemo_cross_180lon.nc"),
+        "data": f(TEST_DATA / "Uu_eastward_nemo_cross_180lon.nc"),
+    }
+    variable = "U"
+    dimensions = {"lon": "glamf", "lat": "gphif"}
+
+    Field.from_netcdf(filenames, variable, dimensions, interp_method="cgrid_velocity")
+
+
+@pytest.mark.parametrize(
     "calendar, cftime_datetime", zip(_get_cftime_calendars(), _get_cftime_datetimes(), strict=True)
 )
 def test_field_nonstandardtime(calendar, cftime_datetime, tmpdir):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,4 +1,3 @@
-import glob
 from pathlib import Path
 
 import cftime
@@ -105,19 +104,11 @@ def test_sanitize_field_filenames_cases(input_, expected):
 @pytest.mark.parametrize(
     "input_,expected",
     [
-        ("file*.nc", ["file0.nc", "file1.nc", "file2.nc"]),
+        pytest.param("file*.nc", [], id="glob-no-match"),
     ],
 )
-def test_sanitize_field_filenames_glob(input_, expected, tmp_path, monkeypatch):
-    def monkey_glob(pattern):
-        return glob.glob(pattern, root_dir=tmp_path)
-
-    monkeypatch.setattr(_sanitize_field_filenames, "glob", monkey_glob)
-
-    for f in expected:
-        Path(tmp_path / f).touch()
-
-    assert _sanitize_field_filenames(input_, tmp_path) == expected
+def test_sanitize_field_filenames_glob(input_, expected):
+    assert _sanitize_field_filenames(input_) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -1092,6 +1092,25 @@ def test_fieldset_frompop(mode):
     pset.execute(AdvectionRK4, runtime=3, dt=1)
 
 
+@pytest.mark.parametrize(
+    "f",
+    [
+        pytest.param(lambda x: x, id="pathlib.Path"),
+        pytest.param(lambda x: str(x), id="str"),
+    ],
+)
+def test_fieldset_from_netcdf_path_type(f):
+    filenames = {
+        "lon": f(TEST_DATA / "mask_nemo_cross_180lon.nc"),
+        "lat": f(TEST_DATA / "mask_nemo_cross_180lon.nc"),
+        "data": f(TEST_DATA / "Uu_eastward_nemo_cross_180lon.nc"),
+    }
+    variable = "U"
+    dimensions = {"lon": "glamf", "lat": "gphif"}
+
+    Field.from_netcdf(filenames, variable, dimensions, interp_method="cgrid_velocity")
+
+
 def test_fieldset_from_data_gridtypes():
     """Simple test for fieldset initialisation from data."""
     xdim, ydim, zdim = 20, 10, 4

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -4,7 +4,6 @@ import os
 import sys
 from datetime import timedelta
 
-import cftime
 import dask
 import dask.array as da
 import numpy as np
@@ -29,8 +28,6 @@ from parcels.tools.converters import (
     GeographicPolar,
     TimeConverter,
     UnitConverter,
-    _get_cftime_calendars,
-    _get_cftime_datetimes,
 )
 from tests.common_kernels import DoNothing
 from tests.utils import TEST_DATA
@@ -61,6 +58,7 @@ def test_fieldset_from_data(xdim, ydim):
     """Simple test for fieldset initialisation from data."""
     data, dimensions = generate_fieldset_data(xdim, ydim)
     fieldset = FieldSet.from_data(data, dimensions)
+    assert fieldset.U._creation_log == "from_data"
     assert len(fieldset.U.data.shape) == 3
     assert len(fieldset.V.data.shape) == 3
     assert np.allclose(fieldset.U.data[0, :], data["U"], rtol=1e-12)
@@ -137,65 +135,6 @@ def test_fieldset_from_parcels(xdim, ydim, tmpdir):
     assert len(fieldset.V.data.shape) == 3
     assert np.allclose(fieldset.U.data[0, :], data["U"], rtol=1e-12)
     assert np.allclose(fieldset.V.data[0, :], data["V"], rtol=1e-12)
-
-
-def test_field_from_netcdf_variables():
-    filename = str(TEST_DATA / "perlinfieldsU.nc")
-    dims = {"lon": "x", "lat": "y"}
-
-    variable = "vozocrtx"
-    f1 = Field.from_netcdf(filename, variable, dims)
-    variable = ("U", "vozocrtx")
-    f2 = Field.from_netcdf(filename, variable, dims)
-    variable = {"U": "vozocrtx"}
-    f3 = Field.from_netcdf(filename, variable, dims)
-
-    assert np.allclose(f1.data, f2.data, atol=1e-12)
-    assert np.allclose(f1.data, f3.data, atol=1e-12)
-
-    with pytest.raises(AssertionError):
-        variable = {"U": "vozocrtx", "nav_lat": "nav_lat"}  # multiple variables will fail
-        f3 = Field.from_netcdf(filename, variable, dims)
-
-
-@pytest.mark.parametrize(
-    "calendar, cftime_datetime", zip(_get_cftime_calendars(), _get_cftime_datetimes(), strict=True)
-)
-def test_fieldset_nonstandardtime(
-    calendar, cftime_datetime, tmpdir, filename="test_nonstandardtime.nc", xdim=4, ydim=6
-):
-    filepath = tmpdir.join(filename)
-    dates = [getattr(cftime, cftime_datetime)(1, m, 1) for m in range(1, 13)]
-    da = xr.DataArray(
-        np.random.rand(12, xdim, ydim), coords=[dates, range(xdim), range(ydim)], dims=["time", "lon", "lat"], name="U"
-    )
-    da.to_netcdf(str(filepath))
-
-    dims = {"lon": "lon", "lat": "lat", "time": "time"}
-    try:
-        field = Field.from_netcdf(filepath, "U", dims)
-    except NotImplementedError:
-        field = None
-
-    if field is not None:
-        assert field.grid.time_origin.calendar == calendar
-
-
-@pytest.mark.parametrize("with_timestamps", [True, False])
-def test_field_from_netcdf(with_timestamps):
-    filenames = {
-        "lon": str(TEST_DATA / "mask_nemo_cross_180lon.nc"),
-        "lat": str(TEST_DATA / "mask_nemo_cross_180lon.nc"),
-        "data": str(TEST_DATA / "Uu_eastward_nemo_cross_180lon.nc"),
-    }
-    variable = "U"
-    dimensions = {"lon": "glamf", "lat": "gphif"}
-    if with_timestamps:
-        timestamp_types = [[[2]], [[np.datetime64("2000-01-01")]]]
-        for timestamps in timestamp_types:
-            Field.from_netcdf(filenames, variable, dimensions, interp_method="cgrid_velocity", timestamps=timestamps)
-    else:
-        Field.from_netcdf(filenames, variable, dimensions, interp_method="cgrid_velocity")
 
 
 def test_fieldset_from_modulefile():

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -958,8 +958,7 @@ def test_fieldset_defer_loading_with_diff_time_origin(tmpdir, fail):
 
 @pytest.mark.parametrize("zdim", [2, 8])
 @pytest.mark.parametrize("scale_fac", [0.2, 4, 1])
-def test_fieldset_defer_loading_function(zdim, scale_fac, tmpdir):
-    filepath = tmpdir.join("test_parcels_defer_loading")
+def test_fieldset_defer_loading_function(zdim, scale_fac, tmp_path):
     data0, dims0 = generate_fieldset_data(3, 3, zdim, 10)
     data0["U"][:, 0, :, :] = (
         np.nan
@@ -967,9 +966,9 @@ def test_fieldset_defer_loading_function(zdim, scale_fac, tmpdir):
     dims0["time"] = np.arange(0, 10, 1) * 3600
     dims0["depth"] = np.arange(0, zdim, 1)
     fieldset_out = FieldSet.from_data(data0, dims0)
-    fieldset_out.write(filepath)
+    fieldset_out.write(tmp_path)
     fieldset = FieldSet.from_parcels(
-        filepath, chunksize={"time": ("time_counter", 1), "depth": ("depthu", 1), "lat": ("y", 2), "lon": ("x", 2)}
+        tmp_path, chunksize={"time": ("time_counter", 1), "depth": ("depthu", 1), "lat": ("y", 2), "lon": ("x", 2)}
     )
 
     # testing for combination of deferred-loaded and numpy Fields


### PR DESCRIPTION
Changes:
- Sanitize the `filenames` file object passed to `Field.from_netcdf` making clear the data format (results in `Field.from_netcdf` having support for `Path` objects contributing to #1706)
- Separate field tests into separate file `test_field.py`
- Ensuring filenames are converted to strings for downstream processing

