### PR TITLE
Add v4 pytest markers and TODO in documentation

### DIFF
--- a/docs/v4/TODO.md
+++ b/docs/v4/TODO.md
@@ -4,3 +4,4 @@ List of tasks that are important to do before the release of version 4 (but can'
 
 - [ ] Make migration guide for v3 to v4
 - [ ] Just prior to release: Update conda feedstock recipe dependencies (remove cgen and compiler dependencies). Make sure that recipe is up-to-date.
+- [ ] Revamp the oceanparcels.org landing page, and perhaps also consider new logo/branding?

--- a/docs/v4/TODO.md
+++ b/docs/v4/TODO.md
@@ -1,0 +1,6 @@
+# TODO
+
+List of tasks that are important to do before the release of version 4 (but can't be done now via code changes in `v4-dev`).
+
+- [ ] Make migration guide for v3 to v4
+- [ ] Just prior to release: Update conda feedstock recipe dependencies (remove cgen and compiler dependencies). Make sure that recipe is up-to-date.

--- a/docs/v4/index.md
+++ b/docs/v4/index.md
@@ -20,5 +20,6 @@ The pages below provide further background on the development of Parcels v4. You
 
 api
 nojit
+TODO
 Parcels v4 Project Board <https://github.com/orgs/OceanParcels/projects/5>
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ minversion = "7"
 markers = [ # can be skipped by doing `pytest -m "not slow"` etc.
   "flaky: flaky tests",
   "slow: slow tests",
+  "v4alpha: failing tests that should work for v4alpha",
+  "v4future: failing tests that should work for a future release of v4",
+  "v4remove: failing tests that should probably be removed later",
 ]
 
 filterwarnings = [


### PR DESCRIPTION
Re the markers, added:

- v4alpha: failing tests that should work for v4alpha
- v4future: failing tests that should work for a future release of v4
- v4remove: failing tests that should probably be removed later
  - This marker is used to postpone the decision of actually removing the test, for example if the test is just slightly off the path of v4 development and might still be relevant once the v4 roadmap is clearer. This prevents the test getting buried in git history

Note that these should be used in conjunction with `pytest.mark.xfail`. I couldn't combine it into one call due to some pytest magic in their internals, so we need to apply the marks directly like so:

```py
import pytest


@pytest.mark.v4alpha
@pytest.mark.xfail
def test_failing_feature():
    assert False

```

usage:

```bash
# run all tests (including v4* ones)
pytest

# run all tests excluding those with v4 flags
pytest -m 'not v4alpha and not v4future and not v4remove'
```

@erikvansebille is there anything we should add to the todo documentation page added in this PR?


cc @willirath @fluidnumerics-joe @danliba re. this workflow