### PR TITLE
Fixes error raised when using multiple files for fields with no time dimension

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -686,7 +686,7 @@ class Field:
         kwargs["data_full_zdim"] = data_full_zdim
 
         if len(data_filenames) > 1 and "time" not in dimensions and timestamps is None:
-            warnings.warn("Multiple files given but no time dimension specified", FieldSetWarning, stacklevel=2)
+            warnings.warn("Multiple files given but no time dimension specified. See https://github.com/OceanParcels/Parcels/issues/1831 for more info.", FieldSetWarning, stacklevel=2)
 
         if grid is None:
             # Concatenate time variable to determine overall dimension

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -686,7 +686,11 @@ class Field:
         kwargs["data_full_zdim"] = data_full_zdim
 
         if len(data_filenames) > 1 and "time" not in dimensions and timestamps is None:
-            warnings.warn("Multiple files given but no time dimension specified. See https://github.com/OceanParcels/Parcels/issues/1831 for more info.", FieldSetWarning, stacklevel=2)
+            warnings.warn(
+                "Multiple files given but no time dimension specified. See https://github.com/OceanParcels/Parcels/issues/1831 for more info.",
+                FieldSetWarning,
+                stacklevel=2,
+            )
 
         if grid is None:
             # Concatenate time variable to determine overall dimension

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -686,7 +686,7 @@ class Field:
         kwargs["data_full_zdim"] = data_full_zdim
 
         if len(data_filenames) > 1 and "time" not in dimensions and timestamps is None:
-            raise RuntimeError("Multiple files given but no time dimension specified")
+            warnings.warn("Multiple files given but no time dimension specified", FieldSetWarning, stacklevel=2)
 
         if grid is None:
             # Concatenate time variable to determine overall dimension


### PR DESCRIPTION
- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- [x] Adds additional fix for #1831

This is a small change that changes a `ValueError` (raised when initializing a field which does not have a time dimension from multiple files, e.g., `Cs_w` used in `FieldSet.from_croco()`) into a `FieldSetWarning`. This enables the support for such fields implemented in #1835.