### PR TITLE
Harmonise Field dimensions order

### DIFF
--- a/parcels/application_kernels/advection.py
+++ b/parcels/application_kernels/advection.py
@@ -184,8 +184,8 @@ def AdvectionAnalytical(particle, fieldset, time):
         time_i = np.linspace(0, fieldset.U.grid.time[ti + 1] - fieldset.U.grid.time[ti], I_s)
         ds_t = min(ds_t, time_i[np.where(time - fieldset.U.grid.time[ti] < time_i)[0][0]])
 
-    xsi, eta, zeta, xi, yi, zi = fieldset.U._search_indices(
-        particle.lon, particle.lat, particle.depth, particle=particle
+    zeta, eta, xsi, zi, yi, xi = fieldset.U._search_indices(
+        -1, particle.depth, particle.lat, particle.lon, particle=particle
     )
     if withW:
         if abs(xsi - 1) < tol:

--- a/parcels/application_kernels/advection.py
+++ b/parcels/application_kernels/advection.py
@@ -232,10 +232,10 @@ def AdvectionAnalytical(particle, fieldset, time):
     else:
         dz = 1.0
 
-    c1 = fieldset.UV.dist(px[0], px[1], py[0], py[1], grid.mesh, np.dot(i_u.phi2D_lin(xsi, 0.0), py))
-    c2 = fieldset.UV.dist(px[1], px[2], py[1], py[2], grid.mesh, np.dot(i_u.phi2D_lin(1.0, eta), py))
-    c3 = fieldset.UV.dist(px[2], px[3], py[2], py[3], grid.mesh, np.dot(i_u.phi2D_lin(xsi, 1.0), py))
-    c4 = fieldset.UV.dist(px[3], px[0], py[3], py[0], grid.mesh, np.dot(i_u.phi2D_lin(0.0, eta), py))
+    c1 = fieldset.UV.dist(px[0], px[1], py[0], py[1], grid.mesh, np.dot(i_u.phi2D_lin(0.0, xsi), py))
+    c2 = fieldset.UV.dist(px[1], px[2], py[1], py[2], grid.mesh, np.dot(i_u.phi2D_lin(eta, 1.0), py))
+    c3 = fieldset.UV.dist(px[2], px[3], py[2], py[3], grid.mesh, np.dot(i_u.phi2D_lin(1.0, xsi), py))
+    c4 = fieldset.UV.dist(px[3], px[0], py[3], py[0], grid.mesh, np.dot(i_u.phi2D_lin(eta, 0.0), py))
     rad = np.pi / 180.0
     deg2m = 1852 * 60.0
     meshJac = (deg2m * deg2m * math.cos(rad * particle.lat)) if grid.mesh == "spherical" else 1

--- a/parcels/application_kernels/advection.py
+++ b/parcels/application_kernels/advection.py
@@ -239,7 +239,7 @@ def AdvectionAnalytical(particle, fieldset, time):
     rad = np.pi / 180.0
     deg2m = 1852 * 60.0
     meshJac = (deg2m * deg2m * math.cos(rad * particle.lat)) if grid.mesh == "spherical" else 1
-    dxdy = fieldset.UV.jacobian(xsi, eta, px, py) * meshJac
+    dxdy = fieldset.UV.jacobian(py, px, eta, xsi) * meshJac
 
     if withW:
         U0 = direction * fieldset.U.data[ti, zi + 1, yi + 1, xi] * c4 * dz

--- a/parcels/application_kernels/advection.py
+++ b/parcels/application_kernels/advection.py
@@ -232,10 +232,10 @@ def AdvectionAnalytical(particle, fieldset, time):
     else:
         dz = 1.0
 
-    c1 = fieldset.UV.dist(px[0], px[1], py[0], py[1], grid.mesh, np.dot(i_u.phi2D_lin(0.0, xsi), py))
-    c2 = fieldset.UV.dist(px[1], px[2], py[1], py[2], grid.mesh, np.dot(i_u.phi2D_lin(eta, 1.0), py))
-    c3 = fieldset.UV.dist(px[2], px[3], py[2], py[3], grid.mesh, np.dot(i_u.phi2D_lin(1.0, xsi), py))
-    c4 = fieldset.UV.dist(px[3], px[0], py[3], py[0], grid.mesh, np.dot(i_u.phi2D_lin(eta, 0.0), py))
+    c1 = fieldset.UV.dist(py[0], py[1], px[0], px[1], grid.mesh, np.dot(i_u.phi2D_lin(0.0, xsi), py))
+    c2 = fieldset.UV.dist(py[1], py[2], px[1], px[2], grid.mesh, np.dot(i_u.phi2D_lin(eta, 1.0), py))
+    c3 = fieldset.UV.dist(py[2], py[3], px[2], px[3], grid.mesh, np.dot(i_u.phi2D_lin(1.0, xsi), py))
+    c4 = fieldset.UV.dist(py[3], py[0], px[3], px[0], grid.mesh, np.dot(i_u.phi2D_lin(eta, 0.0), py))
     rad = np.pi / 180.0
     deg2m = 1852 * 60.0
     meshJac = (deg2m * deg2m * math.cos(rad * particle.lat)) if grid.mesh == "spherical" else 1

--- a/parcels/compilation/codegenerator.py
+++ b/parcels/compilation/codegenerator.py
@@ -834,7 +834,7 @@ class KernelGenerator(ast.NodeVisitor):
             statements_croco = [
                 c.Statement(f"float cs_w[] = {*Cs_w, }".replace("(", "{").replace(")", "}")),
                 c.Statement(
-                    f"{node.var} = croco_from_z_to_sigma(U, H, Zeta, {args[3]}, {args[2]}, {args[1]}, time, &particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], hc, &cs_w)"
+                    f"{node.var} = croco_from_z_to_sigma(time, {args[1]}, {args[2]}, {args[3]}, U, H, Zeta, &particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], hc, &cs_w)"
                 ),
             ]
             args = (args[0], node.var, args[2], args[3])
@@ -863,7 +863,7 @@ class KernelGenerator(ast.NodeVisitor):
             statements_croco = [
                 c.Statement(f"float cs_w[] = {*Cs_w, }".replace("(", "{").replace(")", "}")),
                 c.Statement(
-                    f"{node.var4} = croco_from_z_to_sigma(U, H, Zeta, {args[3]}, {args[2]}, {args[1]}, time, &particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], hc, &cs_w)"
+                    f"{node.var4} = croco_from_z_to_sigma(time, {args[1]}, {args[2]}, {args[3]}, U, H, Zeta, &particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], hc, &cs_w)"
                 ),
             ]
             args = (args[0], node.var4, args[2], args[3])

--- a/parcels/compilation/codegenerator.py
+++ b/parcels/compilation/codegenerator.py
@@ -834,7 +834,7 @@ class KernelGenerator(ast.NodeVisitor):
             statements_croco = [
                 c.Statement(f"float cs_w[] = {*Cs_w, }".replace("(", "{").replace(")", "}")),
                 c.Statement(
-                    f"{node.var} = croco_from_z_to_sigma(time, {args[1]}, {args[2]}, {args[3]}, U, H, Zeta, &particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], hc, &cs_w)"
+                    f"{node.var} = croco_from_z_to_sigma(time, {args[1]}, {args[2]}, {args[3]}, U, H, Zeta, &particles->ti[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->xi[pnum*ngrid], hc, &cs_w)"
                 ),
             ]
             args = (args[0], node.var, args[2], args[3])
@@ -863,7 +863,7 @@ class KernelGenerator(ast.NodeVisitor):
             statements_croco = [
                 c.Statement(f"float cs_w[] = {*Cs_w, }".replace("(", "{").replace(")", "}")),
                 c.Statement(
-                    f"{node.var4} = croco_from_z_to_sigma(time, {args[1]}, {args[2]}, {args[3]}, U, H, Zeta, &particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], hc, &cs_w)"
+                    f"{node.var4} = croco_from_z_to_sigma(time, {args[1]}, {args[2]}, {args[3]}, U, H, Zeta, &particles->ti[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->xi[pnum*ngrid], hc, &cs_w)"
                 ),
             ]
             args = (args[0], node.var4, args[2], args[3])

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1091,7 +1091,7 @@ class Field:
     def reconnect_bnd_indices(self, *args, **kwargs):
         return self._reconnect_bnd_indices(*args, **kwargs)
 
-    def _reconnect_bnd_indices(self, xi, yi, xdim, ydim, sphere_mesh):
+    def _reconnect_bnd_indices(self, yi, xi, ydim, xdim, sphere_mesh):
         if xi < 0:
             if sphere_mesh:
                 xi = xdim - 2
@@ -1108,7 +1108,7 @@ class Field:
             yi = ydim - 2
             if sphere_mesh:
                 xi = xdim - xi
-        return xi, yi
+        return yi, xi
 
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
     def search_indices_rectilinear(self, *args, **kwargs):
@@ -1266,7 +1266,7 @@ class Field:
                 yi -= 1
             elif eta > 1 + tol:
                 yi += 1
-            (xi, yi) = self._reconnect_bnd_indices(xi, yi, grid.xdim, grid.ydim, grid.mesh)
+            (yi, xi) = self._reconnect_bnd_indices(yi, xi, grid.ydim, grid.xdim, grid.mesh)
             it += 1
             if it > maxIterSearch:
                 print(f"Correct cell not found after {maxIterSearch} iterations")

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -645,7 +645,7 @@ class Field:
                 netcdf_engine,
                 gridindexingtype=gridindexingtype,
             ) as filebuffer:
-                lon, lat = filebuffer.lonlat
+                lat, lon = filebuffer.latlon
                 indices = filebuffer.indices
                 # Check if parcels_mesh has been explicitly set in file
                 if "parcels_mesh" in filebuffer.dataset.attrs:
@@ -969,8 +969,8 @@ class Field:
                 y_conv = Geographic() if self.grid.mesh == "spherical" else UnitConverter()
                 for y, (lat, dy) in enumerate(zip(self.grid.lat, np.gradient(self.grid.lat), strict=False)):
                     for x, (lon, dx) in enumerate(zip(self.grid.lon, np.gradient(self.grid.lon), strict=False)):
-                        self.grid.cell_edge_sizes["x"][y, x] = x_conv.to_source(dx, lon, lat, self.grid.depth[0])
-                        self.grid.cell_edge_sizes["y"][y, x] = y_conv.to_source(dy, lon, lat, self.grid.depth[0])
+                        self.grid.cell_edge_sizes["x"][y, x] = x_conv.to_source(dx, self.grid.depth[0], lat, lon)
+                        self.grid.cell_edge_sizes["y"][y, x] = y_conv.to_source(dy, self.grid.depth[0], lat, lon)
             else:
                 raise ValueError(
                     f"Field.cell_edge_sizes() not implemented for {self.grid._gtype} grids. "

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -2056,7 +2056,7 @@ class VectorField:
 
     def spatial_c_grid_interpolation3D_full(self, ti, z, y, x, time, particle=None):
         grid = self.U.grid
-        (xsi, eta, zet, xi, yi, zi) = self.U._search_indices(x, y, z, ti, time, particle=particle)
+        (xsi, eta, zeta, xi, yi, zi) = self.U._search_indices(x, y, z, ti, time, particle=particle)
 
         if grid._gtype in [GridType.RectilinearSGrid, GridType.RectilinearZGrid]:
             px = np.array([grid.lon[xi], grid.lon[xi + 1], grid.lon[xi + 1], grid.lon[xi]])
@@ -2109,10 +2109,10 @@ class VectorField:
         w0 = self.W.data[ti, zi, yi + 1, xi + 1]
         w1 = self.W.data[ti, zi + 1, yi + 1, xi + 1]
 
-        U0 = u0 * i_u.jacobian3D_lin_face(px, py, pz, 0, eta, zet, "zonal", grid.mesh)
-        U1 = u1 * i_u.jacobian3D_lin_face(px, py, pz, 1, eta, zet, "zonal", grid.mesh)
-        V0 = v0 * i_u.jacobian3D_lin_face(px, py, pz, xsi, 0, zet, "meridional", grid.mesh)
-        V1 = v1 * i_u.jacobian3D_lin_face(px, py, pz, xsi, 1, zet, "meridional", grid.mesh)
+        U0 = u0 * i_u.jacobian3D_lin_face(px, py, pz, 0, eta, zeta, "zonal", grid.mesh)
+        U1 = u1 * i_u.jacobian3D_lin_face(px, py, pz, 1, eta, zeta, "zonal", grid.mesh)
+        V0 = v0 * i_u.jacobian3D_lin_face(px, py, pz, xsi, 0, zeta, "meridional", grid.mesh)
+        V1 = v1 * i_u.jacobian3D_lin_face(px, py, pz, xsi, 1, zeta, "meridional", grid.mesh)
         W0 = w0 * i_u.jacobian3D_lin_face(px, py, pz, xsi, eta, 0, "vertical", grid.mesh)
         W1 = w1 * i_u.jacobian3D_lin_face(px, py, pz, xsi, eta, 1, "vertical", grid.mesh)
 
@@ -2231,23 +2231,23 @@ class VectorField:
         flux_w05 = flux_u0_halfz - flux_u1_halfz + flux_v0_halfz - flux_v1_halfz + flux_w0
 
         surf_u05 = i_u.jacobian3D_lin_face(px, py, pz, 0.5, 0.5, 0.5, "zonal", grid.mesh)
-        jac_u05 = i_u.jacobian3D_lin_face(px, py, pz, 0.5, eta, zet, "zonal", grid.mesh)
+        jac_u05 = i_u.jacobian3D_lin_face(px, py, pz, 0.5, eta, zeta, "zonal", grid.mesh)
         U05 = flux_u05 / surf_u05 * jac_u05
 
         surf_v05 = i_u.jacobian3D_lin_face(px, py, pz, 0.5, 0.5, 0.5, "meridional", grid.mesh)
-        jac_v05 = i_u.jacobian3D_lin_face(px, py, pz, xsi, 0.5, zet, "meridional", grid.mesh)
+        jac_v05 = i_u.jacobian3D_lin_face(px, py, pz, xsi, 0.5, zeta, "meridional", grid.mesh)
         V05 = flux_v05 / surf_v05 * jac_v05
 
         surf_w05 = i_u.jacobian3D_lin_face(px, py, pz, 0.5, 0.5, 0.5, "vertical", grid.mesh)
         jac_w05 = i_u.jacobian3D_lin_face(px, py, pz, xsi, eta, 0.5, "vertical", grid.mesh)
         W05 = flux_w05 / surf_w05 * jac_w05
 
-        jac = i_u.jacobian3D_lin(px, py, pz, xsi, eta, zet, grid.mesh)
+        jac = i_u.jacobian3D_lin(px, py, pz, xsi, eta, zeta, grid.mesh)
         dxsidt = i_u.interpolate(i_u.phi1D_quad, [U0, U05, U1], xsi) / jac
         detadt = i_u.interpolate(i_u.phi1D_quad, [V0, V05, V1], eta) / jac
-        dzetdt = i_u.interpolate(i_u.phi1D_quad, [W0, W05, W1], zet) / jac
+        dzetdt = i_u.interpolate(i_u.phi1D_quad, [W0, W05, W1], zeta) / jac
 
-        dphidxsi, dphideta, dphidzet = i_u.dphidxsi3D_lin(xsi, eta, zet)
+        dphidxsi, dphideta, dphidzet = i_u.dphidxsi3D_lin(xsi, eta, zeta)
 
         u = np.dot(dphidxsi, px) * dxsidt + np.dot(dphideta, px) * detadt + np.dot(dphidzet, px) * dzetdt
         v = np.dot(dphidxsi, py) * dxsidt + np.dot(dphideta, py) * detadt + np.dot(dphidzet, py) * dzetdt

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -2000,10 +2000,10 @@ class VectorField:
             px[1:] = np.where(-px[1:] + px[0] > 180, px[1:] + 360, px[1:])
         xx = (1 - xsi) * (1 - eta) * px[0] + xsi * (1 - eta) * px[1] + xsi * eta * px[2] + (1 - xsi) * eta * px[3]
         assert abs(xx - x) < 1e-4
-        c1 = self.dist(px[0], px[1], py[0], py[1], grid.mesh, np.dot(i_u.phi2D_lin(xsi, 0.0), py))
-        c2 = self.dist(px[1], px[2], py[1], py[2], grid.mesh, np.dot(i_u.phi2D_lin(1.0, eta), py))
-        c3 = self.dist(px[2], px[3], py[2], py[3], grid.mesh, np.dot(i_u.phi2D_lin(xsi, 1.0), py))
-        c4 = self.dist(px[3], px[0], py[3], py[0], grid.mesh, np.dot(i_u.phi2D_lin(0.0, eta), py))
+        c1 = self.dist(px[0], px[1], py[0], py[1], grid.mesh, np.dot(i_u.phi2D_lin(0.0, xsi), py))
+        c2 = self.dist(px[1], px[2], py[1], py[2], grid.mesh, np.dot(i_u.phi2D_lin(eta, 1.0), py))
+        c3 = self.dist(px[2], px[3], py[2], py[3], grid.mesh, np.dot(i_u.phi2D_lin(1.0, xsi), py))
+        c4 = self.dist(px[3], px[0], py[3], py[0], grid.mesh, np.dot(i_u.phi2D_lin(eta, 0.0), py))
         if grid.zdim == 1:
             if self.gridindexingtype == "nemo":
                 U0 = self.U.data[ti, yi + 1, xi] * c4
@@ -2247,7 +2247,7 @@ class VectorField:
         detadt = i_u.interpolate(i_u.phi1D_quad, [V0, V05, V1], eta) / jac
         dzetdt = i_u.interpolate(i_u.phi1D_quad, [W0, W05, W1], zeta) / jac
 
-        dphidxsi, dphideta, dphidzet = i_u.dphidxsi3D_lin(xsi, eta, zeta)
+        dphidxsi, dphideta, dphidzet = i_u.dphidxsi3D_lin(zeta, eta, xsi)
 
         u = np.dot(dphidxsi, px) * dxsidt + np.dot(dphideta, px) * detadt + np.dot(dphidzet, px) * dzetdt
         v = np.dot(dphidxsi, py) * dxsidt + np.dot(dphideta, py) * detadt + np.dot(dphidzet, py) * dzetdt

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1579,7 +1579,7 @@ class Field:
             value = self._spatial_interpolation(ti, z, y, x, self.grid.time[ti], particle=particle)
 
         if applyConversion:
-            return self.units.to_target(value, x, y, z)
+            return self.units.to_target(value, z, y, x)
         else:
             return value
 
@@ -1601,7 +1601,7 @@ class Field:
         return self._ccode_convert(*args, **kwargs)
 
     def _ccode_convert(self, _, z, y, x):
-        return self.units.ccode_to_target(x, y, z)
+        return self.units.ccode_to_target(z, y, x)
 
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
     def get_block_id(self, *args, **kwargs):
@@ -2285,7 +2285,7 @@ class VectorField:
             (u, v) = self.spatial_c_grid_interpolation2D(ti, z, y, x, time, particle=particle)
             w = self.W.eval(time, z, y, x, particle=particle, applyConversion=False)
             if applyConversion:
-                w = self.W.units.to_target(w, x, y, z)
+                w = self.W.units.to_target(w, z, y, x)
         return (u, v, w)
 
     def _is_land2D(self, di, yi, xi):
@@ -2406,12 +2406,12 @@ class VectorField:
             u = self.U.eval(time, z, y, x, particle=particle, applyConversion=False)
             v = self.V.eval(time, z, y, x, particle=particle, applyConversion=False)
             if applyConversion:
-                u = self.U.units.to_target(u, x, y, z)
-                v = self.V.units.to_target(v, x, y, z)
+                u = self.U.units.to_target(u, z, y, x)
+                v = self.V.units.to_target(v, z, y, x)
             if "3D" in self.vector_type:
                 w = self.W.eval(time, z, y, x, particle=particle, applyConversion=False)
                 if applyConversion:
-                    w = self.W.units.to_target(w, x, y, z)
+                    w = self.W.units.to_target(w, z, y, x)
                 return (u, v, w)
             else:
                 return (u, v)

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1965,7 +1965,7 @@ class VectorField:
             and np.allclose(grid1.time_full, grid2.time_full)
         )
 
