### PR TITLE
Deprecating curvilnear halo support

### DIFF
--- a/docs/examples/tutorial_periodic_boundaries.ipynb
+++ b/docs/examples/tutorial_periodic_boundaries.ipynb
@@ -42,7 +42,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In case of 'simple' models on an A-grid, the idea in Parcels is to do two things:\n",
+    "If you have a 'simple' `Rectilinear` A-grid, you can create periodic boundaries in Parcels in two steps:\n",
     "\n",
     "1. Extend the fieldset with a small 'halo'\n",
     "2. Add a periodic boundary kernel to the `.execute`\n"

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -694,53 +694,7 @@ class CurvilinearGrid(Grid):
         halosize : int
             size of the halo (in grid points). Default is 5 grid points
         """
-        if zonal:
-            lonshift = self.lon[:, -1] - 2 * self.lon[:, 0] + self.lon[:, 1]
-            if not np.allclose(self.lon[:, 1] - self.lon[:, 0], self.lon[:, -1] - self.lon[:, -2]):
-                warnings.warn(
-                    "The zonal halo is located at the east and west of current grid, "
-                    "with a dx = lon[1]-lon[0] between the last nodes of the original grid and the first ones of the halo. "
-                    "In your grid, lon[1]-lon[0] != lon[-1]-lon[-2]. Is the halo computed as you expect?",
-                    FieldSetWarning,
-                    stacklevel=2,
-                )
-            self._lon = np.concatenate(
-                (
-                    self.lon[:, -halosize:] - lonshift[:, np.newaxis],
-                    self.lon,
-                    self.lon[:, 0:halosize] + lonshift[:, np.newaxis],
-                ),
-                axis=len(self.lon.shape) - 1,
-            )
-            self._lat = np.concatenate(
-                (self.lat[:, -halosize:], self.lat, self.lat[:, 0:halosize]), axis=len(self.lat.shape) - 1
-            )
-            self._zonal_periodic = True
-            self._zonal_halo = halosize
-        if meridional:
-            if not np.allclose(self.lat[1, :] - self.lat[0, :], self.lat[-1, :] - self.lat[-2, :]):
-                warnings.warn(
-                    "The meridional halo is located at the north and south of current grid, "
-                    "with a dy = lat[1]-lat[0] between the last nodes of the original grid and the first ones of the halo. "
-                    "In your grid, lat[1]-lat[0] != lat[-1]-lat[-2]. Is the halo computed as you expect?",
-                    FieldSetWarning,
-                    stacklevel=2,
-                )
-            latshift = self.lat[-1, :] - 2 * self.lat[0, :] + self.lat[1, :]
-            self._lat = np.concatenate(
-                (
-                    self.lat[-halosize:, :] - latshift[np.newaxis, :],
-                    self.lat,
-                    self.lat[0:halosize, :] + latshift[np.newaxis, :],
-                ),
-                axis=len(self.lat.shape) - 2,
-            )
-            self._lon = np.concatenate(
-                (self.lon[-halosize:, :], self.lon, self.lon[0:halosize, :]), axis=len(self.lon.shape) - 2
-            )
-            self._meridional_halo = halosize
-        if isinstance(self, CurvilinearSGrid):
-            self._add_Sdepth_periodic_halo(zonal, meridional, halosize)
+        raise NotImplementedError("CurvilinearGrid does not support add_periodic_halo")
 
 
 class CurvilinearZGrid(CurvilinearGrid):

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -694,7 +694,7 @@ class CurvilinearGrid(Grid):
         halosize : int
             size of the halo (in grid points). Default is 5 grid points
         """
-        raise NotImplementedError("CurvilinearGrid does not support add_periodic_halo")
+        raise NotImplementedError("CurvilinearGrid does not support add_periodic_halo. See https://github.com/OceanParcels/Parcels/pull/1811")
 
 
 class CurvilinearZGrid(CurvilinearGrid):

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -694,7 +694,9 @@ class CurvilinearGrid(Grid):
         halosize : int
             size of the halo (in grid points). Default is 5 grid points
         """
-        raise NotImplementedError("CurvilinearGrid does not support add_periodic_halo. See https://github.com/OceanParcels/Parcels/pull/1811")
+        raise NotImplementedError(
+            "CurvilinearGrid does not support add_periodic_halo. See https://github.com/OceanParcels/Parcels/pull/1811"
+        )
 
 
 class CurvilinearZGrid(CurvilinearGrid):

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -565,7 +565,8 @@ def test_curv_fieldset_add_periodic_halo():
     dimensions = {"dx": {"lon": "glamu", "lat": "gphiu"}, "dy": {"lon": "glamu", "lat": "gphiu"}}
     fieldset = FieldSet.from_nemo(filenames, variables, dimensions)
 
-    fieldset.add_periodic_halo(zonal=3, meridional=2)
+    with pytest.raises(NotImplementedError):
+        fieldset.add_periodic_halo(zonal=3, meridional=2)
 
 
 @pytest.mark.parametrize("mesh", ["flat", "spherical"])


### PR DESCRIPTION
As reported in #1685, the `Field.add_periodic_halo()` method was quite buggy for Fields on Curvilinear Grids. In order to avoid users using broken code, perhaps better to deprecate the method? 