### PR TITLE
Remove deferred loading of FieldSets

### DIFF
--- a/docs/examples/example_globcurrent.py
+++ b/docs/examples/example_globcurrent.py
@@ -211,9 +211,19 @@ def test_globcurrent_time_extrapolation_error(use_xarray):
         )
 
 
+@pytest.mark.v4alpha
+@pytest.mark.xfail(
+    reason="This was always broken when using eager loading `deferred_load=False` for the P field. Needs to be fixed."
+)
 @pytest.mark.parametrize("dt", [-300, 300])
 @pytest.mark.parametrize("with_starttime", [True, False])
 def test_globcurrent_startparticles_between_time_arrays(dt, with_starttime):
+    """Test for correctly initialising particle start times.
+
+    When using Fields with different temporal domains, its important to intialise particles
+    at the beginning of the time period where all Fields have available data (i.e., the
+    intersection of the temporal domains)
+    """
     fieldset = set_globcurrent_fieldset()
 
     data_folder = parcels.download_example_dataset("GlobCurrent_example_data")

--- a/docs/examples/example_globcurrent.py
+++ b/docs/examples/example_globcurrent.py
@@ -11,7 +11,6 @@ import parcels
 def set_globcurrent_fieldset(
     filename=None,
     indices=None,
-    deferred_load=True,
     use_xarray=False,
     timestamps=None,
 ):
@@ -41,7 +40,6 @@ def set_globcurrent_fieldset(
             variables,
             dimensions,
             indices,
-            deferred_load=deferred_load,
             timestamps=timestamps,
         )
 
@@ -80,9 +78,7 @@ def test_globcurrent_fieldset_advancetime(dt, lonstart, latstart, use_xarray):
         lat=[latstart],
     )
 
-    fieldsetall = set_globcurrent_fieldset(
-        files[0:10], deferred_load=False, use_xarray=use_xarray
-    )
+    fieldsetall = set_globcurrent_fieldset(files[0:10], use_xarray=use_xarray)
     psetall = parcels.ParticleSet.from_list(
         fieldset=fieldsetall,
         pclass=parcels.Particle,
@@ -116,32 +112,6 @@ def test_globcurrent_particles(use_xarray):
 
     assert abs(pset[0].lon - 23.8) < 1
     assert abs(pset[0].lat - -35.3) < 1
-
-
-@pytest.mark.v4remove
-@pytest.mark.xfail(reason="time_periodic removed in v4")
-@pytest.mark.parametrize("rundays", [300, 900])
-def test_globcurrent_time_periodic(rundays):
-    sample_var = []
-    for deferred_load in [True, False]:
-        fieldset = set_globcurrent_fieldset(
-            time_periodic=timedelta(days=365), deferred_load=deferred_load
-        )
-
-        MyParticle = parcels.Particle.add_variable("sample_var", initial=0.0)
-
-        pset = parcels.ParticleSet(
-            fieldset, pclass=MyParticle, lon=25, lat=-35, time=fieldset.U.grid.time[0]
-        )
-
-        def SampleU(particle, fieldset, time):  # pragma: no cover
-            u, v = fieldset.UV[time, particle.depth, particle.lat, particle.lon]
-            particle.sample_var += u
-
-        pset.execute(SampleU, runtime=timedelta(days=rundays), dt=timedelta(days=1))
-        sample_var.append(pset[0].sample_var)
-
-    assert np.allclose(sample_var[0], sample_var[1])
 
 
 @pytest.mark.parametrize("dt", [-300, 300])

--- a/docs/examples/example_ofam.py
+++ b/docs/examples/example_ofam.py
@@ -8,7 +8,7 @@ import xarray as xr
 import parcels
 
 
-def set_ofam_fieldset(deferred_load=True, use_xarray=False):
+def set_ofam_fieldset(use_xarray=False):
     data_folder = parcels.download_example_dataset("OFAM_example_data")
     filenames = {
         "U": f"{data_folder}/OFAM_simple_U.nc",
@@ -32,13 +32,12 @@ def set_ofam_fieldset(deferred_load=True, use_xarray=False):
             variables,
             dimensions,
             allow_time_extrapolation=True,
-            deferred_load=deferred_load,
         )
 
 
 @pytest.mark.parametrize("use_xarray", [True, False])
 def test_ofam_fieldset_fillvalues(use_xarray):
-    fieldset = set_ofam_fieldset(deferred_load=False, use_xarray=use_xarray)
+    fieldset = set_ofam_fieldset(use_xarray=use_xarray)
     # V.data[0, 0, 150] is a landpoint, that makes NetCDF4 generate a masked array, instead of an ndarray
     assert fieldset.V.data[0, 0, 150] == 0
 

--- a/parcels/_typing.py
+++ b/parcels/_typing.py
@@ -29,7 +29,6 @@ PathLike = str | os.PathLike
 Mesh = Literal["spherical", "flat"]  # corresponds with `mesh`
 VectorType = Literal["3D", "3DSigma", "2D"] | None  # corresponds with `vector_type`
 GridIndexingType = Literal["pop", "mom5", "mitgcm", "nemo", "croco"]  # corresponds with `gridindexingtype`
-UpdateStatus = Literal["not_updated", "first_updated", "updated"]  # corresponds with `_update_status`
 NetcdfEngine = Literal["netcdf4", "xarray", "scipy"]
 
 

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -539,8 +539,6 @@ class Field:
                 "time dimension in indices is not necessary anymore. It is then ignored.", FieldSetWarning, stacklevel=2
             )
 