-    def dist(self, lon1: float, lon2: float, lat1: float, lat2: float, mesh: Mesh, lat: float):
+    def dist(self, lat1: float, lat2: float, lon1: float, lon2: float, mesh: Mesh, lat: float):
         if mesh == "spherical":
             rad = np.pi / 180.0
             deg2m = 1852 * 60.0
@@ -2002,10 +2002,10 @@ class VectorField:
             px[1:] = np.where(-px[1:] + px[0] > 180, px[1:] + 360, px[1:])
         xx = (1 - xsi) * (1 - eta) * px[0] + xsi * (1 - eta) * px[1] + xsi * eta * px[2] + (1 - xsi) * eta * px[3]
         assert abs(xx - x) < 1e-4
-        c1 = self.dist(px[0], px[1], py[0], py[1], grid.mesh, np.dot(i_u.phi2D_lin(0.0, xsi), py))
-        c2 = self.dist(px[1], px[2], py[1], py[2], grid.mesh, np.dot(i_u.phi2D_lin(eta, 1.0), py))
-        c3 = self.dist(px[2], px[3], py[2], py[3], grid.mesh, np.dot(i_u.phi2D_lin(1.0, xsi), py))
-        c4 = self.dist(px[3], px[0], py[3], py[0], grid.mesh, np.dot(i_u.phi2D_lin(eta, 0.0), py))
+        c1 = self.dist(py[0], py[1], px[0], px[1], grid.mesh, np.dot(i_u.phi2D_lin(0.0, xsi), py))
+        c2 = self.dist(py[1], py[2], px[1], px[2], grid.mesh, np.dot(i_u.phi2D_lin(eta, 1.0), py))
+        c3 = self.dist(py[2], py[3], px[2], px[3], grid.mesh, np.dot(i_u.phi2D_lin(1.0, xsi), py))
+        c4 = self.dist(py[3], py[0], px[3], px[0], grid.mesh, np.dot(i_u.phi2D_lin(eta, 0.0), py))
         if grid.zdim == 1:
             if self.gridindexingtype == "nemo":
                 U0 = self.U.data[ti, yi + 1, xi] * c4

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1587,7 +1587,7 @@ class Field:
 
     def _ccode_eval(self, var, t, z, y, x):
         self._check_velocitysampling()
-        ccode_str = f"temporal_interpolation({x}, {y}, {z}, {t}, {self.ccode_name}, &particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], &{var}, {self.interp_method.upper()}, {self.gridindexingtype.upper()})"
+        ccode_str = f"temporal_interpolation({t}, {z}, {y}, {x}, {self.ccode_name}, &particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], &{var}, {self.interp_method.upper()}, {self.gridindexingtype.upper()})"
         return ccode_str
 
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
@@ -2475,13 +2475,13 @@ class VectorField:
         ccode_str = ""
         if "3D" in self.vector_type:
             ccode_str = (
-                f"temporal_interpolationUVW({x}, {y}, {z}, {t}, {U.ccode_name}, {V.ccode_name}, {W.ccode_name}, "
+                f"temporal_interpolationUVW({t}, {z}, {y}, {x}, {U.ccode_name}, {V.ccode_name}, {W.ccode_name}, "
                 + "&particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid],"
                 + f"&{varU}, &{varV}, &{varW}, {U.interp_method.upper()}, {U.gridindexingtype.upper()})"
             )
         else:
             ccode_str = (
-                f"temporal_interpolationUV({x}, {y}, {z}, {t}, {U.ccode_name}, {V.ccode_name}, "
+                f"temporal_interpolationUV({t}, {z}, {y}, {x}, {U.ccode_name}, {V.ccode_name}, "
                 + "&particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid],"
                 + f" &{varU}, &{varV}, {U.interp_method.upper()}, {U.gridindexingtype.upper()})"
             )

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1587,7 +1587,11 @@ class Field:
 
     def _ccode_eval(self, var, t, z, y, x):
         self._check_velocitysampling()
-        ccode_str = f"temporal_interpolation({t}, {z}, {y}, {x}, {self.ccode_name}, &particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid], &{var}, {self.interp_method.upper()}, {self.gridindexingtype.upper()})"
+        ccode_str = (
+            f"temporal_interpolation({t}, {z}, {y}, {x}, {self.ccode_name}, "
+            + "&particles->ti[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->xi[pnum*ngrid], "
+            + f"&{var}, {self.interp_method.upper()}, {self.gridindexingtype.upper()})"
+        )
         return ccode_str
 
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
@@ -2476,13 +2480,13 @@ class VectorField:
         if "3D" in self.vector_type:
             ccode_str = (
                 f"temporal_interpolationUVW({t}, {z}, {y}, {x}, {U.ccode_name}, {V.ccode_name}, {W.ccode_name}, "
-                + "&particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid],"
+                + "&particles->ti[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->xi[pnum*ngrid],"
                 + f"&{varU}, &{varV}, &{varW}, {U.interp_method.upper()}, {U.gridindexingtype.upper()})"
             )
         else:
             ccode_str = (
                 f"temporal_interpolationUV({t}, {z}, {y}, {x}, {U.ccode_name}, {V.ccode_name}, "
-                + "&particles->xi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->ti[pnum*ngrid],"
+                + "&particles->ti[pnum*ngrid], &particles->zi[pnum*ngrid], &particles->yi[pnum*ngrid], &particles->xi[pnum*ngrid],"
                 + f" &{varU}, &{varV}, {U.interp_method.upper()}, {U.gridindexingtype.upper()})"
             )
         return ccode_str

--- a/parcels/fieldfilebuffer.py
+++ b/parcels/fieldfilebuffer.py
@@ -92,7 +92,7 @@ class NetcdfFileBuffer(_FileBuffer):
         return name
 
     @property
-    def lonlat(self):
+    def latlon(self):
         lon = self.dataset[self.dimensions["lon"]]
         lat = self.dataset[self.dimensions["lat"]]
         if self.nolonlatindices and self.gridindexingtype not in ["croco"]:
@@ -141,7 +141,7 @@ class NetcdfFileBuffer(_FileBuffer):
             if rectilinear:
                 lon_subset = lon_subset[0, :]
                 lat_subset = lat_subset[:, 0]
-        return lon_subset, lat_subset
+        return lat_subset, lon_subset
 
     @property
     def depth(self):

--- a/parcels/include/index_search.h
+++ b/parcels/include/index_search.h
@@ -127,9 +127,10 @@ static inline StatusCode search_indices_vertical_z(type_coord z, int zdim, float
   return SUCCESS;
 }
 
