### PR TITLE
DOC: update link to v4 docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ If you need more help with Parcels, try the `Discussions page on GitHub <https:/
    :hidden:
 
    Home <self>
-   v4 <https://docs.oceanparcels.org/en/latest/v4>
+   v4 <https://docs.oceanparcels.org/en/v4-dev/v4>
    Installation <installation>
    Tutorials & Documentation <documentation/index>
    API reference <reference>


### PR DESCRIPTION
> OH. I just realised that this wouldn't surface in `stable` with the current configuration of the website (since stable points to the latest _release_). I'll see if I can update that in the RTD config, though nothing immediately jumps out...
> 
> Confirming that:
> - `latest` -> `v4-dev`
> - `stable` -> `main`
> 
> would be ideal?
> 

_Originally posted by @VeckoTheGecko in https://github.com/OceanParcels/Parcels/issues/1865#issuecomment-2662526774_

---

I have updated the RTD configuration so that

- `latest` points to `main`
- `stable` points to the latest release
- `v4-dev` points to `v4-dev`
- `latest` is the default branch again when people go to the documentation

I think that this is much clearer than before and keeps existing documentation coherent (was trying to do this initially last week, but was running into some sync issues)