-        # Pre-allocate data before reading files into buffer
-        ti = 0
         with NetcdfFileBuffer(  # type: ignore[operator]
             data_filenames,
             dimensions,
@@ -563,17 +561,6 @@ class Field:
                 assert buffer_data.shape[2] == grid.ydim, errormessage
                 assert buffer_data.shape[3] == grid.xdim, errormessage
 
-            # if len(buffer_data.shape) == 2:
-            #     data_list.append(buffer_data.reshape(sum(((len(tslice), 1), buffer_data.shape), ())))
-            # elif len(buffer_data.shape) == 3:
-            #     if len(filebuffer.indices["depth"]) > 1:
-            #         data_list.append(buffer_data.reshape(sum(((1,), buffer_data.shape), ())))
-            #     else:
-            #         data_list.append(buffer_data.reshape(sum(((len(tslice), 1), buffer_data.shape[1:]), ())))
-            # else:
-            #     data_list.append(buffer_data)
-
-        ti += sum(np.array(slice_).size for slice_ in grid.timeslices)
         data = buffer_data
 
         if allow_time_extrapolation is None:

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1533,32 +1533,6 @@ class VectorField:
             return _deal_with_errors(error, key, vector_type=self.vector_type)
 
 
-class DeferredArray:
-    """Class used for throwing error when Field.data is not read in deferred loading mode."""
-
-    data_shape = ()
-
-    def __init__(self):
-        self.data_shape = (1,)
-
-    def compute_shape(self, xdim, ydim, zdim, tdim, tslices):
-        if zdim == 1 and tdim == 1:
-            self.data_shape = (tslices, 1, ydim, xdim)
-        elif zdim > 1 or tdim > 1:
-            if zdim > 1:
-                self.data_shape = (1, zdim, ydim, xdim)
-            else:
-                self.data_shape = (max(tdim, tslices), 1, ydim, xdim)
-        else:
-            self.data_shape = (tdim, zdim, ydim, xdim)
-        return self.data_shape
-
-    def __getitem__(self, key):
-        raise RuntimeError(
-            "Field is in deferred_load mode, so can't be accessed. Use .computeTimeChunk() method to force loading of data"
-        )
-
-
 class NestedField(list):
     """NestedField is a class that allows for interpolation of fields on different grids of potentially varying resolution.
 

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -540,46 +540,41 @@ class Field:
             )
 
         # Pre-allocate data before reading files into buffer
-        data_list = []
         ti = 0
-        for tslice, fname in zip(grid.timeslices, data_filenames, strict=True):
-            with NetcdfFileBuffer(  # type: ignore[operator]
-                fname,
-                dimensions,
-                indices,
-                netcdf_engine,
-                interp_method=interp_method,
-                data_full_zdim=data_full_zdim,
-            ) as filebuffer:
-                # If Field.from_netcdf is called directly, it may not have a 'data' dimension
-                # In that case, assume that 'name' is the data dimension
-                filebuffer.name = variable[1]
-                buffer_data = filebuffer.data
-                if len(buffer_data.shape) == 4:
-                    errormessage = (
-                        f"Field {filebuffer.name} expecting a data shape of [tdim={grid.tdim}, zdim={grid.zdim}, "
-                        f"ydim={grid.ydim}, xdim={grid.xdim }] "
-                        f"but got shape {buffer_data.shape}."
-                    )
-                    assert buffer_data.shape[0] == grid.tdim, errormessage
-                    assert buffer_data.shape[2] == grid.ydim, errormessage
-                    assert buffer_data.shape[3] == grid.xdim, errormessage
+        with NetcdfFileBuffer(  # type: ignore[operator]
+            data_filenames,
+            dimensions,
+            indices,
+            netcdf_engine,
+            interp_method=interp_method,
+            data_full_zdim=data_full_zdim,
+        ) as filebuffer:
+            # If Field.from_netcdf is called directly, it may not have a 'data' dimension
+            # In that case, assume that 'name' is the data dimension
+            filebuffer.name = variable[1]
+            buffer_data = filebuffer.data
+            if len(buffer_data.shape) == 4:
+                errormessage = (
+                    f"Field {filebuffer.name} expecting a data shape of [tdim={grid.tdim}, zdim={grid.zdim}, "
+                    f"ydim={grid.ydim}, xdim={grid.xdim }] "
+                    f"but got shape {buffer_data.shape}."
+                )
+                assert buffer_data.shape[0] == grid.tdim, errormessage
+                assert buffer_data.shape[2] == grid.ydim, errormessage
+                assert buffer_data.shape[3] == grid.xdim, errormessage
 
-                if len(buffer_data.shape) == 2:
-                    data_list.append(buffer_data.reshape(sum(((len(tslice), 1), buffer_data.shape), ())))
-                elif len(buffer_data.shape) == 3:
-                    if len(filebuffer.indices["depth"]) > 1:
-                        data_list.append(buffer_data.reshape(sum(((1,), buffer_data.shape), ())))
-                    else:
-                        if type(tslice) not in [list, np.ndarray, xr.DataArray]:
-                            tslice = [tslice]
-                        data_list.append(buffer_data.reshape(sum(((len(tslice), 1), buffer_data.shape[1:]), ())))
-                else:
-                    data_list.append(buffer_data)
-                if type(tslice) not in [list, np.ndarray, xr.DataArray]:
-                    tslice = [tslice]
-            ti += len(tslice)
-        data = np.concatenate(data_list, axis=0)
+            # if len(buffer_data.shape) == 2:
+            #     data_list.append(buffer_data.reshape(sum(((len(tslice), 1), buffer_data.shape), ())))
+            # elif len(buffer_data.shape) == 3:
+            #     if len(filebuffer.indices["depth"]) > 1:
+            #         data_list.append(buffer_data.reshape(sum(((1,), buffer_data.shape), ())))
+            #     else:
+            #         data_list.append(buffer_data.reshape(sum(((len(tslice), 1), buffer_data.shape[1:]), ())))
+            # else:
+            #     data_list.append(buffer_data)
+
+        ti += sum(np.array(slice_).size for slice_ in grid.timeslices)
+        data = buffer_data
 
         if allow_time_extrapolation is None:
             allow_time_extrapolation = False if "time" in dimensions else True

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -388,11 +388,6 @@ class Field:
             boolean whether to allow for extrapolation in time
             (i.e. beyond the last available time snapshot)
             Default is False if dimensions includes time, else True
-        deferred_load : bool
-            boolean whether to only pre-load data (in deferred mode) or
-            fully load them (default: True). It is advised to deferred load the data, since in
-            that case Parcels deals with a better memory management during particle set execution.
-            deferred_load=False is however sometimes necessary for plotting the fields.
         gridindexingtype : str
             The type of gridindexing. Either 'nemo' (default), 'mitgcm', 'mom5', 'pop', or 'croco' are supported.
             See also the Grid indexing documentation on oceanparcels.org

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -177,7 +177,7 @@ class Field:
             self.filebuffername = name[1]
         self.data = data
         if grid:
-            if grid.defer_load and isinstance(data, np.ndarray):
+            if False and isinstance(data, np.ndarray):
                 raise ValueError(
                     "Cannot combine Grid from defer_loaded Field with np.ndarray data. please specify lon, lat, depth and time dimensions separately"
                 )
@@ -225,7 +225,7 @@ class Field:
         else:
             self.allow_time_extrapolation = allow_time_extrapolation
 
-        if not self.grid.defer_load:
+        if True:
             self.data = self._reshape(self.data)
             self._loaded_time_indices = range(self.grid.tdim)
 
@@ -712,7 +712,7 @@ class Field:
         if self._scaling_factor:
             raise NotImplementedError(f"Scaling factor for field {self.name} already defined.")
         self._scaling_factor = factor
-        if not self.grid.defer_load:
+        if True:
             self.data *= factor
 
     def set_depth_from_field(self, field):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -177,10 +177,6 @@ class Field:
             self.filebuffername = name[1]
         self.data = data
         if grid:
-            if False and isinstance(data, np.ndarray):
-                raise ValueError(
-                    "Cannot combine Grid from defer_loaded Field with np.ndarray data. please specify lon, lat, depth and time dimensions separately"
-                )
             self._grid = grid
         else:
             if (time is not None) and isinstance(time[0], np.datetime64):
@@ -225,14 +221,12 @@ class Field:
         else:
             self.allow_time_extrapolation = allow_time_extrapolation
 
-        if True:
-            self.data = self._reshape(self.data)
-            self._loaded_time_indices = range(self.grid.tdim)
+        self.data = self._reshape(self.data)
+        self._loaded_time_indices = range(self.grid.tdim)
 
-            # Hack around the fact that NaN and ridiculously large values
-            # propagate in SciPy's interpolators
-            self.data[np.isnan(self.data)] = 0.0
-
+        # Hack around the fact that NaN and ridiculously large values
+        # propagate in SciPy's interpolators
+        self.data[np.isnan(self.data)] = 0.0
         self._scaling_factor = None
 
         self._dimensions = kwargs.pop("dimensions", None)
@@ -712,8 +706,7 @@ class Field:
         if self._scaling_factor:
             raise NotImplementedError(f"Scaling factor for field {self.name} already defined.")
         self._scaling_factor = factor
-        if True:
-            self.data *= factor
+        self.data *= factor
 
     def set_depth_from_field(self, field):
         """Define the depth dimensions from another (time-varying) field.

--- a/parcels/fieldfilebuffer.py
+++ b/parcels/fieldfilebuffer.py
@@ -27,7 +27,6 @@ class NetcdfFileBuffer:
         self.indices = indices
         self.dataset = None
         self.timestamp = timestamp
-        self.ti = None
         self.interp_method = interp_method
         self.gridindexingtype = gridindexingtype
         self.data_full_zdim = data_full_zdim
@@ -189,7 +188,7 @@ class NetcdfFileBuffer:
 
     def data_access(self):
         data = self.dataset[self.name]
-        ti = range(data.shape[0]) if self.ti is None else self.ti
+        ti = range(data.shape[0])
         return np.array(self._apply_indices(data, ti))
 
     @property

--- a/parcels/fieldfilebuffer.py
+++ b/parcels/fieldfilebuffer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
-from parcels._typing import InterpMethodOption
+from parcels._typing import InterpMethodOption, PathLike
 from parcels.tools.converters import convert_xarray_time_units
 from parcels.tools.warnings import FileWarning
 
@@ -22,7 +22,7 @@ class NetcdfFileBuffer:
         gridindexingtype="nemo",
         **kwargs,
     ):
