### PR TITLE
Adding link to v4 documentation on stable docs too

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ If you need more help with Parcels, try the `Discussions page on GitHub <https:/
    :hidden:
 
    Home <self>
+   v4 <https://docs.oceanparcels.org/en/latest/v4>
    Installation <installation>
    Tutorials & Documentation <documentation/index>
    API reference <reference>


### PR DESCRIPTION
This PR adds a link to the v4 documentation (on `latest`) to the `stable` docs-page too; for better visibility of our v4-development efforts
