### PR TITLE
Removing the calculation of periods also from _time_index

### DIFF
--- a/parcels/application_kernels/advection.py
+++ b/parcels/application_kernels/advection.py
@@ -177,7 +177,7 @@ def AdvectionAnalytical(particle, fieldset, time):  # pragma: no cover
     direction = 1.0 if particle.dt > 0 else -1.0
     withW = True if "W" in [f.name for f in fieldset.get_fields()] else False
     withTime = True if len(fieldset.U.grid.time_full) > 1 else False
-    ti = fieldset.U._time_index(time)[0]
+    ti = fieldset.U._time_index(time)
     ds_t = particle.dt
     if withTime:
         tau = (time - fieldset.U.grid.time[ti]) / (fieldset.U.grid.time[ti + 1] - fieldset.U.grid.time[ti])

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -964,13 +964,13 @@ class Field:
         if time_index.all():
             # If given time > last known field time, use
             # the last field frame without interpolation
-            return (len(self.grid.time) - 1, 0)
+            return len(self.grid.time) - 1
         elif np.logical_not(time_index).all():
             # If given time < any time in the field, use
             # the first field frame without interpolation
-            return (0, 0)
+            return 0
         else:
-            return (time_index.argmin() - 1 if time_index.any() else 0, 0)
+            return time_index.argmin() - 1 if time_index.any() else 0
 
     def _check_velocitysampling(self):
         if self.name in ["U", "V", "W"]:
@@ -997,8 +997,7 @@ class Field:
         conversion to the result. Note that we defer to
         scipy.interpolate to perform spatial interpolation.
         """
-        (ti, periods) = self._time_index(time)
-        time -= periods * (self.grid.time_full[-1] - self.grid.time_full[0])
+        ti = self._time_index(time)
         if self.gridindexingtype == "croco" and self not in [self.fieldset.H, self.fieldset.Zeta]:
             z = _croco_from_z_to_sigma_scipy(self.fieldset, time, z, y, x, particle=particle)
         if ti < self.grid.tdim - 1 and time > self.grid.time[ti]:
@@ -1791,8 +1790,7 @@ class VectorField:
                 "freeslip": {"2D": self.spatial_slip_interpolation, "3D": self.spatial_slip_interpolation},
             }
             grid = self.U.grid
-            (ti, periods) = self.U._time_index(time)
-            time -= periods * (grid.time_full[-1] - grid.time_full[0])
+            ti = self.U._time_index(time)
             if ti < grid.tdim - 1 and time > grid.time[ti]:
                 t0 = grid.time[ti]
                 t1 = grid.time[ti + 1]

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -224,7 +224,7 @@ class Grid:
                     self._update_status = "updated"
             if self._ti == -1:
                 self.time = self.time_full
-                self._ti, _ = f._time_index(time)
+                self._ti = f._time_index(time)
 
                 if signdt == -1 and self._ti > 0 and self.time_full[self._ti] == time:
                     self._ti -= 1


### PR DESCRIPTION
This PR continues the removal of `time_periodic` support in #1880, by also removing the calculation of periods in `Field._time_index()`

<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)

