### PR TITLE
Fixing an inconsistency in vertical index search between JIT and Scipy

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1091,6 +1091,12 @@ class Field:
             else:
                 zi = depth_indices.argmin() - 1 if z < depth_vector[0] else 0
         zeta = (z - depth_vector[zi]) / (depth_vector[zi + 1] - depth_vector[zi])
+        while zeta > 1:
+            zi += 1
+            zeta = (z - depth_vector[zi]) / (depth_vector[zi + 1] - depth_vector[zi])
+        while zeta < 0:
+            zi -= 1
+            zeta = (z - depth_vector[zi]) / (depth_vector[zi + 1] - depth_vector[zi])
         return (zi, zeta)
 
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1006,22 +1006,28 @@ class Field:
                 if self.gridindexingtype in ["croco"] and z < 0:
                     return (-2, 1)
                 raise FieldOutOfBoundError(z, 0, 0, field=self)
-            depth_indices = grid.depth <= z
+            depth_indices = grid.depth < z
             if z >= grid.depth[-1]:
                 zi = len(grid.depth) - 2
             else:
-                zi = depth_indices.argmin() - 1 if z >= grid.depth[0] else 0
+                zi = depth_indices.argmin() - 1 if z > grid.depth[0] else 0
         else:
             if z > grid.depth[0]:
                 raise FieldOutOfBoundSurfaceError(z, 0, 0, field=self)
             elif z < grid.depth[-1]:
                 raise FieldOutOfBoundError(z, 0, 0, field=self)
-            depth_indices = grid.depth >= z
+            depth_indices = grid.depth > z
             if z <= grid.depth[-1]:
                 zi = len(grid.depth) - 2
             else:
-                zi = depth_indices.argmin() - 1 if z <= grid.depth[0] else 0
+                zi = depth_indices.argmin() - 1 if z < grid.depth[0] else 0
         zeta = (z - grid.depth[zi]) / (grid.depth[zi + 1] - grid.depth[zi])
+        while zeta > 1:
+            zi += 1
+            zeta = (z - grid.depth[zi]) / (grid.depth[zi + 1] - grid.depth[zi])
+        while zeta < 0:
+            zi -= 1
+            zeta = (z - grid.depth[zi]) / (grid.depth[zi + 1] - grid.depth[zi])
         return (zi, zeta)
 
     @deprecated_made_private  # TODO: Remove 6 months after v3.1.0
@@ -1065,25 +1071,25 @@ class Field:
         z = np.float32(z)  # type: ignore # TODO: remove type ignore once we migrate to float64
 
         if depth_vector[-1] > depth_vector[0]:
-            depth_indices = depth_vector <= z
+            if z < depth_vector[0]:
+                raise FieldOutOfBoundSurfaceError(z, 0, 0, field=self)
+            elif z > depth_vector[-1]:
+                raise FieldOutOfBoundError(z, y, x, field=self)
+            depth_indices = depth_vector < z
             if z >= depth_vector[-1]:
                 zi = len(depth_vector) - 2
             else:
-                zi = depth_indices.argmin() - 1 if z >= depth_vector[0] else 0
-            if z < depth_vector[zi]:
-                raise FieldOutOfBoundSurfaceError(z, 0, 0, field=self)
-            elif z > depth_vector[zi + 1]:
-                raise FieldOutOfBoundError(z, y, x, field=self)
+                zi = depth_indices.argmin() - 1 if z > depth_vector[0] else 0
         else:
-            depth_indices = depth_vector >= z
+            if z > depth_vector[0]:
+                raise FieldOutOfBoundSurfaceError(z, 0, 0, field=self)
+            elif z < depth_vector[-1]:
+                raise FieldOutOfBoundError(z, y, x, field=self)
+            depth_indices = depth_vector > z
             if z <= depth_vector[-1]:
                 zi = len(depth_vector) - 2
             else:
-                zi = depth_indices.argmin() - 1 if z <= depth_vector[0] else 0
-            if z > depth_vector[zi]:
-                raise FieldOutOfBoundSurfaceError(z, 0, 0, field=self)
-            elif z < depth_vector[zi + 1]:
-                raise FieldOutOfBoundError(z, y, x, field=self)
+                zi = depth_indices.argmin() - 1 if z < depth_vector[0] else 0
         zeta = (z - depth_vector[zi]) / (depth_vector[zi + 1] - depth_vector[zi])
         return (zi, zeta)
 


### PR DESCRIPTION
While working on #1816, we found a small inconsistency between the JIT and Scipy implementation of the vertical index search. This meant that a particle that was exactly at the top of a cell in JIT (`zi=k, zeta=1`) would be located at the bottom of the overlying cell in Scipy (`zi=k+1, zeta=0`). 

While this does not matter for linear or nearest interpolation (the particle will get the velocities at the cell interface anyways), it does matter for C-grid interpolation because the horizontal velocities are vertically uniform over a cell; so the horizontal velocities would be different in JIT and Scipy for a particle located exactly at a depth level. 

This PR makes the Scipy index-search consistent with what was already the JIT version. I think(?) it's arbitrary whether the upper (`k+1`) or lower (`k`) cell is chosen when a particle is at a depth level, and because JIT is used much more widely and in production, I decided to use the JIT-implementation also for Scipy.