### PR TITLE
Adding ti index to the ravelled particle index too

### DIFF
--- a/docs/examples/tutorial_particle_field_interaction.ipynb
+++ b/docs/examples/tutorial_particle_field_interaction.ipynb
@@ -162,7 +162,7 @@
     "    deltaC = fieldset.a * fieldset.C[particle] - fieldset.b * particle.c\n",
     "\n",
     "    ei = fieldset.C.unravel_index(particle.ei)\n",
-    "    xi, yi = ei[2], ei[1]\n",
+    "    yi, xi = ei[2], ei[3]\n",
     "\n",
     "    if abs(particle.lon - fieldset.C.grid.lon[xi + 1]) < abs(\n",
     "        particle.lon - fieldset.C.grid.lon[xi]\n",

--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -218,14 +218,14 @@ def _search_indices_rectilinear(
         _raise_field_sampling_error(z, y, x)
 
     if particle:
-        particle.ei[field.igrid] = field.ravel_index(zi, yi, xi)
+        particle.ei[field.igrid] = field.ravel_index(ti, zi, yi, xi)
 
     return (zeta, eta, xsi, zi, yi, xi)
 
 
 def _search_indices_curvilinear(field: Field, time, z, y, x, ti=-1, particle=None, search2D=False):
     if particle:
-        zi, yi, xi = field.unravel_index(particle.ei)
+        ti, zi, yi, xi = field.unravel_index(particle.ei)
     else:
         xi = int(field.grid.xdim / 2) - 1
         yi = int(field.grid.ydim / 2) - 1
@@ -307,7 +307,7 @@ def _search_indices_curvilinear(field: Field, time, z, y, x, ti=-1, particle=Non
         _raise_field_sampling_error(z, y, x)
 
     if particle:
-        particle.ei[field.igrid] = field.ravel_index(zi, yi, xi)
+        particle.ei[field.igrid] = field.ravel_index(ti, zi, yi, xi)
 
     return (zeta, eta, xsi, zi, yi, xi)
 

--- a/parcels/application_kernels/advection.py
+++ b/parcels/application_kernels/advection.py
@@ -210,7 +210,7 @@ def AdvectionAnalytical(particle, fieldset, time):  # pragma: no cover
                 yi += 1
                 eta = 0
 
-    particle.ei[:] = fieldset.U.ravel_index(zi, yi, xi)
+    particle.ei[:] = fieldset.U.ravel_index(ti, zi, yi, xi)
 
     grid = fieldset.U.grid
     if grid._gtype < 2:

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1313,11 +1313,13 @@ class Field:
         self.filebuffers[tindex] = filebuffer
         return data
 
-    def ravel_index(self, zi, yi, xi):
+    def ravel_index(self, ti, zi, yi, xi):
         """Return the flat index of the given grid points.
 
         Parameters
         ----------
+        ti : int
+            time index
         zi : int
             z index
         yi : int
@@ -1330,10 +1332,10 @@ class Field:
         int
             flat index
         """
-        return xi + self.grid.xdim * (yi + self.grid.ydim * zi)
+        return xi + self.grid.xdim * (yi + self.grid.ydim * (zi + self.grid.tdim * ti))
 
     def unravel_index(self, ei):
-        """Return the zi, yi, xi indices for a given flat index.
+        """Return the ti, zi, yi, xi indices for a given flat index.
 
         Parameters
         ----------
@@ -1342,6 +1344,8 @@ class Field:
 
         Returns
         -------
+        ti : int
+            The time index.
         zi : int
             The z index.
         yi : int
@@ -1350,11 +1354,13 @@ class Field:
             The x index.
         """
         _ei = ei[self.igrid]
+        ti = _ei // (self.grid.xdim * self.grid.ydim * self.grid.zdim)
+        _ei = _ei % (self.grid.xdim * self.grid.ydim * self.grid.zdim)
         zi = _ei // (self.grid.xdim * self.grid.ydim)
         _ei = _ei % (self.grid.xdim * self.grid.ydim)
         yi = _ei // self.grid.xdim
         xi = _ei % self.grid.xdim
-        return zi, yi, xi
+        return ti, zi, yi, xi
 
 
 class VectorField:

--- a/parcels/particledata.py
+++ b/parcels/particledata.py
@@ -122,7 +122,7 @@ class ParticleData:
         self._ncount = len(lon)
 
         for v in self.ptype.variables:
-            if v.name in ["ei", "ti"]:
+            if v.name == "ei":
                 self._data[v.name] = np.empty((len(lon), ngrid), dtype=v.dtype)
             else:
                 self._data[v.name] = np.empty(self._ncount, dtype=v.dtype)

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -128,13 +128,11 @@ class ParticleSet:
                 self.ngrids = type(self).ngrids.initial
                 if self.ngrids >= 0:
                     self.ei = np.zeros(self.ngrids, dtype=np.int32)
-                    self.ti = -1 * np.ones(self.ngrids, dtype=np.int32)
                 super(type(self), self).__init__(*args, **kwargs)
 
             array_class_vdict = {
                 "ngrids": Variable("ngrids", dtype=np.int32, to_write=False, initial=-1),
                 "ei": Variable("ei", dtype=np.int32, to_write=False),
-                "ti": Variable("ti", dtype=np.int32, to_write=False, initial=-1),
                 "__init__": ArrayClass_init,
             }
             array_class = type(class_name, (pclass,), array_class_vdict)
@@ -719,7 +717,6 @@ class ParticleSet:
                 v.name
                 not in [
                     "ei",
-                    "ti",
                     "dt",
                     "depth",
                     "id",

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -570,8 +570,8 @@ def test_fieldset_write(tmp_zarrfile):
 
     def UpdateU(particle, fieldset, time):  # pragma: no cover
         tmp1, tmp2 = fieldset.UV[particle]
-        _, yi, xi = fieldset.U.unravel_index(particle.ei)
-        fieldset.U.data[particle.ti, yi, xi] += 1
+        _, _, yi, xi = fieldset.U.unravel_index(particle.ei)
+        fieldset.U.data[0, yi, xi] += 1
         fieldset.U.grid.time[0] = time
 
     pset = ParticleSet(fieldset, pclass=Particle, lon=5, lat=5)

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -131,7 +131,7 @@ def test_verticalsampling(zdir):
     fieldset = FieldSet.from_data(data, dimensions, mesh="flat")
     pset = ParticleSet(fieldset, pclass=Particle, lon=0, lat=0, depth=0.7 * zdir)
     pset.execute(AdvectionRK4, dt=1.0, runtime=1.0)
-    zi, yi, xi = fieldset.U.unravel_index(pset[0].ei)
+    _, zi, _, _ = fieldset.U.unravel_index(pset[0].ei)
     assert zi == [2]
 
 

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -92,11 +92,11 @@ def test_multi_structured_grids():
     # check if particle xi and yi are different for the two grids
     # xi check from unraveled index
     assert np.all(
-        [fieldset.U.unravel_index(pset[i].ei)[2] != fieldset.V.unravel_index(pset[i].ei)[2] for i in range(3)]
+        [fieldset.U.unravel_index(pset[i].ei)[3] != fieldset.V.unravel_index(pset[i].ei)[3] for i in range(3)]
     )
     # yi check from unraveled index
     assert np.all(
-        [fieldset.U.unravel_index(pset[i].ei)[1] != fieldset.V.unravel_index(pset[i].ei)[1] for i in range(3)]
+        [fieldset.U.unravel_index(pset[i].ei)[2] != fieldset.V.unravel_index(pset[i].ei)[2] for i in range(3)]
     )
     # advect without updating temperature to test particle deletion
     pset.remove_indices(np.array([1]))

--- a/tests/test_particlefile.py
+++ b/tests/test_particlefile.py
@@ -273,9 +273,9 @@ def test_write_xiyi(fieldset, tmp_zarrfile):
         and that the first outputted value is zero.
         Be careful when using multiple grids, as the index may be different for the grids.
         """
-        particle.pxi0 = fieldset.U.unravel_index(particle.ei)[2]
-        particle.pxi1 = fieldset.P.unravel_index(particle.ei)[2]
-        particle.pyi = fieldset.U.unravel_index(particle.ei)[1]
+        particle.pxi0 = fieldset.U.unravel_index(particle.ei)[3]
+        particle.pxi1 = fieldset.P.unravel_index(particle.ei)[3]
+        particle.pyi = fieldset.U.unravel_index(particle.ei)[2]
 
     def SampleP(particle, fieldset, time):  # pragma: no cover
         if time > 5 * 3600:


### PR DESCRIPTION
This PR builds on #1878 by also moving the time (`ti`) index into the ravelled index `ei`. This further reduces the memory footprint of the `Particle` Class, by dropping another `Variable`

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
