### PR TITLE
Remove `trajan` as core dependency

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -3,3 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - parcels
+  - trajan

--- a/.github/ci/min-core-deps.yml
+++ b/.github/ci/min-core-deps.yml
@@ -20,7 +20,6 @@ dependencies:
   - pymbolic=2022.1
   - pytest=7.1
   - scipy=1.9
-  - trajan=0.1
   - tqdm=4.64
   - xarray=2022.6
   - zarr=2.12

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,12 +11,12 @@ The steps below are the installation instructions for Linux, macOS and Windows.
 
 **Step 1:** Install Anaconda's Miniconda following the steps at https://docs.anaconda.com/miniconda/. If you're on Linux /macOS, the following assumes that you installed Miniconda to your home directory.
 
-**Step 2:** Start a terminal (Linux / macOS) or the Anaconda prompt (Windows). Activate the ``base`` environment of your Miniconda and create an environment containing Parcels, all its essential dependencies, and the nice-to-have cartopy and jupyter packages:
+**Step 2:** Start a terminal (Linux / macOS) or the Anaconda prompt (Windows). Activate the ``base`` environment of your Miniconda and create an environment containing Parcels, all its essential dependencies, ``trajan`` (a trajectory plotting dependency used in the notebooks) and the nice-to-have cartopy and jupyter packages:
 
 .. code-block:: bash
 
     conda activate base
-    conda create -n parcels -c conda-forge parcels cartopy jupyter
+    conda create -n parcels -c conda-forge parcels trajan cartopy jupyter
 
 .. note::
 

--- a/environment.yml
+++ b/environment.yml
@@ -14,12 +14,14 @@ dependencies:
   - pymbolic
   - scipy>=0.16.0
   - tqdm
-  - trajan
   - xarray>=0.10.8
   - cftime>=1.3.1
   - dask>=2.0
   - scikit-learn
   - zarr>=2.11.0,!=2.18.0,<3
+
+  # Notebooks
+  - trajan
 
   # Testing
   - nbval


### PR DESCRIPTION
Fixes #1832 

Note that this change will only take effect with the next release.

Feedstock PR: https://github.com/conda-forge/parcels-feedstock/pull/130