### PR TITLE
remove duplicate cftime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
   "cftime",
   "numpy",
   "dask",
-  "cftime",
   "psutil",
   "netCDF4",
   "zarr",


### PR DESCRIPTION
Hi 👋 ,

Thank you for this great package. I just tried installing it with a new package manager ([pixi](https://pixi.sh/latest/)), which failed due to the duplicate `cftime` dependency.

Cheers,
Hauke