### PR TITLE
Removing stray __del__ method from interaction kernel

### DIFF
--- a/parcels/interaction/interactionkernel.py
+++ b/parcels/interaction/interactionkernel.py
@@ -111,12 +111,6 @@ class InteractionKernel(BaseKernel):
             kernel = InteractionKernel(self.fieldset, self.ptype, pyfunc=kernel)
         return kernel.merge(self, InteractionKernel)
 
-    def __del__(self):
-        # Clean-up the in-memory dynamic linked libraries.
-        # This is not really necessary, as these programs are not that large, but with the new random
-        # naming scheme which is required on Windows OS'es to deal with updates to a Parcels' kernel.)
-        super().__del__()
-
     def execute_python(self, pset, endtime, dt):
         """Performs the core update loop via Python.
 


### PR DESCRIPTION
The __del__ method in the interaction kernel was a left-over that is not needed now that JIT is gone in v4. 

<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)