### PR TITLE
Remove latitude flipping in Grid

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -691,8 +691,6 @@ class Field:
         # Ensure that field data is the right data type
         if not isinstance(data, (np.ndarray)):
             data = np.array(data)
-        if self.grid._lat_flipped:
-            data = np.flip(data, axis=-2)
 
         if self.grid.xdim == 1 or self.grid.ydim == 1:
             data = np.squeeze(data)  # First remove all length-1 dimensions in data, so that we can add them below

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -382,15 +382,11 @@ def test_partialslip_nearland_vertical(boundaryslip):
         assert np.allclose([p.lat for p in pset], 0.1)
 
 
-@pytest.mark.parametrize("lat_flip", [False, True])
-def test_fieldset_sample_particle(lat_flip):
+def test_fieldset_sample_particle():
     """Sample the fieldset using an array of particles."""
     npart = 120
     lon = np.linspace(-180, 180, 200, dtype=np.float32)
-    if lat_flip:
-        lat = np.linspace(90, -90, 100, dtype=np.float32)
-    else:
-        lat = np.linspace(-90, 90, 100, dtype=np.float32)
+    lat = np.linspace(-90, 90, 100, dtype=np.float32)
     V, U = np.meshgrid(lon, lat)
     data = {"U": U, "V": V}
     dimensions = {"lon": lon, "lat": lat}

--- a/tests/tools/test_warnings.py
+++ b/tests/tools/test_warnings.py
@@ -17,16 +17,6 @@ from parcels import (
 from tests.utils import TEST_DATA
 
 
-def test_fieldset_warning_latflipped():
-    # flipping lats warning
-    lat = [0, 1, 5, -5]
-    lon = [0, 1, 5, 10]
-    u = [[1, 1, 1, 1] for _ in range(4)]
-    v = [[1, 1, 1, 1] for _ in range(4)]
-    with pytest.warns(FieldSetWarning, match="Flipping lat data from North-South to South-North.*"):
-        FieldSet.from_data(data={"U": u, "V": v}, dimensions={"lon": lon, "lat": lat})
-
-
 def test_fieldset_warning_pop():
     filenames = str(TEST_DATA / "POPtestdata_time.nc")
     variables = {"U": "U", "V": "V", "W": "W", "T": "T"}


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->
Flipping the latitude to be ascending is no longer necessary due to the hash search.

If this is actually necessary down the line, then it can be done via another method (i.e., lazily evaluated dask calls)


- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- xref #1844
