### PR TITLE
Remove `FieldSet.compute_on_defer`

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -52,7 +52,6 @@ class FieldSet:
             for name, field in fields.items():
                 self.add_field(field, name)
 
-        self.compute_on_defer = None
         self._add_UVfield()
 
     def __repr__(self):
@@ -1469,9 +1468,6 @@ class FieldSet:
                             f.data[1, :] = None
                     f.data[1, :] = f.data[0, :]
                     f.data[0, :] = data
-        # do user-defined computations on fieldset data
-        if self.compute_on_defer:
-            self.compute_on_defer(self)
 
         # update time varying grid depth
         for f in self.get_fields():


### PR DESCRIPTION
This is undocumented functionality in Parcels providing computation for deferred loading.

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- xref #1844