-        self.filename = filename
+        self.filename: PathLike | list[PathLike] = filename
         self.dimensions = dimensions  # Dict with dimension keys for file data
         self.indices = indices
         self.dataset = None
@@ -222,7 +222,7 @@ def open_xarray_dataset(filename: Path | str, netcdf_engine: str) -> xr.Dataset:
         # Unfortunately we need to do if-else here, cause the lock-parameter is either False or a Lock-object
         # (which we would rather want to have being auto-managed).
         # If 'lock' is not specified, the Lock-object is auto-created and managed by xarray internally.
-        ds = xr.open_dataset(filename, decode_cf=True, engine=netcdf_engine)
+        ds = xr.open_mfdataset(filename, decode_cf=True, engine=netcdf_engine)
         ds["decoded"] = True
     except:
         warnings.warn(  # TODO: Is this warning necessary? What cases does this except block get triggered - is it to do with the bare except???
@@ -232,6 +232,6 @@ def open_xarray_dataset(filename: Path | str, netcdf_engine: str) -> xr.Dataset:
             stacklevel=2,
         )
 
-        ds = xr.open_dataset(filename, decode_cf=False, engine=netcdf_engine)
+        ds = xr.open_mfdataset(filename, decode_cf=False, engine=netcdf_engine)
         ds["decoded"] = False
     return ds

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -1368,9 +1368,6 @@ class FieldSet:
         """
         nextTime = np.inf if dt > 0 else -np.inf
 
-        for g in self.gridset.grids:
-            g._update_status = "not_updated"
-
         if abs(nextTime) == np.inf or np.isnan(nextTime):  # Second happens when dt=0
             return nextTime
         else:

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -285,7 +285,7 @@ class FieldSet:
                 g.time_origin.time_origin, type(self.time_origin.time_origin)
             ), "time origins of different grids must be have the same type"
             g.time = g.time + self.time_origin.reltime(g.time_origin)
-            if g.defer_load:
+            if False:
                 g.time_full = g.time_full + self.time_origin.reltime(g.time_origin)
             g._time_origin = self.time_origin
         self._add_UVfield()
@@ -298,7 +298,7 @@ class FieldSet:
                     raise ValueError(
                         "If depth dimension is set at 'not_yet_set', it must be added later using Field.set_depth_from_field(field)"
                     )
-                if not f.grid.defer_load:
+                if True:
                     depth_data = f.grid.depth_field.data
                     f.grid._depth = depth_data if isinstance(depth_data, np.ndarray) else np.array(depth_data)
         self._completed = True
@@ -1376,7 +1376,7 @@ class FieldSet:
         for g in self.gridset.grids:
             g._update_status = "not_updated"
         for f in self.get_fields():
-            if isinstance(f, (VectorField, NestedField)) or not f.grid.defer_load:
+            if isinstance(f, (VectorField, NestedField)) or True:
                 continue
             if f.grid._update_status == "not_updated":
                 nextTime_loc = f.grid._computeTimeChunk(f, time, signdt)
@@ -1385,7 +1385,7 @@ class FieldSet:
             nextTime = min(nextTime, nextTime_loc) if signdt >= 0 else max(nextTime, nextTime_loc)
 
         for f in self.get_fields():
-            if isinstance(f, (VectorField, NestedField)) or not f.grid.defer_load or f._dataFiles is None:
+            if isinstance(f, (VectorField, NestedField)) or True or f._dataFiles is None:
                 continue
             f._loaded_time_indices = []  # reset loaded time indices
             g = f.grid
@@ -1457,7 +1457,7 @@ class FieldSet:
 
         # update time varying grid depth
         for f in self.get_fields():
-            if isinstance(f, (VectorField, NestedField)) or not f.grid.defer_load or f._dataFiles is None:
+            if isinstance(f, (VectorField, NestedField)) or True or f._dataFiles is None:
                 continue
             if f.grid.depth_field is not None:
                 depth_data = f.grid.depth_field.data

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -326,7 +326,6 @@ class FieldSet:
         mesh: Mesh = "spherical",
         timestamps=None,
         allow_time_extrapolation: bool | None = None,
-        deferred_load=True,
         **kwargs,
     ):
         """Initialises FieldSet object from NetCDF files.