-static inline StatusCode search_indices_vertical_s(type_coord z, int xdim, int ydim, int zdim, float *zvals,
-                                    int xi, int yi, int *zi, double xsi, double eta, double *zeta,
-                                    int z4d, int ti, int tdim, double time, double t0, double t1, int interp_method)
+static inline StatusCode search_indices_vertical_s(double time, type_coord z,
+                                                   int tdim, int zdim, int ydim, int xdim, float *zvals,
+                                                   int ti, int *zi, int yi, int xi, double *zeta, double eta, double xsi,
+                                                   int z4d, double t0, double t1, int interp_method)
 {
   if (interp_method == BGRID_VELOCITY || interp_method == BGRID_W_VELOCITY || interp_method == BGRID_TRACER){
     xsi = 1;
@@ -211,10 +212,11 @@ static inline void reconnect_bnd_indices(int *xi, int *yi, int xdim, int ydim, i
 }
 
 
-static inline StatusCode search_indices_rectilinear(type_coord x, type_coord y, type_coord z, CStructuredGrid *grid, GridType gtype,
-                                                   int *xi, int *yi, int *zi, double *xsi, double *eta, double *zeta,
-                                                   int ti, double time, double t0, double t1, int interp_method,
-                                                   int gridindexingtype)
+static inline StatusCode search_indices_rectilinear(double time, type_coord z, type_coord y, type_coord x,
+                                                    CStructuredGrid *grid, GridType gtype,
+                                                    int ti, int *zi, int *yi, int *xi, double *zeta, double *eta, double *xsi,
+                                                    double t0, double t1, int interp_method,
+                                                    int gridindexingtype)
 {
   int xdim = grid->xdim;
   int ydim = grid->ydim;
@@ -294,9 +296,9 @@ static inline StatusCode search_indices_rectilinear(type_coord x, type_coord y, 
         status = search_indices_vertical_z(z, zdim, zvals, zi, zeta, gridindexingtype);
         break;
       case RECTILINEAR_S_GRID:
-        status = search_indices_vertical_s(z, xdim, ydim, zdim, zvals,
-                                        *xi, *yi, zi, *xsi, *eta, zeta,
-                                        z4d, ti, tdim, time, t0, t1, interp_method);
+        status = search_indices_vertical_s(time, z, tdim, zdim, ydim, xdim, zvals,
+                                           ti, zi, *yi, *xi, zeta, *eta, *xsi,
+                                           z4d, t0, t1, interp_method);
         break;
       default:
         status = ERRORINTERPOLATION;
@@ -321,10 +323,12 @@ static inline StatusCode search_indices_rectilinear(type_coord x, type_coord y, 
 }
 
 
-static inline StatusCode search_indices_curvilinear(type_coord x, type_coord y, type_coord z, CStructuredGrid *grid, GridType gtype,
-                                                   int *xi, int *yi, int *zi, double *xsi, double *eta, double *zeta,
-                                                   int ti, double time, double t0, double t1, int interp_method,
-                                                   int gridindexingtype)
+static inline StatusCode search_indices_curvilinear(double time, type_coord z, type_coord y, type_coord x,
+                                                    CStructuredGrid *grid, GridType gtype,
+                                                    int ti, int *zi, int *yi, int *xi,
+                                                    double *zeta, double *eta, double *xsi,
+                                                    double t0, double t1, int interp_method,
+                                                    int gridindexingtype)
 {
   int xi_old = *xi;
   int yi_old = *yi;
@@ -438,9 +442,9 @@ static inline StatusCode search_indices_curvilinear(type_coord x, type_coord y, 
         status = search_indices_vertical_z(z, zdim, zvals, zi, zeta, gridindexingtype);
         break;
       case CURVILINEAR_S_GRID:
-        status = search_indices_vertical_s(z, xdim, ydim, zdim, zvals,
-                                        *xi, *yi, zi, *xsi, *eta, zeta,
-                                        z4d, ti, tdim, time, t0, t1, interp_method);
+        status = search_indices_vertical_s(time, z, tdim, ydim, xdim, zdim, zvals,
+                                           ti, zi, *yi, *xi, zeta, *eta, *xsi,
+                                           z4d, t0, t1, interp_method);
         break;
       default:
         status = ERRORINTERPOLATION;
@@ -460,21 +464,23 @@ static inline StatusCode search_indices_curvilinear(type_coord x, type_coord y, 
 /* Local linear search to update grid index
  * params ti, sizeT, time. t0, t1 are only used for 4D S grids
  * */
-static inline StatusCode search_indices(type_coord x, type_coord y, type_coord z, CStructuredGrid *grid,
-                                       int *xi, int *yi, int *zi, double *xsi, double *eta, double *zeta,
-                                       GridType gtype, int ti, double time, double t0, double t1, int interp_method,
-                                       int gridindexingtype)
+static inline StatusCode search_indices(double time, type_coord z, type_coord y, type_coord x,
+                                        CStructuredGrid *grid,
+                                        int ti, int *zi, int *yi, int *xi,
+                                        double *zeta, double *eta, double *xsi,
+                                        GridType gtype, double t0, double t1, int interp_method,
+                                        int gridindexingtype)
 {
   switch(gtype){
     case RECTILINEAR_Z_GRID:
     case RECTILINEAR_S_GRID:
-      return search_indices_rectilinear(x, y, z, grid, gtype, xi, yi, zi, xsi, eta, zeta,
-                                   ti, time, t0, t1, interp_method, gridindexingtype);
+      return search_indices_rectilinear(time, z, y, x, grid, gtype, ti, zi, yi, xi, zeta, eta, xsi,
+                                        t0, t1, interp_method, gridindexingtype);
       break;
     case CURVILINEAR_Z_GRID:
     case CURVILINEAR_S_GRID:
-      return search_indices_curvilinear(x, y, z, grid, gtype, xi, yi, zi, xsi, eta, zeta,
-                                   ti, time, t0, t1, interp_method, gridindexingtype);
+      return search_indices_curvilinear(time, z, y, x, grid, gtype, ti, zi, yi, xi, zeta, eta, xsi,
+                                        t0, t1, interp_method, gridindexingtype);
       break;
     default:
       printf("Only RECTILINEAR_Z_GRID, RECTILINEAR_S_GRID, CURVILINEAR_Z_GRID and CURVILINEAR_S_GRID grids are currently implemented\n");

--- a/parcels/include/index_search.h
+++ b/parcels/include/index_search.h
@@ -185,7 +185,7 @@ static inline StatusCode search_indices_vertical_s(double time, type_coord z,
   return SUCCESS;
 }
 
-static inline void reconnect_bnd_indices(int *xi, int *yi, int xdim, int ydim, int onlyX, int sphere_mesh)
+static inline void reconnect_bnd_indices(int *yi, int *xi, int ydim, int xdim, int onlyX, int sphere_mesh)
 {
   if (*xi < 0){
     if (sphere_mesh)
@@ -263,7 +263,7 @@ static inline StatusCode search_indices_rectilinear(double time, type_coord z, t
         ++(*xi);
       else if (xvalsi > x)
         --(*xi);
-      reconnect_bnd_indices(xi, yi, xdim, ydim, 1, 1);
+      reconnect_bnd_indices(yi, xi, ydim, xdim, 1, 1);
       xvalsi = xvals[*xi];
       if (xvalsi < x - 225) xvalsi += 360;
       if (xvalsi > x + 225) xvalsi -= 360;
@@ -411,7 +411,7 @@ static inline StatusCode search_indices_curvilinear(double time, type_coord z, t
       (*yi)--;
     if (*eta > 1+tol)
       (*yi)++;
-    reconnect_bnd_indices(xi, yi, xdim, ydim, 0, sphere_mesh);
+    reconnect_bnd_indices(yi, xi, ydim, xdim, 0, sphere_mesh);
     it++;
     if ( it > maxIterSearch){
       printf("Correct cell not found for (%f, %f) after %d iterations\n", x, y, maxIterSearch);

--- a/parcels/include/index_search.h
+++ b/parcels/include/index_search.h
@@ -414,20 +414,20 @@ static inline StatusCode search_indices_curvilinear(double time, type_coord z, t
     reconnect_bnd_indices(yi, xi, ydim, xdim, 0, sphere_mesh);
     it++;
     if ( it > maxIterSearch){
-      printf("Correct cell not found for (%f, %f) after %d iterations\n", x, y, maxIterSearch);
+      printf("Correct cell not found for (lat, lon) = (%f, %f) after %d iterations\n", y, x, maxIterSearch);
       printf("Debug info: old particle indices: (yi, xi) %d %d\n", yi_old, xi_old);
       printf("            new particle indices: (yi, xi) %d %d\n", *yi, *xi);
       printf("            Mesh 2d shape:  %d %d\n", ydim, xdim);
-      printf("            Relative particle position:  (xsi, eta) %1.16e %1.16e\n", *xsi, *eta);
+      printf("            Relative particle position:  (eta, xsi) %1.16e %1.16e\n", *eta, *xsi);
       return ERROROUTOFBOUNDS;
     }
   }
   if ( (*xsi != *xsi) || (*eta != *eta) ){  // check if nan
-      printf("Correct cell not found for (%f, %f))\n", x, y);
+      printf("Correct cell not found for (lat, lon) = (%f, %f))\n", y, x);
       printf("Debug info: old particle indices: (yi, xi) %d %d\n", yi_old, xi_old);
       printf("            new particle indices: (yi, xi) %d %d\n", *yi, *xi);
       printf("            Mesh 2d shape:  %d %d\n", ydim, xdim);
-      printf("            Relative particle position:  (xsi, eta) %1.16e %1.16e\n", *xsi, *eta);
+      printf("            Relative particle position:  (eta, xsi) %1.16e %1.16e\n", *eta, *xsi);
       return ERROROUTOFBOUNDS;
   }
   if (*xsi < 0) *xsi = 0;

--- a/parcels/include/interpolation_utils.h
+++ b/parcels/include/interpolation_utils.h
@@ -86,7 +86,9 @@ static inline void dxdxsi3D_lin(double *pz, double *py, double *px, double zeta,
   }
 }
 
-static inline double jacobian3D_lin_face(double *px, double *py, double *pz, double xsi, double eta, double zeta, Orientation orientation, int sphere_mesh)
+static inline double jacobian3D_lin_face(double *pz, double *py, double *px,
+                                         double zeta, double eta, double xsi,
+                                         Orientation orientation, int sphere_mesh)
 {
   double jacM[9];
   dxdxsi3D_lin(pz, py, px, zeta, eta, xsi, jacM, sphere_mesh);
@@ -112,7 +114,9 @@ static inline double jacobian3D_lin_face(double *px, double *py, double *pz, dou
   return sqrt(j[0]*j[0]+j[1]*j[1]+j[2]*j[2]);
 }
 
-static inline double jacobian3D_lin(double *px, double *py, double *pz, double xsi, double eta, double zeta, int sphere_mesh)
+static inline double jacobian3D_lin(double *pz, double *py, double *px,
+                                    double zeta, double eta, double xsi,
+                                    int sphere_mesh)
 {
   double jacM[9];
   dxdxsi3D_lin(pz, py, px, zeta, eta, xsi, jacM, sphere_mesh);

--- a/parcels/include/interpolation_utils.h
+++ b/parcels/include/interpolation_utils.h
@@ -25,25 +25,25 @@ static inline void phi1D_quad(double xsi, double *phi)
 }
 
 
-static inline void dphidxsi3D_lin(double xsi, double eta, double zet, double *dphidxsi, double *dphideta, double *dphidzet)
+static inline void dphidxsi3D_lin(double xsi, double eta, double zeta, double *dphidxsi, double *dphideta, double *dphidzet)
 {
-  dphidxsi[0] = - (1-eta) * (1-zet);
-  dphidxsi[1] =   (1-eta) * (1-zet);
-  dphidxsi[2] =   (  eta) * (1-zet);
-  dphidxsi[3] = - (  eta) * (1-zet);
-  dphidxsi[4] = - (1-eta) * (  zet);
-  dphidxsi[5] =   (1-eta) * (  zet);
-  dphidxsi[6] =   (  eta) * (  zet);
-  dphidxsi[7] = - (  eta) * (  zet);
+  dphidxsi[0] = - (1-eta) * (1-zeta);
+  dphidxsi[1] =   (1-eta) * (1-zeta);
+  dphidxsi[2] =   (  eta) * (1-zeta);
+  dphidxsi[3] = - (  eta) * (1-zeta);
+  dphidxsi[4] = - (1-eta) * (  zeta);
+  dphidxsi[5] =   (1-eta) * (  zeta);
+  dphidxsi[6] =   (  eta) * (  zeta);
+  dphidxsi[7] = - (  eta) * (  zeta);
 
-  dphideta[0] = - (1-xsi) * (1-zet);
-  dphideta[1] = - (  xsi) * (1-zet);
-  dphideta[2] =   (  xsi) * (1-zet);
-  dphideta[3] =   (1-xsi) * (1-zet);
-  dphideta[4] = - (1-xsi) * (  zet);
-  dphideta[5] = - (  xsi) * (  zet);
-  dphideta[6] =   (  xsi) * (  zet);
-  dphideta[7] =   (1-xsi) * (  zet);
+  dphideta[0] = - (1-xsi) * (1-zeta);
+  dphideta[1] = - (  xsi) * (1-zeta);
+  dphideta[2] =   (  xsi) * (1-zeta);
+  dphideta[3] =   (1-xsi) * (1-zeta);
+  dphideta[4] = - (1-xsi) * (  zeta);
+  dphideta[5] = - (  xsi) * (  zeta);
+  dphideta[6] =   (  xsi) * (  zeta);
+  dphideta[7] =   (1-xsi) * (  zeta);
 
   dphidzet[0] = - (1-xsi) * (1-eta);
   dphidzet[1] = - (  xsi) * (1-eta);
@@ -55,10 +55,10 @@ static inline void dphidxsi3D_lin(double xsi, double eta, double zet, double *dp
   dphidzet[7] =   (1-xsi) * (  eta);
 }
 
-static inline void dxdxsi3D_lin(double *px, double *py, double *pz, double xsi, double eta, double zet, double *jacM, int sphere_mesh)
+static inline void dxdxsi3D_lin(double *px, double *py, double *pz, double xsi, double eta, double zeta, double *jacM, int sphere_mesh)
 {
   double dphidxsi[8], dphideta[8], dphidzet[8];
-  dphidxsi3D_lin(xsi, eta, zet, dphidxsi, dphideta, dphidzet);
+  dphidxsi3D_lin(xsi, eta, zeta, dphidxsi, dphideta, dphidzet);
 
   int i;
   for(i=0; i<9; ++i)
@@ -86,10 +86,10 @@ static inline void dxdxsi3D_lin(double *px, double *py, double *pz, double xsi, 
   }
 }
 
-static inline double jacobian3D_lin_face(double *px, double *py, double *pz, double xsi, double eta, double zet, Orientation orientation, int sphere_mesh)
+static inline double jacobian3D_lin_face(double *px, double *py, double *pz, double xsi, double eta, double zeta, Orientation orientation, int sphere_mesh)
 {
   double jacM[9];
-  dxdxsi3D_lin(px, py, pz, xsi, eta, zet, jacM, sphere_mesh);
+  dxdxsi3D_lin(px, py, pz, xsi, eta, zeta, jacM, sphere_mesh);
 
   double j[3];
 
@@ -112,10 +112,10 @@ static inline double jacobian3D_lin_face(double *px, double *py, double *pz, dou
   return sqrt(j[0]*j[0]+j[1]*j[1]+j[2]*j[2]);
 }
 
-static inline double jacobian3D_lin(double *px, double *py, double *pz, double xsi, double eta, double zet, int sphere_mesh)
+static inline double jacobian3D_lin(double *px, double *py, double *pz, double xsi, double eta, double zeta, int sphere_mesh)
 {
   double jacM[9];
-  dxdxsi3D_lin(px, py, pz, xsi, eta, zet, jacM, sphere_mesh);
+  dxdxsi3D_lin(px, py, pz, xsi, eta, zeta, jacM, sphere_mesh);
 
   double jac = jacM[3*0+0] * (jacM[3*1+1]*jacM[3*2+2] - jacM[3*2+1]*jacM[3*1+2])
              - jacM[3*0+1] * (jacM[3*1+0]*jacM[3*2+2] - jacM[3*2+0]*jacM[3*1+2])

--- a/parcels/include/interpolation_utils.h
+++ b/parcels/include/interpolation_utils.h
@@ -8,7 +8,7 @@ typedef enum
   } Orientation;
 
 
-static inline void phi2D_lin(double xsi, double eta, double *phi)
+static inline void phi2D_lin(double eta, double xsi, double *phi)
 {
     phi[0] = (1-xsi) * (1-eta);
     phi[1] =    xsi  * (1-eta);
@@ -25,7 +25,7 @@ static inline void phi1D_quad(double xsi, double *phi)
 }
 
 
-static inline void dphidxsi3D_lin(double xsi, double eta, double zeta, double *dphidxsi, double *dphideta, double *dphidzet)
+static inline void dphidxsi3D_lin(double zeta, double eta, double xsi, double *dphidzeta, double *dphideta, double *dphidxsi)
 {
   dphidxsi[0] = - (1-eta) * (1-zeta);
   dphidxsi[1] =   (1-eta) * (1-zeta);
@@ -45,20 +45,20 @@ static inline void dphidxsi3D_lin(double xsi, double eta, double zeta, double *d
   dphideta[6] =   (  xsi) * (  zeta);
   dphideta[7] =   (1-xsi) * (  zeta);
 
-  dphidzet[0] = - (1-xsi) * (1-eta);
-  dphidzet[1] = - (  xsi) * (1-eta);
-  dphidzet[2] = - (  xsi) * (  eta);
-  dphidzet[3] = - (1-xsi) * (  eta);
-  dphidzet[4] =   (1-xsi) * (1-eta);
-  dphidzet[5] =   (  xsi) * (1-eta);
-  dphidzet[6] =   (  xsi) * (  eta);
-  dphidzet[7] =   (1-xsi) * (  eta);
+  dphidzeta[0] = - (1-xsi) * (1-eta);
+  dphidzeta[1] = - (  xsi) * (1-eta);
+  dphidzeta[2] = - (  xsi) * (  eta);
+  dphidzeta[3] = - (1-xsi) * (  eta);
+  dphidzeta[4] =   (1-xsi) * (1-eta);
+  dphidzeta[5] =   (  xsi) * (1-eta);
+  dphidzeta[6] =   (  xsi) * (  eta);
+  dphidzeta[7] =   (1-xsi) * (  eta);
 }
 
-static inline void dxdxsi3D_lin(double *px, double *py, double *pz, double xsi, double eta, double zeta, double *jacM, int sphere_mesh)
+static inline void dxdxsi3D_lin(double *pz, double *py, double *px, double zeta, double eta, double xsi, double *jacM, int sphere_mesh)
 {
-  double dphidxsi[8], dphideta[8], dphidzet[8];
-  dphidxsi3D_lin(xsi, eta, zeta, dphidxsi, dphideta, dphidzet);
+  double dphidxsi[8], dphideta[8], dphidzeta[8];
+  dphidxsi3D_lin(zeta, eta, xsi, dphidzeta, dphideta, dphidxsi);
 
   int i;
   for(i=0; i<9; ++i)
@@ -76,20 +76,20 @@ static inline void dxdxsi3D_lin(double *px, double *py, double *pz, double xsi, 
   for(i=0; i<8; ++i){
     jacM[3*0+0] += px[i] * dphidxsi[i] * jac_lon; // dxdxsi
     jacM[3*0+1] += px[i] * dphideta[i] * jac_lon; // dxdeta
-    jacM[3*0+2] += px[i] * dphidzet[i] * jac_lon; // dxdzet
+    jacM[3*0+2] += px[i] * dphidzeta[i] * jac_lon; // dxdzeta
     jacM[3*1+0] += py[i] * dphidxsi[i] * jac_lat; // dydxsi
     jacM[3*1+1] += py[i] * dphideta[i] * jac_lat; // dydeta
-    jacM[3*1+2] += py[i] * dphidzet[i] * jac_lat; // dydzet
+    jacM[3*1+2] += py[i] * dphidzeta[i] * jac_lat; // dydzeta
     jacM[3*2+0] += pz[i] * dphidxsi[i];           // dzdxsi
     jacM[3*2+1] += pz[i] * dphideta[i];           // dzdeta
-    jacM[3*2+2] += pz[i] * dphidzet[i];           // dzdzet
+    jacM[3*2+2] += pz[i] * dphidzeta[i];           // dzdzeta
   }
 }
 
 static inline double jacobian3D_lin_face(double *px, double *py, double *pz, double xsi, double eta, double zeta, Orientation orientation, int sphere_mesh)
 {
   double jacM[9];
-  dxdxsi3D_lin(px, py, pz, xsi, eta, zeta, jacM, sphere_mesh);
+  dxdxsi3D_lin(pz, py, px, zeta, eta, xsi, jacM, sphere_mesh);
 
   double j[3];
 
@@ -115,7 +115,7 @@ static inline double jacobian3D_lin_face(double *px, double *py, double *pz, dou
 static inline double jacobian3D_lin(double *px, double *py, double *pz, double xsi, double eta, double zeta, int sphere_mesh)
 {
   double jacM[9];
-  dxdxsi3D_lin(px, py, pz, xsi, eta, zeta, jacM, sphere_mesh);
+  dxdxsi3D_lin(pz, py, px, zeta, eta, xsi, jacM, sphere_mesh);
 
   double jac = jacM[3*0+0] * (jacM[3*1+1]*jacM[3*2+2] - jacM[3*2+1]*jacM[3*1+2])
              - jacM[3*0+1] * (jacM[3*1+0]*jacM[3*2+2] - jacM[3*2+0]*jacM[3*1+2])

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -797,59 +797,59 @@ static inline StatusCode spatial_interpolation_UVW_c_grid(double zeta, double et
     }
   }
 
-  double U0 = u0 * jacobian3D_lin_face(px, py, pz, 0, eta, zeta, ZONAL, grid->sphere_mesh);
-  double U1 = u1 * jacobian3D_lin_face(px, py, pz, 1, eta, zeta, ZONAL, grid->sphere_mesh);
-  double V0 = v0 * jacobian3D_lin_face(px, py, pz, xsi, 0, zeta, MERIDIONAL, grid->sphere_mesh);
-  double V1 = v1 * jacobian3D_lin_face(px, py, pz, xsi, 1, zeta, MERIDIONAL, grid->sphere_mesh);
-  double W0 = w0 * jacobian3D_lin_face(px, py, pz, xsi, eta, 0, VERTICAL, grid->sphere_mesh);
-  double W1 = w1 * jacobian3D_lin_face(px, py, pz, xsi, eta, 1, VERTICAL, grid->sphere_mesh);
+  double U0 = u0 * jacobian3D_lin_face(pz, py, px, zeta, eta, 0, ZONAL, grid->sphere_mesh);
+  double U1 = u1 * jacobian3D_lin_face(pz, py, px, zeta, eta, 1, ZONAL, grid->sphere_mesh);
+  double V0 = v0 * jacobian3D_lin_face(pz, py, px, zeta, 0, xsi, MERIDIONAL, grid->sphere_mesh);
+  double V1 = v1 * jacobian3D_lin_face(pz, py, px, zeta, 1, xsi, MERIDIONAL, grid->sphere_mesh);
+  double W0 = w0 * jacobian3D_lin_face(pz, py, px, 0, eta, xsi, VERTICAL, grid->sphere_mesh);
+  double W1 = w1 * jacobian3D_lin_face(pz, py, px, 1, eta, xsi, VERTICAL, grid->sphere_mesh);
 
   // Computing fluxes in half left hexahedron -> flux_u05
   double xxu[8] = {px[0], (px[0]+px[1])/2, (px[2]+px[3])/2, px[3], px[4], (px[4]+px[5])/2, (px[6]+px[7])/2, px[7]};
   double yyu[8] = {py[0], (py[0]+py[1])/2, (py[2]+py[3])/2, py[3], py[4], (py[4]+py[5])/2, (py[6]+py[7])/2, py[7]};
   double zzu[8] = {pz[0], (pz[0]+pz[1])/2, (pz[2]+pz[3])/2, pz[3], pz[4], (pz[4]+pz[5])/2, (pz[6]+pz[7])/2, pz[7]};
-  double flux_u0 = u0 * jacobian3D_lin_face(xxu, yyu, zzu, 0, .5, .5, ZONAL, grid->sphere_mesh);
-  double flux_v0_halfx = v0 * jacobian3D_lin_face(xxu, yyu, zzu, .5, 0, .5, MERIDIONAL, grid->sphere_mesh);
-  double flux_v1_halfx = v1 * jacobian3D_lin_face(xxu, yyu, zzu, .5, 1, .5, MERIDIONAL, grid->sphere_mesh);
-  double flux_w0_halfx = w0 * jacobian3D_lin_face(xxu, yyu, zzu, .5, .5, 0, VERTICAL, grid->sphere_mesh);
-  double flux_w1_halfx = w1 * jacobian3D_lin_face(xxu, yyu, zzu, .5, .5, 1, VERTICAL, grid->sphere_mesh);
+  double flux_u0 = u0 * jacobian3D_lin_face(zzu, yyu, xxu, .5, .5, 0, ZONAL, grid->sphere_mesh);
+  double flux_v0_halfx = v0 * jacobian3D_lin_face(zzu, yyu, xxu, .5, 0, .5, MERIDIONAL, grid->sphere_mesh);
+  double flux_v1_halfx = v1 * jacobian3D_lin_face(zzu, yyu, xxu, .5, 1, .5, MERIDIONAL, grid->sphere_mesh);
+  double flux_w0_halfx = w0 * jacobian3D_lin_face(zzu, yyu, xxu, 0, .5, .5, VERTICAL, grid->sphere_mesh);
+  double flux_w1_halfx = w1 * jacobian3D_lin_face(zzu, yyu, xxu, 1, .5, .5, VERTICAL, grid->sphere_mesh);
   double flux_u05 = flux_u0 + flux_v0_halfx - flux_v1_halfx + flux_w0_halfx - flux_w1_halfx;
 
   // Computing fluxes in half front hexahedron -> flux_v05
   double xxv[8] = {px[0], px[1], (px[1]+px[2])/2, (px[0]+px[3])/2, px[4], px[5], (px[5]+px[6])/2, (px[4]+px[7])/2};
   double yyv[8] = {py[0], py[1], (py[1]+py[2])/2, (py[0]+py[3])/2, py[4], py[5], (py[5]+py[6])/2, (py[4]+py[7])/2};
   double zzv[8] = {pz[0], pz[1], (pz[1]+pz[2])/2, (pz[0]+pz[3])/2, pz[4], pz[5], (pz[5]+pz[6])/2, (pz[4]+pz[7])/2};
-  double flux_u0_halfy = u0 * jacobian3D_lin_face(xxv, yyv, zzv, 0, .5, .5, ZONAL, grid->sphere_mesh);
-  double flux_u1_halfy = u1 * jacobian3D_lin_face(xxv, yyv, zzv, 1, .5, .5, ZONAL, grid->sphere_mesh);
-  double flux_v0 = v0 * jacobian3D_lin_face(xxv, yyv, zzv, .5, 0, .5, MERIDIONAL, grid->sphere_mesh);
-  double flux_w0_halfy = w0 * jacobian3D_lin_face(xxv, yyv, zzv, .5, .5, 0, VERTICAL, grid->sphere_mesh);
-  double flux_w1_halfy = w1 * jacobian3D_lin_face(xxv, yyv, zzv, .5, .5, 1, VERTICAL, grid->sphere_mesh);
+  double flux_u0_halfy = u0 * jacobian3D_lin_face(zzv, yyv, xxv, .5, .5, 0, ZONAL, grid->sphere_mesh);
+  double flux_u1_halfy = u1 * jacobian3D_lin_face(zzv, yyv, xxv, .5, .5, 1, ZONAL, grid->sphere_mesh);
+  double flux_v0 = v0 * jacobian3D_lin_face(zzv, yyv, xxv, .5, 0, .5, MERIDIONAL, grid->sphere_mesh);
+  double flux_w0_halfy = w0 * jacobian3D_lin_face(zzv, yyv, xxv, 0, .5, .5, VERTICAL, grid->sphere_mesh);
+  double flux_w1_halfy = w1 * jacobian3D_lin_face(zzv, yyv, xxv, 1, .5, .5, VERTICAL, grid->sphere_mesh);
   double flux_v05 = flux_u0_halfy - flux_u1_halfy + flux_v0 + flux_w0_halfy - flux_w1_halfy;
 
   // Computing fluxes in half lower hexahedron -> flux_w05
   double xx[8] = {px[0], px[1], px[2], px[3], (px[0]+px[4])/2, (px[1]+px[5])/2, (px[2]+px[6])/2, (px[3]+px[7])/2};
   double yy[8] = {py[0], py[1], py[2], py[3], (py[0]+py[4])/2, (py[1]+py[5])/2, (py[2]+py[6])/2, (py[3]+py[7])/2};
   double zz[8] = {pz[0], pz[1], pz[2], pz[3], (pz[0]+pz[4])/2, (pz[1]+pz[5])/2, (pz[2]+pz[6])/2, (pz[3]+pz[7])/2};
-  double flux_u0_halfz = u0 * jacobian3D_lin_face(xx, yy, zz, 0, .5, .5, ZONAL, grid->sphere_mesh);
-  double flux_u1_halfz = u1 * jacobian3D_lin_face(xx, yy, zz, 1, .5, .5, ZONAL, grid->sphere_mesh);
-  double flux_v0_halfz = v0 * jacobian3D_lin_face(xx, yy, zz, .5, 0, .5, MERIDIONAL, grid->sphere_mesh);
-  double flux_v1_halfz = v1 * jacobian3D_lin_face(xx, yy, zz, .5, 1, .5, MERIDIONAL, grid->sphere_mesh);
-  double flux_w0 = w0 * jacobian3D_lin_face(xx, yy, zz, .5, .5, 0, VERTICAL, grid->sphere_mesh);
+  double flux_u0_halfz = u0 * jacobian3D_lin_face(zz, yy, xx, .5, .5, 0, ZONAL, grid->sphere_mesh);
+  double flux_u1_halfz = u1 * jacobian3D_lin_face(zz, yy, xx, .5, .5, 1, ZONAL, grid->sphere_mesh);
+  double flux_v0_halfz = v0 * jacobian3D_lin_face(zz, yy, xx, .5, 0, .5, MERIDIONAL, grid->sphere_mesh);
+  double flux_v1_halfz = v1 * jacobian3D_lin_face(zz, yy, xx, .5, 1, .5, MERIDIONAL, grid->sphere_mesh);
+  double flux_w0 = w0 * jacobian3D_lin_face(zz, yy, xx, 0, .5, .5, VERTICAL, grid->sphere_mesh);
   double flux_w05 = flux_u0_halfz - flux_u1_halfz + flux_v0_halfz - flux_v1_halfz + flux_w0;
 
-  double surf_u05 = jacobian3D_lin_face(px, py, pz, .5, .5, .5, ZONAL, grid->sphere_mesh);
-  double jac_u05 = jacobian3D_lin_face(px, py, pz, .5, eta, zeta, ZONAL, grid->sphere_mesh);
+  double surf_u05 = jacobian3D_lin_face(pz, py, px, .5, .5, .5, ZONAL, grid->sphere_mesh);
+  double jac_u05 = jacobian3D_lin_face(pz, py, px, zeta, eta, .5, ZONAL, grid->sphere_mesh);
   double U05 = flux_u05 / surf_u05 * jac_u05;
 
-  double surf_v05 = jacobian3D_lin_face(px, py, pz, .5, .5, .5, MERIDIONAL, grid->sphere_mesh);
-  double jac_v05 = jacobian3D_lin_face(px, py, pz, xsi, .5, zeta, MERIDIONAL, grid->sphere_mesh);
+  double surf_v05 = jacobian3D_lin_face(pz, py, px, .5, .5, .5, MERIDIONAL, grid->sphere_mesh);
+  double jac_v05 = jacobian3D_lin_face(pz, py, px, zeta, .5, xsi, MERIDIONAL, grid->sphere_mesh);
   double V05 = flux_v05 / surf_v05 * jac_v05;
 
-  double surf_w05 = jacobian3D_lin_face(px, py, pz, .5, .5, .5, VERTICAL, grid->sphere_mesh);
-  double jac_w05 = jacobian3D_lin_face(px, py, pz, xsi, eta, .5, VERTICAL, grid->sphere_mesh);
+  double surf_w05 = jacobian3D_lin_face(pz, py, px, .5, .5, .5, VERTICAL, grid->sphere_mesh);
+  double jac_w05 = jacobian3D_lin_face(pz, py, px, .5, eta, xsi, VERTICAL, grid->sphere_mesh);
   double W05 = flux_w05 / surf_w05 * jac_w05;
 
-  double jac = jacobian3D_lin(px, py, pz, xsi, eta, zeta, grid->sphere_mesh);
+  double jac = jacobian3D_lin(pz, py, px, zeta, eta, xsi, grid->sphere_mesh);
 
   double phi[3];
   phi1D_quad(xsi, phi);

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -434,9 +434,10 @@ static inline StatusCode getCell3D(CField *f, int xi, int yi, int zi, int ti, fl
 
 
 /* Linear interpolation along the time axis */
-static inline StatusCode temporal_interpolation_structured_grid(type_coord x, type_coord y, type_coord z, double time, CField *f,
-                                                               GridType gtype, int *xi, int *yi, int *zi, int *ti,
-                                                               float *value, int interp_method, int gridindexingtype)
+static inline StatusCode temporal_interpolation_structured_grid(double time, type_coord z, type_coord y, type_coord x,
+                                                                CField *f,
+                                                                GridType gtype, int *xi, int *yi, int *zi, int *ti,
+                                                                float *value, int interp_method, int gridindexingtype)
 {
   StatusCode status;
   CStructuredGrid *grid = f->grid->grid;
@@ -642,7 +643,8 @@ static inline StatusCode spatial_interpolation_UV_c_grid(double xsi, double eta,
 
 
 
-static inline StatusCode temporal_interpolationUV_c_grid(type_coord x, type_coord y, type_coord z, double time, CField *U, CField *V,
+static inline StatusCode temporal_interpolationUV_c_grid(double time, type_coord z, type_coord y, type_coord x,
+                                                         CField *U, CField *V,
                                                          GridType gtype, int *xi, int *yi, int *zi, int *ti,
                                                          float *u, float *v, int gridindexingtype)
 {
@@ -860,9 +862,10 @@ static inline StatusCode spatial_interpolation_UVW_c_grid(double xsi, double eta
   return SUCCESS;
 }
 
-static inline StatusCode temporal_interpolationUVW_c_grid(type_coord x, type_coord y, type_coord z, double time, CField *U, CField *V, CField *W,
-                                                         GridType gtype, int *xi, int *yi, int *zi, int *ti,
-                                                         float *u, float *v, float *w, int gridindexingtype)
+static inline StatusCode temporal_interpolationUVW_c_grid(double time, type_coord z, type_coord y, type_coord x,
+                                                          CField *U, CField *V, CField *W,
+                                                          GridType gtype, int *xi, int *yi, int *zi, int *ti,
+                                                          float *u, float *v, float *w, int gridindexingtype)
 {
   StatusCode status;
   CStructuredGrid *grid = U->grid->grid;
@@ -1080,9 +1083,10 @@ static inline StatusCode calculate_slip_conditions_3D(double xsi, double eta, do
   return SUCCESS;
 }
 
-static inline StatusCode temporal_interpolation_slip(type_coord x, type_coord y, type_coord z, double time, CField *U, CField *V, CField *W,
-                                                         GridType gtype, int *xi, int *yi, int *zi, int *ti,
-                                                         float *u, float *v, float *w, int interp_method, int gridindexingtype, int withW)
+static inline StatusCode temporal_interpolation_slip(double time, type_coord z, type_coord y, type_coord x,
+                                                     CField *U, CField *V, CField *W,
+                                                     GridType gtype, int *xi, int *yi, int *zi, int *ti,
+                                                     float *u, float *v, float *w, int interp_method, int gridindexingtype, int withW)
 {
   StatusCode status;
   CStructuredGrid *grid = U->grid->grid;
@@ -1173,78 +1177,79 @@ static inline StatusCode temporal_interpolation_slip(type_coord x, type_coord y,
   return SUCCESS;
 }
 
-static inline StatusCode temporal_interpolation(type_coord x, type_coord y, type_coord z, double time, CField *f,
-                                               int *xi, int *yi, int *zi, int *ti,
-                                               float *value, int interp_method, int gridindexingtype)
+static inline StatusCode temporal_interpolation(double time, type_coord z, type_coord y, type_coord x,
+                                                CField *f,
+                                                int *xi, int *yi, int *zi, int *ti,
+                                                float *value, int interp_method, int gridindexingtype)
 {
   CGrid *_grid = f->grid;
   GridType gtype = _grid->gtype;
 
   if (gtype == RECTILINEAR_Z_GRID || gtype == RECTILINEAR_S_GRID || gtype == CURVILINEAR_Z_GRID || gtype == CURVILINEAR_S_GRID)
-    return temporal_interpolation_structured_grid(x, y, z, time, f, gtype, xi, yi, zi, ti, value, interp_method, gridindexingtype);
+    return temporal_interpolation_structured_grid(time, z, y, x, f, gtype, xi, yi, zi, ti, value, interp_method, gridindexingtype);
   else{
     printf("Only RECTILINEAR_Z_GRID, RECTILINEAR_S_GRID, CURVILINEAR_Z_GRID and CURVILINEAR_S_GRID grids are currently implemented\n");
     return ERROR;
   }
 }
 
-static inline StatusCode temporal_interpolationUV(type_coord x, type_coord y, type_coord z, double time,
-                                                 CField *U, CField *V,
-                                                 int *xi, int *yi, int *zi, int *ti,
-                                                 float *valueU, float *valueV, int interp_method, int gridindexingtype)
+static inline StatusCode temporal_interpolationUV(double time, type_coord z, type_coord y, type_coord x,
+                                                  CField *U, CField *V,
+                                                  int *xi, int *yi, int *zi, int *ti,
+                                                  float *valueU, float *valueV, int interp_method, int gridindexingtype)
 {
   StatusCode status;
   if (interp_method == CGRID_VELOCITY){
     CGrid *_grid = U->grid;
     GridType gtype = _grid->gtype;
-    status = temporal_interpolationUV_c_grid(x, y, z, time, U, V, gtype, xi, yi, zi, ti, valueU, valueV, gridindexingtype); CHECKSTATUS(status);
+    status = temporal_interpolationUV_c_grid(time, z, y, x, U, V, gtype, xi, yi, zi, ti, valueU, valueV, gridindexingtype); CHECKSTATUS(status);
     return SUCCESS;
   } else if ((interp_method == PARTIALSLIP) || (interp_method == FREESLIP)){
     CGrid *_grid = U->grid;
     CField *W = U;
     GridType gtype = _grid->gtype;
     int withW = 0;
-    status = temporal_interpolation_slip(x, y, z, time, U, V, W, gtype, xi, yi, zi, ti, valueU, valueV, 0, interp_method, gridindexingtype, withW); CHECKSTATUS(status);
+    status = temporal_interpolation_slip(time, z, y, x, U, V, W, gtype, xi, yi, zi, ti, valueU, valueV, 0, interp_method, gridindexingtype, withW); CHECKSTATUS(status);
     return SUCCESS;
   } else {
-    status = temporal_interpolation(x, y, z, time, U, xi, yi, zi, ti, valueU, interp_method, gridindexingtype); CHECKSTATUS(status);
-    status = temporal_interpolation(x, y, z, time, V, xi, yi, zi, ti, valueV, interp_method, gridindexingtype); CHECKSTATUS(status);
+    status = temporal_interpolation(time, z, y, x, U, xi, yi, zi, ti, valueU, interp_method, gridindexingtype); CHECKSTATUS(status);
+    status = temporal_interpolation(time, z, y, x, V, xi, yi, zi, ti, valueV, interp_method, gridindexingtype); CHECKSTATUS(status);
     return SUCCESS;
   }
 }
 
-static inline StatusCode temporal_interpolationUVW(type_coord x, type_coord y, type_coord z, double time,
-                                                  CField *U, CField *V, CField *W,
-                                                  int *xi, int *yi, int *zi, int *ti,
-                                                  float *valueU, float *valueV, float *valueW, int interp_method, int gridindexingtype)
+static inline StatusCode temporal_interpolationUVW(double time, type_coord z, type_coord y, type_coord x,
+                                                   CField *U, CField *V, CField *W,
+                                                   int *xi, int *yi, int *zi, int *ti,
+                                                   float *valueU, float *valueV, float *valueW, int interp_method, int gridindexingtype)
 {
   StatusCode status;
   if (interp_method == CGRID_VELOCITY){
     CGrid *_grid = U->grid;
     GridType gtype = _grid->gtype;
     if (gtype == RECTILINEAR_S_GRID || gtype == CURVILINEAR_S_GRID){
-      status = temporal_interpolationUVW_c_grid(x, y, z, time, U, V, W, gtype, xi, yi, zi, ti, valueU, valueV, valueW, gridindexingtype); CHECKSTATUS(status);
+      status = temporal_interpolationUVW_c_grid(time, z, y, x, U, V, W, gtype, xi, yi, zi, ti, valueU, valueV, valueW, gridindexingtype); CHECKSTATUS(status);
       return SUCCESS;
     }
   } else if ((interp_method == PARTIALSLIP) || (interp_method == FREESLIP)){
     CGrid *_grid = U->grid;
     GridType gtype = _grid->gtype;
     int withW = 1;
-    status = temporal_interpolation_slip(x, y, z, time, U, V, W, gtype, xi, yi, zi, ti, valueU, valueV, valueW, interp_method, gridindexingtype, withW); CHECKSTATUS(status);
+    status = temporal_interpolation_slip(time, z, y, x, U, V, W, gtype, xi, yi, zi, ti, valueU, valueV, valueW, interp_method, gridindexingtype, withW); CHECKSTATUS(status);
     return SUCCESS;
   }
-  status = temporal_interpolationUV(x, y, z, time, U, V, xi, yi, zi, ti, valueU, valueV, interp_method, gridindexingtype); CHECKSTATUS(status);
+  status = temporal_interpolationUV(time, z, y, x, U, V, xi, yi, zi, ti, valueU, valueV, interp_method, gridindexingtype); CHECKSTATUS(status);
   if (interp_method == BGRID_VELOCITY)
     interp_method = BGRID_W_VELOCITY;
   if (gridindexingtype == CROCO)  // Linear vertical interpolation for CROCO
     interp_method = LINEAR;
-  status = temporal_interpolation(x, y, z, time, W, xi, yi, zi, ti, valueW, interp_method, gridindexingtype); CHECKSTATUS(status);
+  status = temporal_interpolation(time, z, y, x, W, xi, yi, zi, ti, valueW, interp_method, gridindexingtype); CHECKSTATUS(status);
   return SUCCESS;
 }
 
 
-static inline double croco_from_z_to_sigma(CField *U, CField *H, CField *Zeta,
-                                           type_coord x, type_coord y, type_coord z, double time,
+static inline double croco_from_z_to_sigma(double time, type_coord z, type_coord y, type_coord x,
+                                           CField *U, CField *H, CField *Zeta,
                                            int *xi, int *yi, int *zi, int *ti, double hc, float *cs_w)
 {
   float local_h, local_zeta, z0;
@@ -1253,8 +1258,8 @@ static inline double croco_from_z_to_sigma(CField *U, CField *H, CField *Zeta,
   float *sigma_levels = grid->depth;
   int zdim = grid->zdim;
   float zvec[zdim];
-  status = temporal_interpolation(x, y, 0, time, H, xi, yi, zi, ti, &local_h, LINEAR, CROCO); CHECKSTATUS(status);
-  status = temporal_interpolation(x, y, 0, time, Zeta, xi, yi, zi, ti, &local_zeta, LINEAR, CROCO); CHECKSTATUS(status);
+  status = temporal_interpolation(time, 0, y, x, H, xi, yi, zi, ti, &local_h, LINEAR, CROCO); CHECKSTATUS(status);
+  status = temporal_interpolation(time, 0, y, x, Zeta, xi, yi, zi, ti, &local_zeta, LINEAR, CROCO); CHECKSTATUS(status);
   for (zii = 0; zii < zdim; zii++)  {
     z0 = hc*sigma_levels[zii] + (local_h - hc) *cs_w[zii];
     zvec[zii] = z0 + local_zeta * (1 + z0 / local_h);

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -24,7 +24,8 @@ typedef struct
 } CField;
 
 /* Bilinear interpolation routine for 2D grid */
-static inline StatusCode spatial_interpolation_bilinear(double xsi, double eta, float data[2][2], float *value)
+static inline StatusCode spatial_interpolation_bilinear(double eta, double xsi,
+                                                        float data[2][2], float *value)
 {
   *value = (1-xsi)*(1-eta) * data[0][0]
          +    xsi *(1-eta) * data[0][1]
@@ -34,7 +35,8 @@ static inline StatusCode spatial_interpolation_bilinear(double xsi, double eta, 
 }
 
 /* Bilinear interpolation routine for 2D grid for tracers with squared inverse distance weighting near land*/
-static inline StatusCode spatial_interpolation_bilinear_invdist_land(double xsi, double eta, float data[2][2], float *value)
+static inline StatusCode spatial_interpolation_bilinear_invdist_land(double eta, double xsi,
+                                                                     float data[2][2], float *value)
 {
   int i, j, k, l, nb_land = 0, land[2][2] = {{0}};
   float w_sum = 0.;
@@ -55,7 +57,7 @@ static inline StatusCode spatial_interpolation_bilinear_invdist_land(double xsi,
   }
   switch (nb_land) {
   case 0:  // no land, use usual routine
-    return spatial_interpolation_bilinear(xsi, eta, data, value);
+    return spatial_interpolation_bilinear(eta, xsi, data, value);
   case 3:  // single non-land point
     *value = data[k][l];
     return SUCCESS;
@@ -91,8 +93,8 @@ static inline StatusCode spatial_interpolation_bilinear_invdist_land(double xsi,
 }
 
 /* Trilinear interpolation routine for 3D grid */
-static inline StatusCode spatial_interpolation_trilinear(double xsi, double eta, double zeta,
-                                                        float data[2][2][2], float *value)
+static inline StatusCode spatial_interpolation_trilinear(double zeta, double eta, double xsi,
+                                                         float data[2][2][2], float *value)
 {
   float f0, f1;
   f0 = (1-xsi)*(1-eta) * data[0][0][0]
@@ -108,7 +110,7 @@ static inline StatusCode spatial_interpolation_trilinear(double xsi, double eta,
 }
 
 /* Trilinear interpolation routine for MOM surface 3D grid */
-static inline StatusCode spatial_interpolation_trilinear_surface(double xsi, double eta, double zeta,
+static inline StatusCode spatial_interpolation_trilinear_surface(double zeta, double eta, double xsi,
                                                                  float data[2][2][2], float *value)
 {
   float f1;
@@ -120,8 +122,8 @@ static inline StatusCode spatial_interpolation_trilinear_surface(double xsi, dou
   return SUCCESS;
 }
 
-static inline StatusCode spatial_interpolation_trilinear_bottom(double xsi, double eta, double zeta,
-                                                                 float data[2][2][2], float *value)
+static inline StatusCode spatial_interpolation_trilinear_bottom(double zeta, double eta, double xsi,
+                                                                float data[2][2][2], float *value)
 {
   float f1;
   f1 = (1-xsi)*(1-eta) * data[1][0][0]
@@ -133,7 +135,8 @@ static inline StatusCode spatial_interpolation_trilinear_bottom(double xsi, doub
 }
 
 /* Trilinear interpolation routine for 3D grid for tracers with squared inverse distance weighting near land*/
-static inline StatusCode spatial_interpolation_trilinear_invdist_land(double xsi, double eta, double zeta, float data[2][2][2], float *value)
+static inline StatusCode spatial_interpolation_trilinear_invdist_land(double zeta, double eta, double xsi,
+                                                                      float data[2][2][2], float *value)
 {
   int i, j, k, l, m, n, nb_land = 0, land[2][2][2] = {{{0}}};
   float w_sum = 0.;
@@ -157,7 +160,7 @@ static inline StatusCode spatial_interpolation_trilinear_invdist_land(double xsi
   }
   switch (nb_land) {
   case 0:  // no land, use usual routine
-    return spatial_interpolation_trilinear(xsi, eta, zeta, data, value);
+    return spatial_interpolation_trilinear(zeta, eta, xsi, data, value);
   case 7:  // single non-land point
     *value = data[l][m][n];
     return SUCCESS;
@@ -195,7 +198,7 @@ static inline StatusCode spatial_interpolation_trilinear_invdist_land(double xsi
 }
 
 /* Nearest neighbor interpolation routine for 2D grid */
-static inline StatusCode spatial_interpolation_nearest2D(double xsi, double eta,
+static inline StatusCode spatial_interpolation_nearest2D(double eta, double xsi,
                                                         float data[2][2], float *value)
 {
   /* Cast data array into data[lat][lon] as per NEMO convention */
@@ -207,31 +210,31 @@ static inline StatusCode spatial_interpolation_nearest2D(double xsi, double eta,
 }
 
 /* C grid interpolation routine for tracers on 2D grid */
-static inline StatusCode spatial_interpolation_tracer_bc_grid_2D(double _xsi, double _eta,
-								float data[2][2], float *value)
+static inline StatusCode spatial_interpolation_tracer_bc_grid_2D(double _eta, double _xsi,
+								                                                 float data[2][2], float *value)
 {
   *value = data[1][1];
   return SUCCESS;
 }
 
 /* C grid interpolation routine for tracers on 3D grid */
-static inline StatusCode spatial_interpolation_tracer_bc_grid_3D(double _xsi, double _eta, double _zeta,
-								float data[2][2][2], float *value)
+static inline StatusCode spatial_interpolation_tracer_bc_grid_3D(double _zeta, double _eta, double _xsi,
+								                                                 float data[2][2][2], float *value)
 {
   *value = data[0][1][1];
   return SUCCESS;
 }
 
-static inline StatusCode spatial_interpolation_tracer_bc_grid_bottom(double _xsi, double _eta, double _zeta,
-								float data[2][2][2], float *value)
+static inline StatusCode spatial_interpolation_tracer_bc_grid_bottom(double _zeta, double _eta, double _xsi,
+								                                                     float data[2][2][2], float *value)
 {
   *value = data[1][1][1];
   return SUCCESS;
 }
 
 /* Nearest neighbor interpolation routine for 3D grid */
-static inline StatusCode spatial_interpolation_nearest3D(double xsi, double eta, double zeta,
-                                                        float data[2][2][2], float *value)
+static inline StatusCode spatial_interpolation_nearest3D(double zeta, double eta, double xsi,
+                                                         float data[2][2][2], float *value)
 {
   int i, j, k;
   if (xsi < .5) {i = 0;} else {i = 1;}
@@ -436,7 +439,7 @@ static inline StatusCode getCell3D(CField *f, int xi, int yi, int zi, int ti, fl
 /* Linear interpolation along the time axis */
 static inline StatusCode temporal_interpolation_structured_grid(double time, type_coord z, type_coord y, type_coord x,
                                                                 CField *f,
-                                                                GridType gtype, int *xi, int *yi, int *zi, int *ti,
+                                                                GridType gtype, int *ti, int *zi, int *yi, int *xi,
                                                                 float *value, int interp_method, int gridindexingtype)
 {
   StatusCode status;
@@ -491,12 +494,12 @@ static inline StatusCode temporal_interpolation_structured_grid(double time, typ
   do {                                                                  \
     if (grid->zdim == 1) {                                              \
       for (int i = 0; i < tii; i++) {                                   \
-        status = fn_2d(xsi, eta, data2D[i], &val[i]);                   \
+        status = fn_2d(eta, xsi, data2D[i], &val[i]);                   \
         CHECKSTATUS(status);                                            \
       }                                                                 \
     } else {                                                            \
       for (int i = 0; i < tii; i++) {                                   \
-        status = fn_3d(xsi, eta, zeta, data3D[i], &val[i]);             \
+        status = fn_3d(zeta, eta, xsi, data3D[i], &val[i]);             \
         CHECKSTATUS(status);                                            \
       }                                                                 \
     }                                                                   \
@@ -564,8 +567,11 @@ static double dist(double lon1, double lon2, double lat1, double lat2, int spher
 }
 
 /* Linear interpolation routine for 2D C grid */
-static inline StatusCode spatial_interpolation_UV_c_grid(double xsi, double eta, int xi, int yi, CStructuredGrid *grid,
-                                                        GridType gtype, float dataU[2][2], float dataV[2][2], float *u, float *v)
+static inline StatusCode spatial_interpolation_UV_c_grid(double eta, double xsi,
+                                                         int yi, int xi,
+                                                         CStructuredGrid *grid, GridType gtype,
+                                                         float dataU[2][2], float dataV[2][2],
+                                                         float *u, float *v)
 {
   /* Cast data array into data[lat][lon] as per NEMO convention */
   int xdim = grid->xdim;
@@ -645,7 +651,7 @@ static inline StatusCode spatial_interpolation_UV_c_grid(double xsi, double eta,
 
 static inline StatusCode temporal_interpolationUV_c_grid(double time, type_coord z, type_coord y, type_coord x,
                                                          CField *U, CField *V,
-                                                         GridType gtype, int *xi, int *yi, int *zi, int *ti,
+                                                         GridType gtype, int *ti, int *zi, int *yi, int *xi,
                                                          float *u, float *v, int gridindexingtype)
 {
   StatusCode status;
@@ -676,8 +682,8 @@ static inline StatusCode temporal_interpolationUV_c_grid(double time, type_coord
         status = getCell2D(U, xi[igrid], yi[igrid]-1, ti[igrid], data2D_U, 0); CHECKSTATUS(status);
         status = getCell2D(V, xi[igrid]-1, yi[igrid], ti[igrid], data2D_V, 0); CHECKSTATUS(status);
       }
-      status = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gtype, data2D_U[0], data2D_V[0], &u0, &v0); CHECKSTATUS(status);
-      status = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gtype, data2D_U[1], data2D_V[1], &u1, &v1); CHECKSTATUS(status);
+      status = spatial_interpolation_UV_c_grid(eta, xsi, yi[igrid], xi[igrid], grid, gtype, data2D_U[0], data2D_V[0], &u0, &v0); CHECKSTATUS(status);
+      status = spatial_interpolation_UV_c_grid(eta, xsi, yi[igrid], xi[igrid], grid, gtype, data2D_U[1], data2D_V[1], &u1, &v1); CHECKSTATUS(status);
 
     } else {
       float data3D_U[2][2][2][2], data3D_V[2][2][2][2];
@@ -689,8 +695,8 @@ static inline StatusCode temporal_interpolationUV_c_grid(double time, type_coord
         status = getCell3D(U, xi[igrid], yi[igrid]-1, zi[igrid], ti[igrid], data3D_U, 0); CHECKSTATUS(status);
         status = getCell3D(V, xi[igrid]-1, yi[igrid], zi[igrid], ti[igrid], data3D_V, 0); CHECKSTATUS(status);
       }
-      status = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gtype, data3D_U[0][0], data3D_V[0][0], &u0, &v0); CHECKSTATUS(status);
-      status = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gtype, data3D_U[1][0], data3D_V[1][0], &u1, &v1); CHECKSTATUS(status);
+      status = spatial_interpolation_UV_c_grid(eta, xsi, yi[igrid], xi[igrid], grid, gtype, data3D_U[0][0], data3D_V[0][0], &u0, &v0); CHECKSTATUS(status);
+      status = spatial_interpolation_UV_c_grid(eta, xsi, yi[igrid], xi[igrid], grid, gtype, data3D_U[1][0], data3D_V[1][0], &u1, &v1); CHECKSTATUS(status);
     }
     *u = u0 + (u1 - u0) * (float)((time - t0) / (t1 - t0));
     *v = v0 + (v1 - v0) * (float)((time - t0) / (t1 - t0));
@@ -708,7 +714,7 @@ static inline StatusCode temporal_interpolationUV_c_grid(double time, type_coord
         status = getCell2D(U, xi[igrid], yi[igrid]-1, ti[igrid], data2D_U, 1); CHECKSTATUS(status);
         status = getCell2D(V, xi[igrid]-1, yi[igrid], ti[igrid], data2D_V, 1); CHECKSTATUS(status);
       }
-      status = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gtype, data2D_U[0], data2D_V[0], u, v); CHECKSTATUS(status);
+      status = spatial_interpolation_UV_c_grid(eta, xsi, yi[igrid], xi[igrid], grid, gtype, data2D_U[0], data2D_V[0], u, v); CHECKSTATUS(status);
     }
     else{
       float data3D_U[2][2][2][2], data3D_V[2][2][2][2];
@@ -720,15 +726,18 @@ static inline StatusCode temporal_interpolationUV_c_grid(double time, type_coord
         status = getCell3D(U, xi[igrid], yi[igrid]-1, zi[igrid], ti[igrid], data3D_U, 1); CHECKSTATUS(status);
         status = getCell3D(V, xi[igrid]-1, yi[igrid], zi[igrid], ti[igrid], data3D_V, 1); CHECKSTATUS(status);
       }
-      status = spatial_interpolation_UV_c_grid(xsi, eta, xi[igrid], yi[igrid], grid, gtype, data3D_U[0][0], data3D_V[0][0], u, v); CHECKSTATUS(status);
+      status = spatial_interpolation_UV_c_grid(eta, xsi, yi[igrid], xi[igrid], grid, gtype, data3D_U[0][0], data3D_V[0][0], u, v); CHECKSTATUS(status);
     }
     return SUCCESS;
   }
 }
 
 /* Quadratic interpolation routine for 3D C grid */
-static inline StatusCode spatial_interpolation_UVW_c_grid(double xsi, double eta, double zet, int xi, int yi, int zi, int ti, CStructuredGrid *grid,
-                                                        GridType gtype, float dataU[2][2][2], float dataV[2][2][2], float dataW[2][2][2], float *u, float *v, float *w, int gridindexingtype)
+static inline StatusCode spatial_interpolation_UVW_c_grid(double zeta, double eta, double xsi,
+                                                          int ti, int zi, int yi, int xi,
+                                                          CStructuredGrid *grid, GridType gtype,
+                                                          float dataU[2][2][2], float dataV[2][2][2], float dataW[2][2][2],
+                                                          float *u, float *v, float *w, int gridindexingtype)
 {
   /* Cast data array into data[lat][lon] as per NEMO convention */
   int xdim = grid->xdim;
@@ -787,10 +796,10 @@ static inline StatusCode spatial_interpolation_UVW_c_grid(double xsi, double eta
     }
   }
 
-  double U0 = u0 * jacobian3D_lin_face(px, py, pz, 0, eta, zet, ZONAL, grid->sphere_mesh);
-  double U1 = u1 * jacobian3D_lin_face(px, py, pz, 1, eta, zet, ZONAL, grid->sphere_mesh);
-  double V0 = v0 * jacobian3D_lin_face(px, py, pz, xsi, 0, zet, MERIDIONAL, grid->sphere_mesh);
-  double V1 = v1 * jacobian3D_lin_face(px, py, pz, xsi, 1, zet, MERIDIONAL, grid->sphere_mesh);
+  double U0 = u0 * jacobian3D_lin_face(px, py, pz, 0, eta, zeta, ZONAL, grid->sphere_mesh);
+  double U1 = u1 * jacobian3D_lin_face(px, py, pz, 1, eta, zeta, ZONAL, grid->sphere_mesh);
+  double V0 = v0 * jacobian3D_lin_face(px, py, pz, xsi, 0, zeta, MERIDIONAL, grid->sphere_mesh);
+  double V1 = v1 * jacobian3D_lin_face(px, py, pz, xsi, 1, zeta, MERIDIONAL, grid->sphere_mesh);
   double W0 = w0 * jacobian3D_lin_face(px, py, pz, xsi, eta, 0, VERTICAL, grid->sphere_mesh);
   double W1 = w1 * jacobian3D_lin_face(px, py, pz, xsi, eta, 1, VERTICAL, grid->sphere_mesh);
 
@@ -828,18 +837,18 @@ static inline StatusCode spatial_interpolation_UVW_c_grid(double xsi, double eta
   double flux_w05 = flux_u0_halfz - flux_u1_halfz + flux_v0_halfz - flux_v1_halfz + flux_w0;
 
   double surf_u05 = jacobian3D_lin_face(px, py, pz, .5, .5, .5, ZONAL, grid->sphere_mesh);
-  double jac_u05 = jacobian3D_lin_face(px, py, pz, .5, eta, zet, ZONAL, grid->sphere_mesh);
+  double jac_u05 = jacobian3D_lin_face(px, py, pz, .5, eta, zeta, ZONAL, grid->sphere_mesh);
   double U05 = flux_u05 / surf_u05 * jac_u05;
 
   double surf_v05 = jacobian3D_lin_face(px, py, pz, .5, .5, .5, MERIDIONAL, grid->sphere_mesh);
-  double jac_v05 = jacobian3D_lin_face(px, py, pz, xsi, .5, zet, MERIDIONAL, grid->sphere_mesh);
+  double jac_v05 = jacobian3D_lin_face(px, py, pz, xsi, .5, zeta, MERIDIONAL, grid->sphere_mesh);
   double V05 = flux_v05 / surf_v05 * jac_v05;
 
   double surf_w05 = jacobian3D_lin_face(px, py, pz, .5, .5, .5, VERTICAL, grid->sphere_mesh);
   double jac_w05 = jacobian3D_lin_face(px, py, pz, xsi, eta, .5, VERTICAL, grid->sphere_mesh);
   double W05 = flux_w05 / surf_w05 * jac_w05;
 
-  double jac = jacobian3D_lin(px, py, pz, xsi, eta, zet, grid->sphere_mesh);
+  double jac = jacobian3D_lin(px, py, pz, xsi, eta, zeta, grid->sphere_mesh);
 
   double phi[3];
   phi1D_quad(xsi, phi);
@@ -848,12 +857,12 @@ static inline StatusCode spatial_interpolation_UVW_c_grid(double xsi, double eta
   phi1D_quad(eta, phi);
   double vvec[3] = {V0, V05, V1};
   double detadt = dot_prod(phi, vvec, 3) / jac;
-  phi1D_quad(zet, phi);
+  phi1D_quad(zeta, phi);
   double wvec[3] = {W0, W05, W1};
   double dzetdt = dot_prod(phi, wvec, 3) / jac;
 
   double dphidxsi[8], dphideta[8], dphidzet[8];
-  dphidxsi3D_lin(xsi, eta, zet, dphidxsi, dphideta, dphidzet);
+  dphidxsi3D_lin(xsi, eta, zeta, dphidxsi, dphideta, dphidzet);
 
   *u = dot_prod(dphidxsi, px, 8) * dxsidt + dot_prod(dphideta, px, 8) * detadt + dot_prod(dphidzet, px, 8) * dzetdt;
   *v = dot_prod(dphidxsi, py, 8) * dxsidt + dot_prod(dphideta, py, 8) * detadt + dot_prod(dphidzet, py, 8) * dzetdt;
@@ -864,7 +873,7 @@ static inline StatusCode spatial_interpolation_UVW_c_grid(double xsi, double eta
 
 static inline StatusCode temporal_interpolationUVW_c_grid(double time, type_coord z, type_coord y, type_coord x,
                                                           CField *U, CField *V, CField *W,
-                                                          GridType gtype, int *xi, int *yi, int *zi, int *ti,
+                                                          GridType gtype, int *ti, int *zi, int *yi, int *xi,
                                                           float *u, float *v, float *w, int gridindexingtype)
 {
   StatusCode status;
@@ -877,7 +886,7 @@ static inline StatusCode temporal_interpolationUVW_c_grid(double time, type_coor
   }
   status = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic, grid->tfull_min, grid->tfull_max, grid->periods); CHECKSTATUS(status);
 
-  double xsi, eta, zet;
+  double xsi, eta, zeta;
   float data3D_U[2][2][2][2];
   float data3D_V[2][2][2][2];
   float data3D_W[2][2][2][2];
@@ -887,15 +896,15 @@ static inline StatusCode temporal_interpolationUVW_c_grid(double time, type_coor
     float u0, u1, v0, v1, w0, w1;
     double t0 = grid->time[ti[igrid]]; double t1 = grid->time[ti[igrid]+1];
     /* Identify grid cell to sample through local linear search */
-    status = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zet, gtype, ti[igrid], time, t0, t1, CGRID_VELOCITY, gridindexingtype); CHECKSTATUS(status);
+    status = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gtype, ti[igrid], time, t0, t1, CGRID_VELOCITY, gridindexingtype); CHECKSTATUS(status);
     status = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_U, 0); CHECKSTATUS(status);
     status = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_V, 0); CHECKSTATUS(status);
     status = getCell3D(W, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_W, 0); CHECKSTATUS(status);
     if (grid->zdim==1){
       return ERROR;
     } else {
-      status = spatial_interpolation_UVW_c_grid(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid],   grid, gtype, data3D_U[0], data3D_V[0], data3D_W[0], &u0, &v0, &w0, gridindexingtype); CHECKSTATUS(status);
-      status = spatial_interpolation_UVW_c_grid(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid]+1, grid, gtype, data3D_U[1], data3D_V[1], data3D_W[1], &u1, &v1, &w1, gridindexingtype); CHECKSTATUS(status);
+      status = spatial_interpolation_UVW_c_grid(zeta, eta, xsi, ti[igrid], zi[igrid], yi[igrid], xi[igrid],   grid, gtype, data3D_U[0], data3D_V[0], data3D_W[0], &u0, &v0, &w0, gridindexingtype); CHECKSTATUS(status);
+      status = spatial_interpolation_UVW_c_grid(zeta, eta, xsi, ti[igrid]+1, zi[igrid], yi[igrid], xi[igrid], grid, gtype, data3D_U[1], data3D_V[1], data3D_W[1], &u1, &v1, &w1, gridindexingtype); CHECKSTATUS(status);
     }
     *u = u0 + (u1 - u0) * (float)((time - t0) / (t1 - t0));
     *v = v0 + (v1 - v0) * (float)((time - t0) / (t1 - t0));
@@ -903,7 +912,7 @@ static inline StatusCode temporal_interpolationUVW_c_grid(double time, type_coor
     return SUCCESS;
   } else {
     double t0 = grid->time[ti[igrid]];
-    status = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zet, gtype, ti[igrid], t0, t0, t0+1, CGRID_VELOCITY, gridindexingtype); CHECKSTATUS(status);
+    status = search_indices(x, y, z, grid, &xi[igrid], &yi[igrid], &zi[igrid], &xsi, &eta, &zeta, gtype, ti[igrid], t0, t0, t0+1, CGRID_VELOCITY, gridindexingtype); CHECKSTATUS(status);
     status = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_U, 1); CHECKSTATUS(status);
     status = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_V, 1); CHECKSTATUS(status);
     status = getCell3D(W, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_W, 1); CHECKSTATUS(status);
@@ -911,14 +920,14 @@ static inline StatusCode temporal_interpolationUVW_c_grid(double time, type_coor
       return ERROR;
     }
     else{
-      status = spatial_interpolation_UVW_c_grid(xsi, eta, zet, xi[igrid], yi[igrid], zi[igrid], ti[igrid], grid, gtype, data3D_U[0], data3D_V[0], data3D_W[0], u, v, w, gridindexingtype); CHECKSTATUS(status);
+      status = spatial_interpolation_UVW_c_grid(zeta, eta, xsi, ti[igrid], zi[igrid], yi[igrid], xi[igrid], grid, gtype, data3D_U[0], data3D_V[0], data3D_W[0], u, v, w, gridindexingtype); CHECKSTATUS(status);
     }
     return SUCCESS;
   }
 }
 
-static inline StatusCode calculate_slip_conditions_2D(double xsi, double eta, float dataU[2][2],
-                                                      float dataV[2][2], float dataW[2][2],
+static inline StatusCode calculate_slip_conditions_2D(double eta, double xsi,
+                                                      float dataU[2][2], float dataV[2][2], float dataW[2][2],
                                                       float *u, float *v, float *w, int interp_method, int withW)
 {
       float f_u = 1, f_v = 1, f_w = 1;
@@ -987,8 +996,8 @@ static inline StatusCode calculate_slip_conditions_2D(double xsi, double eta, fl
   return SUCCESS;
 }
 
-static inline StatusCode calculate_slip_conditions_3D(double xsi, double eta, double zeta, float dataU[2][2][2],
-                                                      float dataV[2][2][2], float dataW[2][2][2],
+static inline StatusCode calculate_slip_conditions_3D(double zeta, double eta, double xsi,
+                                                      float dataU[2][2][2], float dataV[2][2][2], float dataW[2][2][2],
                                                       float *u, float *v, float *w, int interp_method, int withW)
 {
       float f_u = 1, f_v = 1, f_w = 1;
@@ -1085,7 +1094,7 @@ static inline StatusCode calculate_slip_conditions_3D(double xsi, double eta, do
 
 static inline StatusCode temporal_interpolation_slip(double time, type_coord z, type_coord y, type_coord x,
                                                      CField *U, CField *V, CField *W,
-                                                     GridType gtype, int *xi, int *yi, int *zi, int *ti,
+                                                     GridType gtype, int *ti, int *zi, int *yi, int *xi,
                                                      float *u, float *v, float *w, int interp_method, int gridindexingtype, int withW)
 {
   StatusCode status;
@@ -1111,33 +1120,33 @@ static inline StatusCode temporal_interpolation_slip(double time, type_coord z, 
       status = getCell2D(V, xi[igrid], yi[igrid], ti[igrid], data2D_V, 0); CHECKSTATUS(status);
       if (withW){
         status = getCell2D(W, xi[igrid], yi[igrid], ti[igrid], data2D_W, 0); CHECKSTATUS(status);
-        status = spatial_interpolation_bilinear(xsi, eta, data2D_W[0], &w0); CHECKSTATUS(status);
-        status = spatial_interpolation_bilinear(xsi, eta, data2D_W[1], &w1); CHECKSTATUS(status);
+        status = spatial_interpolation_bilinear(eta, xsi, data2D_W[0], &w0); CHECKSTATUS(status);
+        status = spatial_interpolation_bilinear(eta, xsi, data2D_W[1], &w1); CHECKSTATUS(status);
       }
 
-      status = spatial_interpolation_bilinear(xsi, eta, data2D_U[0], &u0); CHECKSTATUS(status);
-      status = spatial_interpolation_bilinear(xsi, eta, data2D_V[0], &v0); CHECKSTATUS(status);
-      status = calculate_slip_conditions_2D(xsi, eta, data2D_U[0], data2D_V[0], data2D_W[0], &u0, &v0, &w0, interp_method, withW); CHECKSTATUS(status);
+      status = spatial_interpolation_bilinear(eta, xsi, data2D_U[0], &u0); CHECKSTATUS(status);
+      status = spatial_interpolation_bilinear(eta, xsi, data2D_V[0], &v0); CHECKSTATUS(status);
+      status = calculate_slip_conditions_2D(eta, xsi, data2D_U[0], data2D_V[0], data2D_W[0], &u0, &v0, &w0, interp_method, withW); CHECKSTATUS(status);
 
-      status = spatial_interpolation_bilinear(xsi, eta, data2D_U[1], &u1); CHECKSTATUS(status);
-      status = spatial_interpolation_bilinear(xsi, eta, data2D_V[1], &v1); CHECKSTATUS(status);
-      status = calculate_slip_conditions_2D(xsi, eta, data2D_U[1], data2D_V[1], data2D_W[1], &u1, &v1, &w1, interp_method, withW); CHECKSTATUS(status);
+      status = spatial_interpolation_bilinear(eta, xsi, data2D_U[1], &u1); CHECKSTATUS(status);
+      status = spatial_interpolation_bilinear(eta, xsi, data2D_V[1], &v1); CHECKSTATUS(status);
+      status = calculate_slip_conditions_2D(eta, xsi, data2D_U[1], data2D_V[1], data2D_W[1], &u1, &v1, &w1, interp_method, withW); CHECKSTATUS(status);
     } else {
       float data3D_U[2][2][2][2], data3D_V[2][2][2][2], data3D_W[2][2][2][2];
       status = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_U, 0); CHECKSTATUS(status);
       status = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_V, 0); CHECKSTATUS(status);
       if (withW){
         status = getCell3D(W, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_W, 0); CHECKSTATUS(status);
-        status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D_W[0], &w0); CHECKSTATUS(status);
-        status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D_W[1], &w1); CHECKSTATUS(status);
+        status = spatial_interpolation_trilinear(zeta, eta, xsi, data3D_W[0], &w0); CHECKSTATUS(status);
+        status = spatial_interpolation_trilinear(zeta, eta, xsi, data3D_W[1], &w1); CHECKSTATUS(status);
       }
-      status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D_U[0], &u0); CHECKSTATUS(status);
-      status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D_V[0], &v0); CHECKSTATUS(status);
-      status = calculate_slip_conditions_3D(xsi, eta, zeta, data3D_U[0], data3D_V[0], data3D_W[0], &u0, &v0, &w0, interp_method, withW); CHECKSTATUS(status);
+      status = spatial_interpolation_trilinear(zeta, eta, xsi, data3D_U[0], &u0); CHECKSTATUS(status);
+      status = spatial_interpolation_trilinear(zeta, eta, xsi, data3D_V[0], &v0); CHECKSTATUS(status);
+      status = calculate_slip_conditions_3D(zeta, eta, xsi, data3D_U[0], data3D_V[0], data3D_W[0], &u0, &v0, &w0, interp_method, withW); CHECKSTATUS(status);
 
-      status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D_U[1], &u1); CHECKSTATUS(status);
-      status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D_V[1], &v1); CHECKSTATUS(status);
-      status = calculate_slip_conditions_3D(xsi, eta, zeta, data3D_U[1], data3D_V[1], data3D_W[1], &u1, &v1, &w1, interp_method, withW); CHECKSTATUS(status);
+      status = spatial_interpolation_trilinear(zeta, eta, xsi, data3D_U[1], &u1); CHECKSTATUS(status);
+      status = spatial_interpolation_trilinear(zeta, eta, xsi, data3D_V[1], &v1); CHECKSTATUS(status);
+      status = calculate_slip_conditions_3D(zeta, eta, xsi, data3D_U[1], data3D_V[1], data3D_W[1], &u1, &v1, &w1, interp_method, withW); CHECKSTATUS(status);
     }
     *u = u0 + (u1 - u0) * (float)((time - t0) / (t1 - t0));
     *v = v0 + (v1 - v0) * (float)((time - t0) / (t1 - t0));
@@ -1154,24 +1163,24 @@ static inline StatusCode temporal_interpolation_slip(double time, type_coord z, 
       status = getCell2D(V, xi[igrid], yi[igrid], ti[igrid], data2D_V, 1); CHECKSTATUS(status);
       if (withW){
         status = getCell2D(W, xi[igrid], yi[igrid], ti[igrid], data2D_W, 1); CHECKSTATUS(status);
-        status = spatial_interpolation_bilinear(xsi, eta, data2D_W[0], w); CHECKSTATUS(status);
+        status = spatial_interpolation_bilinear(eta, xsi, data2D_W[0], w); CHECKSTATUS(status);
       }
 
-      status = spatial_interpolation_bilinear(xsi, eta, data2D_U[0], u); CHECKSTATUS(status);
-      status = spatial_interpolation_bilinear(xsi, eta, data2D_V[0], v); CHECKSTATUS(status);
+      status = spatial_interpolation_bilinear(eta, xsi, data2D_U[0], u); CHECKSTATUS(status);
+      status = spatial_interpolation_bilinear(eta, xsi, data2D_V[0], v); CHECKSTATUS(status);
 
-      status = calculate_slip_conditions_2D(xsi, eta, data2D_U[0], data2D_V[0], data2D_W[0], u, v, w, interp_method, withW); CHECKSTATUS(status);
+      status = calculate_slip_conditions_2D(eta, xsi, data2D_U[0], data2D_V[0], data2D_W[0], u, v, w, interp_method, withW); CHECKSTATUS(status);
     } else {
       float data3D_U[2][2][2][2], data3D_V[2][2][2][2], data3D_W[2][2][2][2];
       status = getCell3D(U, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_U, 1); CHECKSTATUS(status);
       status = getCell3D(V, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_V, 1); CHECKSTATUS(status);
       if (withW){
         status = getCell3D(W, xi[igrid], yi[igrid], zi[igrid], ti[igrid], data3D_W, 1); CHECKSTATUS(status);
-        status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D_W[0], w); CHECKSTATUS(status);
+        status = spatial_interpolation_trilinear(zeta, eta, xsi, data3D_W[0], w); CHECKSTATUS(status);
       }
-      status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D_U[0], u); CHECKSTATUS(status);
-      status = spatial_interpolation_trilinear(xsi, eta, zeta, data3D_V[0], v); CHECKSTATUS(status);
-      status = calculate_slip_conditions_3D(xsi, eta, zeta, data3D_U[0], data3D_V[0], data3D_W[0], u, v, w, interp_method, withW); CHECKSTATUS(status);
+      status = spatial_interpolation_trilinear(zeta, eta, xsi, data3D_U[0], u); CHECKSTATUS(status);
+      status = spatial_interpolation_trilinear(zeta, eta, xsi, data3D_V[0], v); CHECKSTATUS(status);
+      status = calculate_slip_conditions_3D(zeta, eta, xsi, data3D_U[0], data3D_V[0], data3D_W[0], u, v, w, interp_method, withW); CHECKSTATUS(status);
     }
   }
   return SUCCESS;
@@ -1179,14 +1188,15 @@ static inline StatusCode temporal_interpolation_slip(double time, type_coord z, 
 
 static inline StatusCode temporal_interpolation(double time, type_coord z, type_coord y, type_coord x,
                                                 CField *f,
-                                                int *xi, int *yi, int *zi, int *ti,
+                                                int *ti, int *zi, int *yi, int *xi,
                                                 float *value, int interp_method, int gridindexingtype)
 {
   CGrid *_grid = f->grid;
   GridType gtype = _grid->gtype;
 
-  if (gtype == RECTILINEAR_Z_GRID || gtype == RECTILINEAR_S_GRID || gtype == CURVILINEAR_Z_GRID || gtype == CURVILINEAR_S_GRID)
-    return temporal_interpolation_structured_grid(time, z, y, x, f, gtype, xi, yi, zi, ti, value, interp_method, gridindexingtype);
+  if (gtype == RECTILINEAR_Z_GRID || gtype == RECTILINEAR_S_GRID || gtype == CURVILINEAR_Z_GRID || gtype == CURVILINEAR_S_GRID){
+    return temporal_interpolation_structured_grid(time, z, y, x, f, gtype, ti, zi, yi, xi, value, interp_method, gridindexingtype);
+  }
   else{
     printf("Only RECTILINEAR_Z_GRID, RECTILINEAR_S_GRID, CURVILINEAR_Z_GRID and CURVILINEAR_S_GRID grids are currently implemented\n");
     return ERROR;
@@ -1195,32 +1205,32 @@ static inline StatusCode temporal_interpolation(double time, type_coord z, type_
 
 static inline StatusCode temporal_interpolationUV(double time, type_coord z, type_coord y, type_coord x,
                                                   CField *U, CField *V,
-                                                  int *xi, int *yi, int *zi, int *ti,
+                                                  int *ti, int *zi, int *yi, int *xi,
                                                   float *valueU, float *valueV, int interp_method, int gridindexingtype)
 {
   StatusCode status;
   if (interp_method == CGRID_VELOCITY){
     CGrid *_grid = U->grid;
     GridType gtype = _grid->gtype;
-    status = temporal_interpolationUV_c_grid(time, z, y, x, U, V, gtype, xi, yi, zi, ti, valueU, valueV, gridindexingtype); CHECKSTATUS(status);
+    status = temporal_interpolationUV_c_grid(time, z, y, x, U, V, gtype, ti, zi, yi, xi, valueU, valueV, gridindexingtype); CHECKSTATUS(status);
     return SUCCESS;
   } else if ((interp_method == PARTIALSLIP) || (interp_method == FREESLIP)){
     CGrid *_grid = U->grid;
     CField *W = U;
     GridType gtype = _grid->gtype;
     int withW = 0;
-    status = temporal_interpolation_slip(time, z, y, x, U, V, W, gtype, xi, yi, zi, ti, valueU, valueV, 0, interp_method, gridindexingtype, withW); CHECKSTATUS(status);
+    status = temporal_interpolation_slip(time, z, y, x, U, V, W, gtype, ti, zi, yi, xi, valueU, valueV, 0, interp_method, gridindexingtype, withW); CHECKSTATUS(status);
     return SUCCESS;
   } else {
-    status = temporal_interpolation(time, z, y, x, U, xi, yi, zi, ti, valueU, interp_method, gridindexingtype); CHECKSTATUS(status);
-    status = temporal_interpolation(time, z, y, x, V, xi, yi, zi, ti, valueV, interp_method, gridindexingtype); CHECKSTATUS(status);
+    status = temporal_interpolation(time, z, y, x, U, ti, zi, yi, xi, valueU, interp_method, gridindexingtype); CHECKSTATUS(status);
+    status = temporal_interpolation(time, z, y, x, V, ti, zi, yi, xi, valueV, interp_method, gridindexingtype); CHECKSTATUS(status);
     return SUCCESS;
   }
 }
 
 static inline StatusCode temporal_interpolationUVW(double time, type_coord z, type_coord y, type_coord x,
                                                    CField *U, CField *V, CField *W,
-                                                   int *xi, int *yi, int *zi, int *ti,
+                                                   int *ti, int *zi, int *yi, int *xi,
                                                    float *valueU, float *valueV, float *valueW, int interp_method, int gridindexingtype)
 {
   StatusCode status;
@@ -1228,29 +1238,29 @@ static inline StatusCode temporal_interpolationUVW(double time, type_coord z, ty
     CGrid *_grid = U->grid;
     GridType gtype = _grid->gtype;
     if (gtype == RECTILINEAR_S_GRID || gtype == CURVILINEAR_S_GRID){
-      status = temporal_interpolationUVW_c_grid(time, z, y, x, U, V, W, gtype, xi, yi, zi, ti, valueU, valueV, valueW, gridindexingtype); CHECKSTATUS(status);
+      status = temporal_interpolationUVW_c_grid(time, z, y, x, U, V, W, gtype, ti, zi, yi, xi, valueU, valueV, valueW, gridindexingtype); CHECKSTATUS(status);
       return SUCCESS;
     }
   } else if ((interp_method == PARTIALSLIP) || (interp_method == FREESLIP)){
     CGrid *_grid = U->grid;
     GridType gtype = _grid->gtype;
     int withW = 1;
-    status = temporal_interpolation_slip(time, z, y, x, U, V, W, gtype, xi, yi, zi, ti, valueU, valueV, valueW, interp_method, gridindexingtype, withW); CHECKSTATUS(status);
+    status = temporal_interpolation_slip(time, z, y, x, U, V, W, gtype, ti, zi, yi, xi, valueU, valueV, valueW, interp_method, gridindexingtype, withW); CHECKSTATUS(status);
     return SUCCESS;
   }
-  status = temporal_interpolationUV(time, z, y, x, U, V, xi, yi, zi, ti, valueU, valueV, interp_method, gridindexingtype); CHECKSTATUS(status);
+  status = temporal_interpolationUV(time, z, y, x, U, V, ti, zi, yi, xi, valueU, valueV, interp_method, gridindexingtype); CHECKSTATUS(status);
   if (interp_method == BGRID_VELOCITY)
     interp_method = BGRID_W_VELOCITY;
   if (gridindexingtype == CROCO)  // Linear vertical interpolation for CROCO
     interp_method = LINEAR;
-  status = temporal_interpolation(time, z, y, x, W, xi, yi, zi, ti, valueW, interp_method, gridindexingtype); CHECKSTATUS(status);
+  status = temporal_interpolation(time, z, y, x, W, ti, zi, yi, xi, valueW, interp_method, gridindexingtype); CHECKSTATUS(status);
   return SUCCESS;
 }
 
 
 static inline double croco_from_z_to_sigma(double time, type_coord z, type_coord y, type_coord x,
                                            CField *U, CField *H, CField *Zeta,
-                                           int *xi, int *yi, int *zi, int *ti, double hc, float *cs_w)
+                                           int *ti, int *zi, int *yi, int *xi, double hc, float *cs_w)
 {
   float local_h, local_zeta, z0;
   int status, zii;
@@ -1258,8 +1268,8 @@ static inline double croco_from_z_to_sigma(double time, type_coord z, type_coord
   float *sigma_levels = grid->depth;
   int zdim = grid->zdim;
   float zvec[zdim];
-  status = temporal_interpolation(time, 0, y, x, H, xi, yi, zi, ti, &local_h, LINEAR, CROCO); CHECKSTATUS(status);
-  status = temporal_interpolation(time, 0, y, x, Zeta, xi, yi, zi, ti, &local_zeta, LINEAR, CROCO); CHECKSTATUS(status);
+  status = temporal_interpolation(time, 0, y, x, H, ti, zi, yi, xi, &local_h, LINEAR, CROCO); CHECKSTATUS(status);
+  status = temporal_interpolation(time, 0, y, x, Zeta, ti, zi, yi, xi, &local_zeta, LINEAR, CROCO); CHECKSTATUS(status);
   for (zii = 0; zii < zdim; zii++)  {
     z0 = hc*sigma_levels[zii] + (local_h - hc) *cs_w[zii];
     zvec[zii] = z0 + local_zeta * (1 + z0 / local_h);

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -603,13 +603,13 @@ static inline StatusCode spatial_interpolation_UV_c_grid(double eta, double xsi,
 
 
   double phi[4];
-  phi2D_lin(0., eta, phi);
+  phi2D_lin(eta, 0.,phi);
   double U0 = dataU[1][0] * dist(xgrid_loc[3], xgrid_loc[0], ygrid_loc[3], ygrid_loc[0], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
-  phi2D_lin(1., eta, phi);
+  phi2D_lin(eta, 1., phi);
   double U1 = dataU[1][1] * dist(xgrid_loc[1], xgrid_loc[2], ygrid_loc[1], ygrid_loc[2], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
-  phi2D_lin(xsi, 0., phi);
+  phi2D_lin(0., xsi, phi);
   double V0 = dataV[0][1] * dist(xgrid_loc[0], xgrid_loc[1], ygrid_loc[0], ygrid_loc[1], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
-  phi2D_lin(xsi, 1., phi);
+  phi2D_lin(1., xsi, phi);
   double V1 = dataV[1][1] * dist(xgrid_loc[2], xgrid_loc[3], ygrid_loc[2], ygrid_loc[3], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
   double U = (1-xsi) * U0 + xsi * U1;
   double V = (1-eta) * V0 + eta * V1;
@@ -629,7 +629,7 @@ static inline StatusCode spatial_interpolation_UV_c_grid(double eta, double xsi,
   if (grid->sphere_mesh == 1){
     double deg2m = 1852 * 60.;
     double rad = M_PI / 180.;
-    phi2D_lin(xsi, eta, phi);
+    phi2D_lin(eta, xsi, phi);
     double lat = dot_prod(phi, ygrid_loc, 4);
     meshJac = deg2m * deg2m * cos(rad * lat);
   }
@@ -861,12 +861,12 @@ static inline StatusCode spatial_interpolation_UVW_c_grid(double zeta, double et
   double wvec[3] = {W0, W05, W1};
   double dzetdt = dot_prod(phi, wvec, 3) / jac;
 
-  double dphidxsi[8], dphideta[8], dphidzet[8];
-  dphidxsi3D_lin(xsi, eta, zeta, dphidxsi, dphideta, dphidzet);
+  double dphidxsi[8], dphideta[8], dphidzeta[8];
+  dphidxsi3D_lin(zeta, eta, xsi, dphidzeta, dphideta, dphidxsi);
 
-  *u = dot_prod(dphidxsi, px, 8) * dxsidt + dot_prod(dphideta, px, 8) * detadt + dot_prod(dphidzet, px, 8) * dzetdt;
-  *v = dot_prod(dphidxsi, py, 8) * dxsidt + dot_prod(dphideta, py, 8) * detadt + dot_prod(dphidzet, py, 8) * dzetdt;
-  *w = dot_prod(dphidxsi, pz, 8) * dxsidt + dot_prod(dphideta, pz, 8) * detadt + dot_prod(dphidzet, pz, 8) * dzetdt;
+  *u = dot_prod(dphidxsi, px, 8) * dxsidt + dot_prod(dphideta, px, 8) * detadt + dot_prod(dphidzeta, px, 8) * dzetdt;
+  *v = dot_prod(dphidxsi, py, 8) * dxsidt + dot_prod(dphideta, py, 8) * detadt + dot_prod(dphidzeta, py, 8) * dzetdt;
+  *w = dot_prod(dphidxsi, pz, 8) * dxsidt + dot_prod(dphideta, pz, 8) * detadt + dot_prod(dphidzeta, pz, 8) * dzetdt;
 
   return SUCCESS;
 }

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -555,7 +555,7 @@ static inline StatusCode temporal_interpolation_structured_grid(double time, typ
 #undef INTERP
 }
 
-static double dist(double lon1, double lon2, double lat1, double lat2, int sphere_mesh, double lat)
+static double dist(double lat1, double lat2, double lon1, double lon2, int sphere_mesh, double lat)
 {
   if (sphere_mesh == 1){
     double rad = M_PI / 180.;
@@ -605,13 +605,13 @@ static inline StatusCode spatial_interpolation_UV_c_grid(double eta, double xsi,
 
   double phi[4];
   phi2D_lin(eta, 0.,phi);
-  double U0 = dataU[1][0] * dist(xgrid_loc[3], xgrid_loc[0], ygrid_loc[3], ygrid_loc[0], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
+  double U0 = dataU[1][0] * dist(ygrid_loc[3], ygrid_loc[0], xgrid_loc[3], xgrid_loc[0], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
   phi2D_lin(eta, 1., phi);
-  double U1 = dataU[1][1] * dist(xgrid_loc[1], xgrid_loc[2], ygrid_loc[1], ygrid_loc[2], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
+  double U1 = dataU[1][1] * dist(ygrid_loc[1], ygrid_loc[2], xgrid_loc[1], xgrid_loc[2], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
   phi2D_lin(0., xsi, phi);
-  double V0 = dataV[0][1] * dist(xgrid_loc[0], xgrid_loc[1], ygrid_loc[0], ygrid_loc[1], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
+  double V0 = dataV[0][1] * dist(ygrid_loc[0], ygrid_loc[1], xgrid_loc[0], xgrid_loc[1], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
   phi2D_lin(1., xsi, phi);
-  double V1 = dataV[1][1] * dist(xgrid_loc[2], xgrid_loc[3], ygrid_loc[2], ygrid_loc[3], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
+  double V1 = dataV[1][1] * dist(ygrid_loc[2], ygrid_loc[3], xgrid_loc[2], xgrid_loc[3], grid->sphere_mesh, dot_prod(phi, ygrid_loc, 4));
   double U = (1-xsi) * U0 + xsi * U1;
   double V = (1-eta) * V0 + eta * V1;
 

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -648,11 +648,11 @@ class Kernel(BaseKernel):
                 elif p.state == StatusCode.ErrorTimeExtrapolation:
                     raise TimeExtrapolationError(p.time)
                 elif p.state == StatusCode.ErrorOutOfBounds:
-                    raise FieldOutOfBoundError(p.lon, p.lat, p.depth)
+                    raise FieldOutOfBoundError(p.depth, p.lat, p.lon)
                 elif p.state == StatusCode.ErrorThroughSurface:
-                    raise FieldOutOfBoundSurfaceError(p.lon, p.lat, p.depth)
+                    raise FieldOutOfBoundSurfaceError(p.depth, p.lat, p.lon)
                 elif p.state == StatusCode.Error:
-                    raise FieldSamplingError(p.lon, p.lat, p.depth)
+                    raise FieldSamplingError(p.depth, p.lat, p.lon)
                 elif p.state == StatusCode.Delete:
                     pass
                 else:

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -700,7 +700,7 @@ class ParticleSet:
                     + xsi * eta * grid.lat[j + 1, i + 1]
                     + (1 - xsi) * eta * grid.lat[j + 1, i]
                 )
-            return list(lon), list(lat)
+            return list(lat), list(lon)
         else:
             raise NotImplementedError(f'Mode {mode} not implemented. Please use "monte carlo" algorithm instead.')
 
@@ -742,7 +742,7 @@ class ParticleSet:
             It is either np.float32 or np.float64. Default is np.float32 if fieldset.U.interp_method is 'linear'
             and np.float64 if the interpolation method is 'cgrid_velocity'
         """
-        lon, lat = cls._monte_carlo_sample(start_field, size, mode)
+        lat, lon = cls._monte_carlo_sample(start_field, size, mode)
 
         return cls(
             fieldset=fieldset,

--- a/parcels/tools/converters.py
+++ b/parcels/tools/converters.py
@@ -166,16 +166,16 @@ class UnitConverter:
     source_unit: str | None = None
     target_unit: str | None = None
 
-    def to_target(self, value, x, y, z):
+    def to_target(self, value, z, y, x):
         return value
 
-    def ccode_to_target(self, x, y, z):
+    def ccode_to_target(self, z, y, x):
         return "1.0"
 
-    def to_source(self, value, x, y, z):
+    def to_source(self, value, z, y, x):
         return value
 
-    def ccode_to_source(self, x, y, z):
+    def ccode_to_source(self, z, y, x):
         return "1.0"
 
 
@@ -185,16 +185,16 @@ class Geographic(UnitConverter):
     source_unit = "m"
     target_unit = "degree"
 
-    def to_target(self, value, x, y, z):
+    def to_target(self, value, z, y, x):
         return value / 1000.0 / 1.852 / 60.0
 
-    def to_source(self, value, x, y, z):
+    def to_source(self, value, z, y, x):
         return value * 1000.0 * 1.852 * 60.0
 
-    def ccode_to_target(self, x, y, z):
+    def ccode_to_target(self, z, y, x):
         return "(1.0 / (1000.0 * 1.852 * 60.0))"
 
-    def ccode_to_source(self, x, y, z):
+    def ccode_to_source(self, z, y, x):
         return "(1000.0 * 1.852 * 60.0)"
 
 
@@ -206,16 +206,16 @@ class GeographicPolar(UnitConverter):
     source_unit = "m"
     target_unit = "degree"
 
-    def to_target(self, value, x, y, z):
+    def to_target(self, value, z, y, x):
         return value / 1000.0 / 1.852 / 60.0 / cos(y * pi / 180)
 
-    def to_source(self, value, x, y, z):
+    def to_source(self, value, z, y, x):
         return value * 1000.0 * 1.852 * 60.0 * cos(y * pi / 180)
 
-    def ccode_to_target(self, x, y, z):
+    def ccode_to_target(self, z, y, x):
         return f"(1.0 / (1000. * 1.852 * 60. * cos({y} * M_PI / 180)))"
 
-    def ccode_to_source(self, x, y, z):
+    def ccode_to_source(self, z, y, x):
         return f"(1000. * 1.852 * 60. * cos({y} * M_PI / 180))"
 
 
@@ -225,16 +225,16 @@ class GeographicSquare(UnitConverter):
     source_unit = "m2"
     target_unit = "degree2"
 
-    def to_target(self, value, x, y, z):
+    def to_target(self, value, z, y, x):
         return value / pow(1000.0 * 1.852 * 60.0, 2)
 
-    def to_source(self, value, x, y, z):
+    def to_source(self, value, z, y, x):
         return value * pow(1000.0 * 1.852 * 60.0, 2)
 
-    def ccode_to_target(self, x, y, z):
+    def ccode_to_target(self, z, y, x):
         return "pow(1.0 / (1000.0 * 1.852 * 60.0), 2)"
 
-    def ccode_to_source(self, x, y, z):
+    def ccode_to_source(self, z, y, x):
         return "pow((1000.0 * 1.852 * 60.0), 2)"
 
 
@@ -246,16 +246,16 @@ class GeographicPolarSquare(UnitConverter):
     source_unit = "m2"
     target_unit = "degree2"
 
-    def to_target(self, value, x, y, z):
+    def to_target(self, value, z, y, x):
         return value / pow(1000.0 * 1.852 * 60.0 * cos(y * pi / 180), 2)
 
-    def to_source(self, value, x, y, z):
+    def to_source(self, value, z, y, x):
         return value * pow(1000.0 * 1.852 * 60.0 * cos(y * pi / 180), 2)
 
-    def ccode_to_target(self, x, y, z):
+    def ccode_to_target(self, z, y, x):
         return f"pow(1.0 / (1000. * 1.852 * 60. * cos({y} * M_PI / 180)), 2)"
 
-    def ccode_to_source(self, x, y, z):
+    def ccode_to_source(self, z, y, x):
         return f"pow((1000. * 1.852 * 60. * cos({y} * M_PI / 180)), 2)"
 
 

--- a/parcels/tools/interpolation_utils.py
+++ b/parcels/tools/interpolation_utils.py
@@ -32,36 +32,36 @@ def phi2D_lin(xsi: float, eta: float) -> list[float]:
     return phi
 
 
-def phi3D_lin(xsi: float, eta: float, zet: float) -> list[float]:
-    phi = [(1-xsi) * (1-eta) * (1-zet),
-              xsi  * (1-eta) * (1-zet),
-              xsi  *    eta  * (1-zet),
-           (1-xsi) *    eta  * (1-zet),
-           (1-xsi) * (1-eta) *    zet ,
-              xsi  * (1-eta) *    zet ,
-              xsi  *    eta  *    zet ,
-           (1-xsi) *    eta  *    zet ]
+def phi3D_lin(xsi: float, eta: float, zeta: float) -> list[float]:
+    phi = [(1-xsi) * (1-eta) * (1-zeta),
+              xsi  * (1-eta) * (1-zeta),
+              xsi  *    eta  * (1-zeta),
+           (1-xsi) *    eta  * (1-zeta),
+           (1-xsi) * (1-eta) *    zeta ,
+              xsi  * (1-eta) *    zeta ,
+              xsi  *    eta  *    zeta ,
+           (1-xsi) *    eta  *    zeta ]
 
     return phi
 
 
-def dphidxsi3D_lin(xsi: float, eta: float, zet: float) -> tuple[list[float], list[float], list[float]]:
-    dphidxsi = [ - (1-eta) * (1-zet),
-                   (1-eta) * (1-zet),
-                   (  eta) * (1-zet),
-                 - (  eta) * (1-zet),
-                 - (1-eta) * (  zet),
-                   (1-eta) * (  zet),
-                   (  eta) * (  zet),
-                 - (  eta) * (  zet)]
-    dphideta = [ - (1-xsi) * (1-zet),
-                 - (  xsi) * (1-zet),
-                   (  xsi) * (1-zet),
-                   (1-xsi) * (1-zet),
-                 - (1-xsi) * (  zet),
-                 - (  xsi) * (  zet),
-                   (  xsi) * (  zet),
-                   (1-xsi) * (  zet)]
+def dphidxsi3D_lin(xsi: float, eta: float, zeta: float) -> tuple[list[float], list[float], list[float]]:
+    dphidxsi = [ - (1-eta) * (1-zeta),
+                   (1-eta) * (1-zeta),
+                   (  eta) * (1-zeta),
+                 - (  eta) * (1-zeta),
+                 - (1-eta) * (  zeta),
+                   (1-eta) * (  zeta),
+                   (  eta) * (  zeta),
+                 - (  eta) * (  zeta)]
+    dphideta = [ - (1-xsi) * (1-zeta),
+                 - (  xsi) * (1-zeta),
+                   (  xsi) * (1-zeta),
+                   (1-xsi) * (1-zeta),
+                 - (1-xsi) * (  zeta),
+                 - (  xsi) * (  zeta),
+                   (  xsi) * (  zeta),
+                   (1-xsi) * (  zeta)]
     dphidzet = [ - (1-xsi) * (1-eta),
                  - (  xsi) * (1-eta),
                  - (  xsi) * (  eta),
@@ -75,9 +75,9 @@ def dphidxsi3D_lin(xsi: float, eta: float, zet: float) -> tuple[list[float], lis
 
 
 def dxdxsi3D_lin(
-    hexa_x: list[float], hexa_y: list[float], hexa_z: list[float], xsi: float, eta: float, zet: float, mesh: Mesh
+    hexa_x: list[float], hexa_y: list[float], hexa_z: list[float], xsi: float, eta: float, zeta: float, mesh: Mesh
 ) -> tuple[float, float, float, float, float, float, float, float, float]:
-    dphidxsi, dphideta, dphidzet = dphidxsi3D_lin(xsi, eta, zet)
+    dphidxsi, dphideta, dphidzet = dphidxsi3D_lin(xsi, eta, zeta)
 
     if mesh == 'spherical':
         deg2m = 1852 * 60.
@@ -106,9 +106,9 @@ def dxdxsi3D_lin(
 
 
 def jacobian3D_lin(
-    hexa_x: list[float], hexa_y: list[float], hexa_z: list[float], xsi: float, eta: float, zet: float, mesh: Mesh
+    hexa_x: list[float], hexa_y: list[float], hexa_z: list[float], xsi: float, eta: float, zeta: float, mesh: Mesh
 ) -> float:
-    dxdxsi, dxdeta, dxdzet, dydxsi, dydeta, dydzet, dzdxsi, dzdeta, dzdzet = dxdxsi3D_lin(hexa_x, hexa_y, hexa_z, xsi, eta, zet, mesh)
+    dxdxsi, dxdeta, dxdzet, dydxsi, dydeta, dydzet, dzdxsi, dzdeta, dzdzet = dxdxsi3D_lin(hexa_x, hexa_y, hexa_z, xsi, eta, zeta, mesh)
 
     jac = (
         dxdxsi * (dydeta * dzdzet - dzdeta * dydzet)
@@ -124,11 +124,11 @@ def jacobian3D_lin_face(
     hexa_z: list[float],
     xsi: float,
     eta: float,
-    zet: float,
+    zeta: float,
     orientation: Literal["zonal", "meridional", "vertical"],
     mesh: Mesh,
 ) -> float:
-    dxdxsi, dxdeta, dxdzet, dydxsi, dydeta, dydzet, dzdxsi, dzdeta, dzdzet = dxdxsi3D_lin(hexa_x, hexa_y, hexa_z, xsi, eta, zet, mesh)
+    dxdxsi, dxdeta, dxdzet, dydxsi, dydeta, dydzet, dzdxsi, dzdeta, dzdzet = dxdxsi3D_lin(hexa_x, hexa_y, hexa_z, xsi, eta, zeta, mesh)
 
     if orientation == 'zonal':
         j = [dydeta*dzdzet-dydzet*dzdeta,

--- a/parcels/tools/interpolation_utils.py
+++ b/parcels/tools/interpolation_utils.py
@@ -169,12 +169,6 @@ def jacobian2D_lin(quad_y, quad_x, eta: float, xsi: float):
     return jac
 
 
-def length2d_lin_edge(quad_x, quad_y, ids):
-    xe = [quad_x[ids[0]], quad_x[ids[1]]]
-    ye = [quad_y[ids[0]], quad_y[ids[1]]]
-    return np.sqrt((xe[1] - xe[0]) ** 2 + (ye[1] - ye[0]) ** 2)
-
-
 def interpolate(phi: Callable[[float], list[float]], f: list[float], xsi: float) -> float:
     return np.dot(phi(xsi), f)
 

--- a/parcels/tools/interpolation_utils.py
+++ b/parcels/tools/interpolation_utils.py
@@ -22,8 +22,7 @@ def phi1D_quad(xsi: float) -> list[float]:
     return phi
 
 
-
-def phi2D_lin(xsi: float, eta: float) -> list[float]:
+def phi2D_lin(eta: float, xsi: float) -> list[float]:
     phi = [(1-xsi) * (1-eta),
               xsi  * (1-eta),
               xsi  *    eta ,
@@ -32,7 +31,7 @@ def phi2D_lin(xsi: float, eta: float) -> list[float]:
     return phi
 
 
-def dphidxsi3D_lin(xsi: float, eta: float, zeta: float) -> tuple[list[float], list[float], list[float]]:
+def dphidxsi3D_lin(zeta: float, eta: float, xsi: float) -> tuple[list[float], list[float], list[float]]:
     dphidxsi = [ - (1-eta) * (1-zeta),
                    (1-eta) * (1-zeta),
                    (  eta) * (1-zeta),
@@ -62,9 +61,9 @@ def dphidxsi3D_lin(xsi: float, eta: float, zeta: float) -> tuple[list[float], li
 
 
 def dxdxsi3D_lin(
-    hexa_x: list[float], hexa_y: list[float], hexa_z: list[float], xsi: float, eta: float, zeta: float, mesh: Mesh
+    hexa_z: list[float], hexa_y: list[float], hexa_x: list[float], zeta: float, eta: float, xsi: float, mesh: Mesh
 ) -> tuple[float, float, float, float, float, float, float, float, float]:
-    dphidxsi, dphideta, dphidzet = dphidxsi3D_lin(xsi, eta, zeta)
+    dphidxsi, dphideta, dphidzet = dphidxsi3D_lin(zeta, eta, xsi)
 
     if mesh == 'spherical':
         deg2m = 1852 * 60.
@@ -95,7 +94,7 @@ def dxdxsi3D_lin(
 def jacobian3D_lin(
     hexa_x: list[float], hexa_y: list[float], hexa_z: list[float], xsi: float, eta: float, zeta: float, mesh: Mesh
 ) -> float:
-    dxdxsi, dxdeta, dxdzet, dydxsi, dydeta, dydzet, dzdxsi, dzdeta, dzdzet = dxdxsi3D_lin(hexa_x, hexa_y, hexa_z, xsi, eta, zeta, mesh)
+    dxdxsi, dxdeta, dxdzet, dydxsi, dydeta, dydzet, dzdxsi, dzdeta, dzdzet = dxdxsi3D_lin(hexa_z, hexa_y, hexa_x, zeta, eta, xsi, mesh)
 
     jac = (
         dxdxsi * (dydeta * dzdzet - dzdeta * dydzet)
@@ -115,7 +114,7 @@ def jacobian3D_lin_face(
     orientation: Literal["zonal", "meridional", "vertical"],
     mesh: Mesh,
 ) -> float:
-    dxdxsi, dxdeta, dxdzet, dydxsi, dydeta, dydzet, dzdxsi, dzdeta, dzdzet = dxdxsi3D_lin(hexa_x, hexa_y, hexa_z, xsi, eta, zeta, mesh)
+    dxdxsi, dxdeta, dxdzet, dydxsi, dydeta, dydzet, dzdxsi, dzdeta, dzdzet = dxdxsi3D_lin(hexa_z, hexa_y, hexa_x, zeta, eta, xsi, mesh)
 
     if orientation == 'zonal':
         j = [dydeta*dzdzet-dydzet*dzdeta,

--- a/parcels/tools/interpolation_utils.py
+++ b/parcels/tools/interpolation_utils.py
@@ -92,7 +92,7 @@ def dxdxsi3D_lin(
 
 
 def jacobian3D_lin(
-    hexa_x: list[float], hexa_y: list[float], hexa_z: list[float], xsi: float, eta: float, zeta: float, mesh: Mesh
+    hexa_z: list[float], hexa_y: list[float], hexa_x: list[float], zeta: float, eta: float, xsi: float, mesh: Mesh
 ) -> float:
     dxdxsi, dxdeta, dxdzet, dydxsi, dydeta, dydzet, dzdxsi, dzdeta, dzdzet = dxdxsi3D_lin(hexa_z, hexa_y, hexa_x, zeta, eta, xsi, mesh)
 
@@ -105,12 +105,12 @@ def jacobian3D_lin(
 
 
 def jacobian3D_lin_face(
-    hexa_x: list[float],
-    hexa_y: list[float],
     hexa_z: list[float],
-    xsi: float,
-    eta: float,
+    hexa_y: list[float],
+    hexa_x: list[float],
     zeta: float,
+    eta: float,
+    xsi: float,
     orientation: Literal["zonal", "meridional", "vertical"],
     mesh: Mesh,
 ) -> float:
@@ -133,7 +133,7 @@ def jacobian3D_lin_face(
     return jac
 
 
-def dphidxsi2D_lin(xsi: float, eta: float) -> tuple[list[float], list[float]]:
+def dphidxsi2D_lin(eta: float, xsi: float) -> tuple[list[float], list[float]]:
     dphidxsi = [-(1-eta),
                   1-eta,
                     eta,
@@ -143,16 +143,16 @@ def dphidxsi2D_lin(xsi: float, eta: float) -> tuple[list[float], list[float]]:
                     xsi,
                   1-xsi]
 
-    return dphidxsi, dphideta
+    return dphideta, dphidxsi
 
 
 def dxdxsi2D_lin(
-    quad_x,
     quad_y,
-    xsi: float,
+    quad_x,
     eta: float,
+    xsi: float,
 ):
-    dphidxsi, dphideta = dphidxsi2D_lin(xsi, eta)
+    dphideta, dphidxsi = dphidxsi2D_lin(eta, xsi)
 
     dxdxsi = np.dot(quad_x, dphidxsi)
     dxdeta = np.dot(quad_x, dphideta)
@@ -162,8 +162,8 @@ def dxdxsi2D_lin(
     return dxdxsi, dxdeta, dydxsi, dydeta
 
 
-def jacobian2D_lin(quad_x, quad_y, xsi: float, eta: float):
-    dxdxsi, dxdeta, dydxsi, dydeta = dxdxsi2D_lin(quad_x, quad_y, xsi, eta)
+def jacobian2D_lin(quad_y, quad_x, eta: float, xsi: float):
+    dxdxsi, dxdeta, dydxsi, dydeta = dxdxsi2D_lin(quad_y, quad_x, eta, xsi)
 
     jac = dxdxsi * dydeta - dxdeta * dydxsi
     return jac

--- a/parcels/tools/interpolation_utils.py
+++ b/parcels/tools/interpolation_utils.py
@@ -32,19 +32,6 @@ def phi2D_lin(xsi: float, eta: float) -> list[float]:
     return phi
 
 
-def phi3D_lin(xsi: float, eta: float, zeta: float) -> list[float]:
-    phi = [(1-xsi) * (1-eta) * (1-zeta),
-              xsi  * (1-eta) * (1-zeta),
-              xsi  *    eta  * (1-zeta),
-           (1-xsi) *    eta  * (1-zeta),
-           (1-xsi) * (1-eta) *    zeta ,
-              xsi  * (1-eta) *    zeta ,
-              xsi  *    eta  *    zeta ,
-           (1-xsi) *    eta  *    zeta ]
-
-    return phi
-
-
 def dphidxsi3D_lin(xsi: float, eta: float, zeta: float) -> tuple[list[float], list[float], list[float]]:
     dphidxsi = [ - (1-eta) * (1-zeta),
                    (1-eta) * (1-zeta),

--- a/parcels/tools/statuscodes.py
+++ b/parcels/tools/statuscodes.py
@@ -109,17 +109,6 @@ def parse_particletime(time, fieldset):
     return time
 
 
-class InterpolationError(KernelError):
-    """Particle kernel error for interpolation error."""
-
-    def __init__(self, particle, fieldset=None, depth=None, lat=None, lon=None):
-        if lon and lat:
-            message = f"Field interpolation error at (depth={depth}, lat={lat}, lon={lon})"
-        else:
-            message = f"Field interpolation error for particle at (depth={particle.depth}, lat={particle.lat}, lon={particle.lon})"
-        super().__init__(particle, fieldset=fieldset, msg=message)
-
-
 AllParcelsErrorCodes = {
     FieldSamplingError: StatusCode.Error,
     FieldOutOfBoundError: StatusCode.ErrorOutOfBounds,

--- a/parcels/tools/statuscodes.py
+++ b/parcels/tools/statuscodes.py
@@ -37,38 +37,38 @@ class DaskChunkingError(RuntimeError):
 class FieldSamplingError(RuntimeError):
     """Utility error class to propagate erroneous field sampling."""
 
-    def __init__(self, x, y, z, field=None):
+    def __init__(self, z, y, x, field=None):
         self.field = field
         self.x = x
         self.y = y
         self.z = z
-        message = f"{field.name if field else 'Field'} sampled at ({self.x}, {self.y}, {self.z})"
+        message = f"{field.name if field else 'Field'} sampled at (depth={self.z}, lat={self.y}, lon={self.x})"
         super().__init__(message)
 
 
 class FieldOutOfBoundError(RuntimeError):
     """Utility error class to propagate out-of-bound field sampling."""
 
-    def __init__(self, x, y, z, field=None):
+    def __init__(self, z, y, x, field=None):
         self.field = field
         self.x = x
         self.y = y
         self.z = z
-        message = f"{field.name if field else 'Field'} sampled out-of-bound, at ({self.x}, {self.y}, {self.z})"
+        message = (
+            f"{field.name if field else 'Field'} sampled out-of-bound, at (depth={self.z}, lat={self.y}, lon={self.x})"
+        )
         super().__init__(message)
 
 
 class FieldOutOfBoundSurfaceError(RuntimeError):
     """Utility error class to propagate out-of-bound field sampling at the surface."""
 
-    def __init__(self, x, y, z, field=None):
+    def __init__(self, z, y, x, field=None):
         self.field = field
         self.x = x
         self.y = y
         self.z = z
-        message = (
-            f"{field.name if field else 'Field'} sampled out-of-bound at the surface, at ({self.x}, {self.y}, {self.z})"
-        )
+        message = f"{field.name if field else 'Field'} sampled out-of-bound at the surface, at (depth={self.z}, lat={self.y}, lon={self.x})"
         super().__init__(message)
 
 
@@ -112,11 +112,11 @@ def parse_particletime(time, fieldset):
 class InterpolationError(KernelError):
     """Particle kernel error for interpolation error."""
 
-    def __init__(self, particle, fieldset=None, lon=None, lat=None, depth=None):
+    def __init__(self, particle, fieldset=None, depth=None, lat=None, lon=None):
         if lon and lat:
-            message = f"Field interpolation error at ({lon}, {lat}, {depth})"
+            message = f"Field interpolation error at (depth={depth}, lat={lat}, lon={lon})"
         else:
-            message = f"Field interpolation error for particle at ({particle.lon}, {particle.lat}, {particle.depth})"
+            message = f"Field interpolation error for particle at (depth={particle.depth}, lat={particle.lat}, lon={particle.lon})"
         super().__init__(particle, fieldset=fieldset, msg=message)
 
 

--- a/tests/customed_header.h
+++ b/tests/customed_header.h
@@ -2,7 +2,7 @@
 static inline StatusCode func(CField *f, double *particle_dlon, double *dt)
 {
   float data2D[2][2][2];
-  StatusCode status = getCell2D(f, 1, 2, 0, data2D, 1); CHECKSTATUS(status);
+  StatusCode status = getCell2D(f, 0, 2, 1, data2D, 1); CHECKSTATUS(status);
   float u = data2D[0][0][0];
   *particle_dlon = +u * *dt;
   return SUCCESS;

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -399,8 +399,8 @@ def test_nemo_grid(mode):
     latp = 81.5
     pset = ParticleSet.from_list(fieldset, MyParticle, lon=[lonp], lat=[latp])
     pset.execute(pset.Kernel(sampleVel), runtime=1)
-    u = fieldset.U.units.to_source(pset.zonal[0], lonp, latp, 0)
-    v = fieldset.V.units.to_source(pset.meridional[0], lonp, latp, 0)
+    u = fieldset.U.units.to_source(pset.zonal[0], 0, latp, lonp)
+    v = fieldset.V.units.to_source(pset.meridional[0], 0, latp, lonp)
     assert abs(u - 1) < 1e-4
     assert abs(v) < 1e-4
 
@@ -577,8 +577,8 @@ def test_cgrid_uniform_3dvel_spherical(mode, vert_mode, time):
     latp = 81.35
     pset = ParticleSet.from_list(fieldset, MyParticle, lon=lonp, lat=latp, depth=0.2)
     pset.execute(pset.Kernel(sampleVel), runtime=1)
-    pset.zonal[0] = fieldset.U.units.to_source(pset.zonal[0], lonp, latp, 0)
-    pset.meridional[0] = fieldset.V.units.to_source(pset.meridional[0], lonp, latp, 0)
+    pset.zonal[0] = fieldset.U.units.to_source(pset.zonal[0], 0, latp, lonp)
+    pset.meridional[0] = fieldset.V.units.to_source(pset.meridional[0], 0, latp, lonp)
     assert abs(pset[0].zonal - 1) < 1e-3
     assert abs(pset[0].meridional) < 1e-3
     assert abs(pset[0].vertical - 1) < 1e-3

--- a/tests/test_kernel_language.py
+++ b/tests/test_kernel_language.py
@@ -380,7 +380,7 @@ def test_c_kernel(fieldset_unit_mesh, mode, c_inc):
                  static inline StatusCode func(CField *f, double *particle_dlon, double *dt)
                  {
                    float data2D[2][2][2];
-                   StatusCode status = getCell2D(f, 1, 2, 0, data2D, 1); CHECKSTATUS(status);
+                   StatusCode status = getCell2D(f, 0, 2, 1, data2D, 1); CHECKSTATUS(status);
                    float u = data2D[0][0][0];
                    *particle_dlon = +u * *dt;
                    return SUCCESS;


### PR DESCRIPTION
As discussed om #1646, the order for Field interpolation has been [time, depth, lat, lon] since Parcels v2, . However, under the hood, there are still multiple cases where that order is different.

This PR fixes #1646 by harmonising the order of the dimensions in any Field operation to be `[time, depth, lat, lon]`