### PR TITLE
Fix broken 'output in zarr' hyperlinks

### DIFF
--- a/docs/examples/documentation_advanced_zarr.ipynb
+++ b/docs/examples/documentation_advanced_zarr.ipynb
@@ -19,8 +19,8 @@
     "\n",
     "Topics:\n",
     "\n",
-    "- Capturing output in memory using the `MemoryStore` of `zarr` ([link](https://zarr.readthedocs.io/en/stable/api/zarr/storage/index.html#zarr.storage.MemoryStore))\n",
-    "- Transferring data from a `MemoryStore` into a directory (via `DirectoryStore`; [link](https://zarr.readthedocs.io/en/stable/api/zarr/storage/index.html#zarr.storage.DirectoryStore)) or a zip file (via `ZipStore`; [link](https://zarr.readthedocs.io/en/stable/api/storage.html#zarr.storage.ZipStore)).\n",
+    "- Capturing output in memory using the `MemoryStore` of `zarr` ([link](https://zarr.readthedocs.io/en/v2.18.4/api/storage.html#zarr.storage.MemoryStore))\n",
+    "- Transferring data from a `MemoryStore` into a directory (via `DirectoryStore`; [link](https://zarr.readthedocs.io/en/v2.18.4/api/storage.html#zarr.storage.DirectoryStore)) or a zip file (via `ZipStore`; [link](https://zarr.readthedocs.io/en/v2.18.4/api/storage.html#zarr.storage.ZipStore)).\n",
     "- Re-chunking output to better align with specific analyses (time vs. spatial filtering).\n"
    ]
   },

--- a/docs/examples/documentation_advanced_zarr.ipynb
+++ b/docs/examples/documentation_advanced_zarr.ipynb
@@ -19,8 +19,8 @@
     "\n",
     "Topics:\n",
     "\n",
-    "- Capturing output in memory using the `MemoryStore` of `zarr` ([link](https://zarr.readthedocs.io/en/stable/api/storage.html#zarr.storage.MemoryStore))\n",
-    "- Transferring data from a `MemoryStore` into a directory (via `DirectoryStore`; [link](https://zarr.readthedocs.io/en/stable/api/storage.html#zarr.storage.DirectoryStore)) or a zip file (via `ZipStore`; [link](https://zarr.readthedocs.io/en/stable/api/storage.html#zarr.storage.ZipStore)).\n",
+    "- Capturing output in memory using the `MemoryStore` of `zarr` ([link](https://zarr.readthedocs.io/en/stable/api/zarr/storage/index.html#zarr.storage.MemoryStore))\n",
+    "- Transferring data from a `MemoryStore` into a directory (via `DirectoryStore`; [link](https://zarr.readthedocs.io/en/stable/api/zarr/storage/index.html#zarr.storage.DirectoryStore)) or a zip file (via `ZipStore`; [link](https://zarr.readthedocs.io/en/stable/api/storage.html#zarr.storage.ZipStore)).\n",
     "- Re-chunking output to better align with specific analyses (time vs. spatial filtering).\n"
    ]
   },


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- [x] Fixes #1863 

This PR fixes #1863, by linking to a fixed version of zarr (v2.18.4), rather than the stable version.