### PR TITLE
Install Parcels in RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: mambaforge-22.9
-
+  jobs:
+    post_create_environment:
+      - pip install -e .
 sphinx:
   configuration: docs/conf.py
 


### PR DESCRIPTION
RTD builds are failing with an import error for Parcels. This PR installs Parcels locally in the RTD environment.

<details><summary>Logs</summary>
<p>

```
Running Sphinx v8.2.1
loading translations [en]... done
making output directory... done
Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
myst v4.0.1: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
Writing evaluated template result to /home/docs/checkouts/readthedocs.org/user_builds/parcels/checkouts/1881/_readthedocs/html/_static/nbsphinx-code-cells.css
[autosummary] generating autosummary for: community/contributing.rst, community/index.rst, community/maintainer.md, community/policies.md, documentation/additional_examples.rst, documentation/index.rst, examples/documentation_LargeRunsOutput.ipynb, examples/documentation_MPI.ipynb, examples/documentation_advanced_zarr.ipynb, examples/documentation_geospatial.ipynb, ..., reference/interaction.rst, reference/misc.rst, reference/particlefile.rst, reference/particles.rst, reference/predefined_kernels.rst, reference/userdefined_kernels.rst, v4/TODO.md, v4/api.md, v4/index.md, v4/nojit.md
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 50 source files that are out of date
updating environment: [new config] 50 added, 0 changed, 0 removed
reading sources... [  2%] community/contributing
reading sources... [  4%] community/index
reading sources... [  6%] community/maintainer
reading sources... [  8%] community/policies
reading sources... [ 10%] documentation/additional_examples
reading sources... [ 12%] documentation/index
reading sources... [ 14%] examples/documentation_LargeRunsOutput
reading sources... [ 16%] examples/documentation_MPI
reading sources... [ 18%] examples/documentation_advanced_zarr
reading sources... [ 20%] examples/documentation_geospatial
reading sources... [ 22%] examples/documentation_homepage_animation
reading sources... [ 24%] examples/documentation_indexing
reading sources... [ 26%] examples/documentation_stuck_particles
reading sources... [ 28%] examples/documentation_unstuck_Agrid
reading sources... [ 30%] examples/parcels_tutorial
reading sources... [ 32%] examples/tutorial_Argofloats
reading sources... [ 34%] examples/tutorial_NestedFields
reading sources... [ 36%] examples/tutorial_analyticaladvection
reading sources... [ 38%] examples/tutorial_croco_3D
reading sources... [ 40%] examples/tutorial_delaystart
reading sources... [ 42%] examples/tutorial_diffusion
reading sources... [ 44%] examples/tutorial_interaction
reading sources... [ 46%] examples/tutorial_interpolation
reading sources... [ 48%] examples/tutorial_kernelloop
reading sources... [ 50%] examples/tutorial_nemo_3D
reading sources... [ 52%] examples/tutorial_nemo_curvilinear
reading sources... [ 54%] examples/tutorial_output
reading sources... [ 56%] examples/tutorial_parcels_structure
reading sources... [ 58%] examples/tutorial_particle_field_interaction
/home/docs/checkouts/readthedocs.org/user_builds/parcels/checkouts/1881/docs/documentation/additional_examples.rst:14: WARNING: Include file '/home/docs/checkouts/readthedocs.org/user_builds/parcels/checkouts/1881/docs/examples/example_dask_chunk_OCMs.py' not found or reading it failed [docutils]
Path to light image logo does not exist: parcelslogo.png
Path to dark image logo does not exist: parcelslogo-inverted.png

Notebook error!

Versions
========

* Platform:         linux; (Linux-6.8.0-1021-aws-x86_64-with-glibc2.35)
* Python version:   3.13.2 (CPython)
* Sphinx version:   8.2.1
* Docutils version: 0.21.2
* Jinja2 version:   3.1.5
* Pygments version: 2.19.1

Last Messages
=============

    examples/tutorial_output

    reading sources... [ 56%]
    examples/tutorial_parcels_structure

    reading sources... [ 58%]
    examples/tutorial_particle_field_interaction

    Path to light image logo does not exist: parcelslogo.png
    Path to dark image logo does not exist: parcelslogo-inverted.png

Loaded Extensions
=================

* sphinx.ext.mathjax (8.2.1)
* alabaster (1.0.0)
* sphinxcontrib.applehelp (2.0.0)
* sphinxcontrib.devhelp (2.0.0)
* sphinxcontrib.htmlhelp (2.1.0)
* sphinxcontrib.serializinghtml (1.1.10)
* sphinxcontrib.qthelp (2.0.0)
* sphinx.ext.autodoc.preserve_defaults (8.2.1)
* sphinx.ext.autodoc.type_comment (8.2.1)
* sphinx.ext.autodoc.typehints (8.2.1)
* sphinx.ext.autodoc (8.2.1)
* sphinx.ext.todo (8.2.1)
* sphinx.ext.linkcode (8.2.1)
* sphinx.ext.napoleon (8.2.1)
* myst_parser (4.0.1)
* nbsphinx (0.9.6)
* sphinx.ext.autosummary (8.2.1)
* numpydoc (1.8.0)
* sphinxcontrib.mermaid (8.2.1)
* pydata_sphinx_theme (unknown version)

Traceback
=========

    Traceback (most recent call last):
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/nbsphinx/__init__.py", line 634, in parse
        rststring, resources = exporter.from_notebook_node(nb, resources)
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/nbsphinx/__init__.py", line 397, in from_notebook_node
        nb, resources = pp.preprocess(nb, resources)
                        ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/nbconvert/preprocessors/execute.py", line 103, in preprocess
        self.preprocess_cell(cell, resources, index)
        ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/nbconvert/preprocessors/execute.py", line 124, in preprocess_cell
        cell = self.execute_cell(cell, index, store_history=True)
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/jupyter_core/utils/__init__.py", line 165, in wrapped
        return loop.run_until_complete(inner)
               ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
        return future.result()
               ~~~~~~~~~~~~~^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/nbclient/client.py", line 1062, in async_execute_cell
        await self._check_raise_for_error(cell, cell_index, exec_reply)
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/nbclient/client.py", line 918, in _check_raise_for_error
        raise CellExecutionError.from_cell_and_msg(cell, exec_reply_content)
    nbclient.exceptions.CellExecutionError: An error occurred while executing the following cell:
    ------------------
    from datetime import timedelta
    
    import matplotlib.pyplot as plt
    import netCDF4
    import numpy as np
    import xarray as xr
    
    import parcels
    ------------------
    
    
    [0;31m---------------------------------------------------------------------------[0m
    [0;31mModuleNotFoundError[0m                       Traceback (most recent call last)
    Cell [0;32mIn[1], line 8[0m
    [1;32m      5[0m [38;5;28;01mimport[39;00m[38;5;250m [39m[38;5;21;01mnumpy[39;00m[38;5;250m [39m[38;5;28;01mas[39;00m[38;5;250m [39m[38;5;21;01mnp[39;00m
    [1;32m      6[0m [38;5;28;01mimport[39;00m[38;5;250m [39m[38;5;21;01mxarray[39;00m[38;5;250m [39m[38;5;28;01mas[39;00m[38;5;250m [39m[38;5;21;01mxr[39;00m
    [0;32m----> 8[0m [38;5;28;01mimport[39;00m[38;5;250m [39m[38;5;21;01mparcels[39;00m
    
    [0;31mModuleNotFoundError[0m: No module named 'parcels'
    
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/sphinx/cmd/build.py", line 432, in build_main
        app.build(args.force_all, args.filenames)
        ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/sphinx/application.py", line 426, in build
        self.builder.build_update()
        ~~~~~~~~~~~~~~~~~~~~~~~~~^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/sphinx/builders/__init__.py", line 375, in build_update
        self.build(
        ~~~~~~~~~~^
            to_build,
            ^^^^^^^^^
        ...<2 lines>...
            method='update',
            ^^^^^^^^^^^^^^^^
        )
        ^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/sphinx/builders/__init__.py", line 403, in build
        updated_docnames = set(self.read())
                               ~~~~~~~~~^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/sphinx/builders/__init__.py", line 519, in read
        self._read_serial(docnames)
        ~~~~~~~~~~~~~~~~~^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/sphinx/builders/__init__.py", line 584, in _read_serial
        self.read_doc(docname)
        ~~~~~~~~~~~~~^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/sphinx/builders/__init__.py", line 648, in read_doc
        publisher.publish()
        ~~~~~~~~~~~~~~~~~^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/docutils/core.py", line 234, in publish
        self.document = self.reader.read(self.source, self.parser,
                        ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
                                         self.settings)
                                         ^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/sphinx/io.py", line 103, in read
        self.parse()
        ~~~~~~~~~~^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/docutils/readers/__init__.py", line 76, in parse
        self.parser.parse(self.input, document)
        ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/parcels/conda/1881/lib/python3.13/site-packages/nbsphinx/__init__.py", line 641, in parse
        raise NotebookError('\n'.join(lines))
    nbsphinx.NotebookError: CellExecutionError in examples/tutorial_particle_field_interaction.ipynb:
    ------------------
    from datetime import timedelta
    
    import matplotlib.pyplot as plt
    import netCDF4
    import numpy as np
    import xarray as xr
    
    import parcels
    ------------------
    
    
    [0;31m---------------------------------------------------------------------------[0m
    [0;31mModuleNotFoundError[0m                       Traceback (most recent call last)
    Cell [0;32mIn[1], line 8[0m
    [1;32m      5[0m [38;5;28;01mimport[39;00m[38;5;250m [39m[38;5;21;01mnumpy[39;00m[38;5;250m [39m[38;5;28;01mas[39;00m[38;5;250m [39m[38;5;21;01mnp[39;00m
    [1;32m      6[0m [38;5;28;01mimport[39;00m[38;5;250m [39m[38;5;21;01mxarray[39;00m[38;5;250m [39m[38;5;28;01mas[39;00m[38;5;250m [39m[38;5;21;01mxr[39;00m
    [0;32m----> 8[0m [38;5;28;01mimport[39;00m[38;5;250m [39m[38;5;21;01mparcels[39;00m
    
    [0;31mModuleNotFoundError[0m: No module named 'parcels'
    
    You can ignore this error by setting the following in conf.py:
    
        nbsphinx_allow_errors = True


The full traceback has been saved in:
/tmp/sphinx-err-k2ygkrjn.log

To report this error to the developers, please open an issue at <https://github.com/sphinx-doc/sphinx/issues/>. Thanks!
Please also report this if it was a user error, so that a better error message can be provided next time.
Command time: 27s Return: 2
```

</p>
</details> 
