### PR TITLE
Adding more background to v4 development on the v4-docpage

### DIFF
--- a/docs/v4/index.md
+++ b/docs/v4/index.md
@@ -4,10 +4,11 @@ Supported by funding from the [WarmWorld](https://www.warmworld.de) [ELPHE](http
 
 The key goals of this update are
 
-1. to support Fields on unstructured grids;
+1. to support `Fields` on unstructured grids;
 2. to allow for user-defined interpolation methods (somewhat similar to user-defined kernels);
-3. to make the codebase more modular, easier to extend, and more maintainable; and
-4. to improve the performance of Parcels.
+3. to make the codebase more modular, easier to extend, and more maintainable;
+4. to align Parcels more with other tools in the [Pangeo ecosystemand](https://www.pangeo.io/#ecosystem), particularly by leveraging `xarray` more; and
+5. to improve the performance of Parcels.
 
 The timeline for the release of Parcels v4 is not yet fixed, but we are aiming for a release of an 'alpha' version in September 2025. This v4-alpha will have support for unstructured grids and user-defined interpolation methods, but is not yet performance-optimised.
 

--- a/docs/v4/index.md
+++ b/docs/v4/index.md
@@ -1,10 +1,19 @@
-# v4 development
+# Parcels v4 development
 
-This is a central hub to discuss the development of v4. As development progresses, some of the pages mentioned here will be incorporated into the main documentation.
+Supported by funding from the [WarmWorld](https://www.warmworld.de) [ELPHE](https://www.kooperation-international.de/foerderung/projekte/detail/info/warmworld-elphe-ermoeglichung-von-lagranian-particle-tracking-fuer-hochaufloesende-und-unstrukturierte-gitter) project and an [NWO Vici project](https://www.nwo.nl/en/researchprogrammes/nwo-talent-programme/projects-vici/vici-2022), the Parcels team is working on a major update to the Parcels codebase.
 
-You can think of this as a "living" document as we work towards the release of v4.
+The key goals of this update are
+
+1. to support Fields on unstructured grids;
+2. to allow for user-defined interpolation methods (somewhat similar to user-defined kernels);
+3. to make the codebase more modular, easier to extend, and more maintainable; and
+4. to improve the performance of Parcels.
+
+The timeline for the release of Parcels v4 is not yet fixed, but we are aiming for a release of an 'alpha' version in September 2025. This v4-alpha will have support for unstructured grids and user-defined interpolation methods, but is not yet performance-optimised.
 
 Collaboration on v4 development is happening on the [Parcels v4 Project Board](https://github.com/orgs/OceanParcels/projects/5).
+
+The pages below provide further background on the development of Parcels v4. You can think of this page as a "living" document as we work towards the release of v4.
 
 ```{toctree}
 


### PR DESCRIPTION
I extended the description on the v4-docpage a bit to better explain the goals, process and timeline for Parcels v4 development