@@ -463,7 +462,6 @@ class FieldSet:
                 mesh=mesh,
                 timestamps=timestamps,
                 allow_time_extrapolation=allow_time_extrapolation,
-                deferred_load=deferred_load,
                 fieldtype=fieldtype,
                 dataFiles=dFiles,
                 **kwargs,
@@ -1163,7 +1161,6 @@ class FieldSet:
         indices=None,
         extra_fields=None,
         allow_time_extrapolation: bool | None = None,
-        deferred_load=True,
         **kwargs,
     ):
         """Initialises FieldSet data from NetCDF files using the Parcels FieldSet.write() conventions.
@@ -1212,7 +1209,6 @@ class FieldSet:
             variables=extra_fields,
             dimensions=dimensions,
             allow_time_extrapolation=allow_time_extrapolation,
-            deferred_load=deferred_load,
             **kwargs,
         )
 

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -374,11 +374,6 @@ class FieldSet:
             boolean whether to allow for extrapolation
             (i.e. beyond the last available time snapshot)
             Default is False if dimensions includes time, else True
-        deferred_load : bool
-            boolean whether to only pre-load data (in deferred mode) or
-            fully load them (default: True). It is advised to deferred load the data, since in
-            that case Parcels deals with a better memory management during particle set execution.
-            deferred_load=False is however sometimes necessary for plotting the fields.
         interp_method : str
             Method for interpolation. Options are 'linear' (default), 'nearest',
             'linear_invdist_land_tracer', 'cgrid_velocity', 'cgrid_tracer' and 'bgrid_velocity'
@@ -1192,11 +1187,6 @@ class FieldSet:
             boolean whether to allow for extrapolation
             (i.e. beyond the last available time snapshot)
             Default is False if dimensions includes time, else True
-        deferred_load : bool
-            boolean whether to only pre-load data (in deferred mode) or
-            fully load them (default: True). It is advised to deferred load the data, since in
-            that case Parcels deals with a better memory management during particle set execution.
-            deferred_load=False is however sometimes necessary for plotting the fields.
         uvar :
              (Default value = 'vozocrtx')
         vvar :

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -1,4 +1,3 @@
-import functools
 from enum import IntEnum
 
 import numpy as np
@@ -176,54 +175,6 @@ class Grid:
                     axis=len(self.depth.shape) - 2,
                 )
                 assert self.depth.shape[2] == self.ydim, "Third dim must be y."
-
-    def _computeTimeChunk(self, f, time, signdt):
-        nextTime_loc = np.inf if signdt >= 0 else -np.inf
-        prev_time_indices = self.time
-        if self._update_status == "not_updated":
-            if self._ti >= 0:
-                if time < self.time[0] or time > self.time[1]:
-                    self._ti = -1  # reset
-                elif signdt >= 0 and (time < self.time_full[0] or time >= self.time_full[-1]):
-                    self._ti = -1  # reset
-                elif signdt < 0 and (time <= self.time_full[0] or time > self.time_full[-1]):
-                    self._ti = -1  # reset
-                elif signdt >= 0 and time >= self.time[1] and self._ti < len(self.time_full) - 2:
-                    self._ti += 1
-                    self.time = self.time_full[self._ti : self._ti + 2]
-                    self._update_status = "updated"
-                elif signdt < 0 and time <= self.time[0] and self._ti > 0:
-                    self._ti -= 1
-                    self.time = self.time_full[self._ti : self._ti + 2]
-                    self._update_status = "updated"
-            if self._ti == -1:
-                self.time = self.time_full
-                self._ti = f._time_index(time)
-
-                if signdt == -1 and self._ti > 0 and self.time_full[self._ti] == time:
-                    self._ti -= 1
-                if self._ti >= len(self.time_full) - 1:
-                    self._ti = len(self.time_full) - 2
-
-                self.time = self.time_full[self._ti : self._ti + 2]
-                self.tdim = 2
-                if prev_time_indices is None or len(prev_time_indices) != 2 or len(prev_time_indices) != len(self.time):
-                    self._update_status = "first_updated"
-                elif functools.reduce(
-                    lambda i, j: i and j, map(lambda m, k: m == k, self.time, prev_time_indices), True
-                ) and len(prev_time_indices) == len(self.time):
-                    self._update_status = "not_updated"
-                elif functools.reduce(
-                    lambda i, j: i and j, map(lambda m, k: m == k, self.time[:1], prev_time_indices[:1]), True
-                ) and len(prev_time_indices) == len(self.time):
-                    self._update_status = "updated"
-                else:
-                    self._update_status = "first_updated"
-            if signdt >= 0 and (self._ti < len(self.time_full) - 2 or not f.allow_time_extrapolation):
-                nextTime_loc = self.time[1]
-            elif signdt < 0 and (self._ti > 0 or not f.allow_time_extrapolation):
-                nextTime_loc = self.time[0]
-        return nextTime_loc
 
 
 class RectilinearGrid(Grid):

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -66,7 +66,6 @@ class Grid:
         assert_valid_mesh(mesh)
         self._mesh = mesh
         self._zonal_periodic = False
-        self._defer_load = False
         self._lonlat_minmax = np.array(
             [np.nanmin(lon), np.nanmax(lon), np.nanmin(lat), np.nanmax(lat)], dtype=np.float32
         )
@@ -114,10 +113,6 @@ class Grid:
     @property
     def zonal_periodic(self):
         return self._zonal_periodic
-
-    @property
-    def defer_load(self):
-        return self._defer_load
 
     @staticmethod
     def create_grid(

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -3,7 +3,7 @@ from enum import IntEnum
 import numpy as np
 import numpy.typing as npt
 
-from parcels._typing import Mesh, UpdateStatus, assert_valid_mesh
+from parcels._typing import Mesh, assert_valid_mesh
 from parcels.tools.converters import TimeConverter
 
 __all__ = [
@@ -41,7 +41,6 @@ class Grid:
         mesh: Mesh,
     ):
         self._ti = -1
-        self._update_status: UpdateStatus | None = None
         lon = np.array(lon)
         lat = np.array(lat)
         time = np.zeros(1, dtype=np.float64) if time is None else time

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -56,7 +56,7 @@ def test_field_nonstandardtime(calendar, cftime_datetime, tmpdir):
     filepath = tmpdir.join("test_nonstandardtime.nc")
     dates = [getattr(cftime, cftime_datetime)(1, m, 1) for m in range(1, 13)]
     da = xr.DataArray(
-        np.random.rand(12, xdim, ydim), coords=[dates, range(xdim), range(ydim)], dims=["time", "lon", "lat"], name="U"
+        np.random.rand(12, ydim, xdim), coords=[dates, range(ydim), range(xdim)], dims=["time", "lat", "lon"], name="U"
     )
     da.to_netcdf(str(filepath))
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -77,7 +77,7 @@ def multifile_fieldset(tmp_path):
     files = {"U": ufiles, "V": vfiles}
     variables = {"U": "U", "V": "V"}
     dimensions = {"lon": "lon", "lat": "lat"}
-    return FieldSet.from_netcdf(files, variables, dimensions, timestamps=timestamps, allow_time_extrapolation=True)
+    return FieldSet.from_netcdf(files, variables, dimensions, timestamps=timestamps)
 
 
 @pytest.mark.parametrize("xdim", [100, 200])

--- a/tests/test_fieldset_sampling.py
+++ b/tests/test_fieldset_sampling.py
@@ -600,6 +600,10 @@ def test_sampling_3DCROCO():
     assert np.isclose(pset.p, 1.0)
 
 
+@pytest.mark.v4alpha
+@pytest.mark.xfail(
+    reason="Now timestamps has been removed, and filebuffer expects different files. This needs to be rewritten/removed."
+)
 @pytest.mark.parametrize("npart", [1, 10])
 def test_sampling_multigrids_non_vectorfield_from_file(npart, tmpdir):
     xdim, ydim = 100, 200

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -576,8 +576,7 @@ def test_cgrid_uniform_3dvel_spherical(vert_mode, time):
 
 
 @pytest.mark.parametrize("vert_discretisation", ["zlevel", "slevel", "slevel2"])
-@pytest.mark.parametrize("deferred_load", [True, False])
-def test_popgrid(vert_discretisation, deferred_load):
+def test_popgrid(vert_discretisation):
     if vert_discretisation == "zlevel":
         w_dep = "w_dep"
     elif vert_discretisation == "slevel":
@@ -589,7 +588,7 @@ def test_popgrid(vert_discretisation, deferred_load):
     variables = {"U": "U", "V": "V", "W": "W", "T": "T"}
     dimensions = {"lon": "lon", "lat": "lat", "depth": w_dep, "time": "time"}
 
-    fieldset = FieldSet.from_pop(filenames, variables, dimensions, mesh="flat", deferred_load=deferred_load)
+    fieldset = FieldSet.from_pop(filenames, variables, dimensions, mesh="flat")
 
     def sampleVel(particle, fieldset, time):  # pragma: no cover
         (particle.zonal, particle.meridional, particle.vert) = fieldset.UVW[particle]

--- a/tests/tools/test_warnings.py
+++ b/tests/tools/test_warnings.py
@@ -48,6 +48,8 @@ def test_file_warnings(tmp_zarrfile):
         pset.execute(AdvectionRK4, runtime=3, dt=1, output_file=pfile)
 
 
+@pytest.mark.v4alpha
+@pytest.mark.xfail(reason="https://github.com/OceanParcels/Parcels/pull/1908#issuecomment-2698014941")
 def test_kernel_warnings():
     # positive scaling factor for W
     filenames = str(TEST_DATA / "POPtestdata_time.nc")


### PR DESCRIPTION
Deferred loading will be handled natively by xarray


Changes/commits:
- Remove deferred_load docstrings
- Remove deferred_load param from FieldSet
- Remove deferred_load param from Field
- Remove deferred_load from test suite
- Remove Grid.defer_load
- Remove unreachable code
- read in files using xr.open_mfdataset
- Fix test data dim order
- Refactor tests to use different nc files for multifile loading
- Create multifile_fieldset fixture
- Remove unused Grid.computeTimeChunk()
- Remove unused Grid._update_status
- Remove unused DeferredArray
- Remove unused Field.computeTimeChunk and Field._data_concatenate

---
- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- xref #1844 


I'm still having difficulty with a couple failing tests, so this is still WIP.


```
FAILED docs/examples/example_globcurrent.py::test_globcurrent_startparticles_between_time_arrays[True--300] - RuntimeError: P sampled outside time domain at time 2002-12-31T00:00:00.000000000. Try setting allow_time_extrapolation to True.. Error could not be handled because particle was not part of the Field Sampling.
FAILED docs/examples/example_globcurrent.py::test_globcurrent_startparticles_between_time_arrays[True-300] - RuntimeError: P sampled outside time domain at time 2002-01-01T00:00:00.000000000. Try setting allow_time_extrapolation to True.. Error could not be handled because particle was not part of the Field Sampling.
FAILED docs/examples/example_globcurrent.py::test_globcurrent_startparticles_between_time_arrays[False--300] - RuntimeError: P sampled outside time domain at time 2002-01-28T00:00:00.000000000. Try setting allow_time_extrapolation to True.. Error could not be handled because particle was not part of the Field Sampling.
FAILED docs/examples/example_globcurrent.py::test_globcurrent_startparticles_between_time_arrays[False-300] - RuntimeError: P sampled outside time domain at time 2002-01-01T00:00:00.000000000. Try setting allow_time_extrapolation to True.. Error could not be handled because particle was not part of the Field Sampling.
FAILED tests/tools/test_warnings.py::test_kernel_warnings - parcels.tools.statuscodes.FieldOutOfBoundError: Field sampled out-of-bound, at (depth=0.0, lat=0.0, lon=0.0)
```