### PR TITLE
fieldfilebuffer.py cleanup

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -568,7 +568,7 @@ class Field:
                 interp_method=interp_method,
                 gridindexingtype=gridindexingtype,
             ) as filebuffer:
-                filebuffer.name = filebuffer.parse_name(variable[1])
+                filebuffer.name = variable[1]
                 if dimensions["depth"] == "not_yet_set":
                     depth = filebuffer.depth_dimensions
                     kwargs["depth_field"] = "not_yet_set"
@@ -628,7 +628,7 @@ class Field:
                 ) as filebuffer:
                     # If Field.from_netcdf is called directly, it may not have a 'data' dimension
                     # In that case, assume that 'name' is the data dimension
-                    filebuffer.name = filebuffer.parse_name(variable[1])
+                    filebuffer.name = variable[1]
                     buffer_data = filebuffer.data
                     if len(buffer_data.shape) == 4:
                         errormessage = (
@@ -1112,7 +1112,7 @@ class Field:
         time_data = g.time_origin.reltime(time_data)
         filebuffer.ti = (time_data <= g.time[tindex]).argmin() - 1
         if self.netcdf_engine != "xarray":
-            filebuffer.name = filebuffer.parse_name(self.filebuffername)
+            filebuffer.name = self.filebuffername
         buffer_data = filebuffer.data
         if len(buffer_data.shape) == 2:
             buffer_data = np.reshape(buffer_data, sum(((1, 1), buffer_data.shape), ()))

--- a/parcels/fieldfilebuffer.py
+++ b/parcels/fieldfilebuffer.py
@@ -51,16 +51,6 @@ class NetcdfFileBuffer:
             self.dataset.close()
             self.dataset = None
 
-    def parse_name(self, name):
-        if isinstance(name, list):
-            for nm in name:
-                if hasattr(self.dataset, nm):
-                    name = nm
-                    break
-        if isinstance(name, list):
-            raise OSError("None of variables in list found in file")
-        return name
-
     @property
     def latlon(self):
         lon = self.dataset[self.dimensions["lon"]]

--- a/parcels/fieldfilebuffer.py
+++ b/parcels/fieldfilebuffer.py
@@ -9,7 +9,7 @@ from parcels.tools.converters import convert_xarray_time_units
 from parcels.tools.warnings import FileWarning
 
 
-class _FileBuffer:
+class NetcdfFileBuffer:
     def __init__(
         self,
         filename,
@@ -36,13 +36,7 @@ class _FileBuffer:
             self.nolonlatindices = False
         else:
             self.nolonlatindices = True
-
-
-class NetcdfFileBuffer(_FileBuffer):
-    def __init__(self, *args, **kwargs):
-        self.lib = np
         self.netcdf_engine = kwargs.pop("netcdf_engine", "netcdf4")
-        super().__init__(*args, **kwargs)
 
     def __enter__(self):
         try:
@@ -251,8 +245,3 @@ class NetcdfFileBuffer(_FileBuffer):
                 "Parcels currently only parses dates ranging from 1678 AD to 2262 AD, which are stored by xarray as np.datetime64. If you need a wider date range, please open an Issue on the parcels github page."
             )
         return time
-
-
-class DeferredNetcdfFileBuffer(NetcdfFileBuffer):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)

--- a/parcels/fieldfilebuffer.py
+++ b/parcels/fieldfilebuffer.py
@@ -1,5 +1,6 @@
 import datetime
 import warnings
+from pathlib import Path
 
 import numpy as np
 import xarray as xr
@@ -39,25 +40,7 @@ class NetcdfFileBuffer:
         self.netcdf_engine = kwargs.pop("netcdf_engine", "netcdf4")
 
     def __enter__(self):
-        try:
-            # Unfortunately we need to do if-else here, cause the lock-parameter is either False or a Lock-object
-            # (which we would rather want to have being auto-managed).
-            # If 'lock' is not specified, the Lock-object is auto-created and managed by xarray internally.
-            self.dataset = xr.open_dataset(str(self.filename), decode_cf=True, engine=self.netcdf_engine)
-            self.dataset["decoded"] = True
-        except:
-            warnings.warn(
-                f"File {self.filename} could not be decoded properly by xarray (version {xr.__version__}). "
-                "It will be opened with no decoding. Filling values might be wrongly parsed.",
-                FileWarning,
-                stacklevel=2,
-            )
-
-            self.dataset = xr.open_dataset(str(self.filename), decode_cf=False, engine=self.netcdf_engine)
-            self.dataset["decoded"] = False
-        for inds in self.indices.values():
-            if type(inds) not in [list, range]:
-                raise RuntimeError("Indices for field subsetting need to be a list")
+        self.dataset = open_xarray_dataset(self.filename, self.netcdf_engine)
         return self
 
     def __exit__(self, type, value, traceback):
@@ -245,3 +228,23 @@ class NetcdfFileBuffer:
                 "Parcels currently only parses dates ranging from 1678 AD to 2262 AD, which are stored by xarray as np.datetime64. If you need a wider date range, please open an Issue on the parcels github page."
             )
         return time
+
+
+def open_xarray_dataset(filename: Path | str, netcdf_engine: str) -> xr.Dataset:
+    try:
+        # Unfortunately we need to do if-else here, cause the lock-parameter is either False or a Lock-object
+        # (which we would rather want to have being auto-managed).
+        # If 'lock' is not specified, the Lock-object is auto-created and managed by xarray internally.
+        ds = xr.open_dataset(filename, decode_cf=True, engine=netcdf_engine)
+        ds["decoded"] = True
+    except:
+        warnings.warn(  # TODO: Is this warning necessary? What cases does this except block get triggered - is it to do with the bare except???
+            f"File {filename} could not be decoded properly by xarray (version {xr.__version__}). "
+            "It will be opened with no decoding. Filling values might be wrongly parsed.",
+            FileWarning,
+            stacklevel=2,
+        )
+
+        ds = xr.open_dataset(filename, decode_cf=False, engine=netcdf_engine)
+        ds["decoded"] = False
+    return ds


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->

Remove obsolete DeferredNetcdfFileBuffer, _FileBuffer classes and unused attributes.

I also realised while doing this that fieldfilebuffer is really where a lot of the magic happens when it comes to reading in from netcdf files and coercing field input into a unified format parcels can understand. Good for me to know - I think there can be some improvements made here :)

- [x] Chose the correct base branch (ie, `swap_space_and_time_interpolation_order`)

🚧 merge after #1892
mypy fixed in next PR