### PR TITLE
Ignore bot PRs in release notes

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
Config to ignore bot PRs in release notes

More info:
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes