### PR TITLE
Add Pixi for development

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 .git_archival.txt  export-subst
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ dist/parcels*.egg
 parcels/_version_setup.py
 .pytest_cache
 .coverage
+
+# pixi environments
+.pixi
+*.egg-info
+pixi.lock

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,6 @@ parcels/_version_setup.py
 # pixi environments
 .pixi
 *.egg-info
+
+# Ignore pixi.lock file for now as Vecko is the only one using pixi for development. This should be checked into VCS if it becomes a more common tool.
 pixi.lock

--- a/docs/community/contributing.rst
+++ b/docs/community/contributing.rst
@@ -74,7 +74,7 @@ From there:
 - create a git branch, implement, commit, and push your changes
 - `create a pull request <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`_ (PR) into ``main`` of the original repo making sure to link to the issue that you are working on. Not yet finished with your feature but still want feedback on how you're going? Then mark it as "draft" and ``@ping`` a maintainer. See our `maintainer notes <maintainer.md>`_ to see our PR review workflow.
 
-If you made changes to the documentation, and want to render a local version, you can run the command ``sphinx-autobuild --ignore "*.zip" docs docs/_build`` to create a server to automatically rebuild the documentation when you make changes.
+Look at the ``[tool.pixi.tasks]`` section of ``pyproject.toml`` for a list of tasks that are useful for development.
 
 Code guidelines
 ~~~~~~~~~~~~~~~

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -56,6 +56,9 @@ The steps below are the installation instructions for Linux, macOS and Windows.
 Installation for developers
 ===========================
 
+Using Miniconda
+---------------
+
 If you would prefer to have a development installation of Parcels (i.e., where the code can be actively edited), you can do so by setting up Miniconda (as detailed in step 1 above), cloning the Parcels repo, installing dependencies using the environment file, and then installing Parcels in an editable mode such that changes to the cloned code can be tested during development.
 
 **Step 1:** Same as `step 1 above`_.
@@ -74,3 +77,20 @@ If you would prefer to have a development installation of Parcels (i.e., where t
 
   conda activate parcels-dev
   pip install --no-build-isolation --no-deps -e .
+
+
+Using Pixi
+----------
+For developers who want to use Pixi (a modern alternative to Anaconda - see `"Transitioning from the conda or mamba to pixi" <https://pixi.sh/latest/switching_from/conda/>`_) to manage their development environment, the following steps can be followed:
+
+**Step 1:** `Install Pixi <https://pixi.sh/latest/>`_.
+
+**Step 2:** Clone the Parcels repo and create a new environment with the development dependencies:
+
+.. code-block:: bash
+
+  git clone https://github.com/OceanParcels/parcels.git
+  cd parcels
+  pixi install
+
+Now you can use ``pixi run`` for a list of available tasks useful for development, such as running tests, checking code coverage, and building the documentation. You can also do ``pixi shell`` to "activate" the environment (and do ``exit`` to deactivate it). See `here <https://pixi.sh/latest/switching_from/conda/#key-differences-at-a-glance>`_ for a comparison between Pixi and Conda commands.

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: parcels
 channels:
   - conda-forge
-dependencies:
+dependencies: #! Keep in sync with [tool.pixi.dependencies] in pyproject.toml
   - python>=3.10
   - ffmpeg>=3.2.3
   - jupyter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,72 @@ homepage = "https://oceanparcels.org/"
 repository = "https://github.com/OceanParcels/parcels"
 Tracker = "https://github.com/OceanParcels/parcels/issues"
 
+[tool.pixi.project]
+channels = ["conda-forge"]
+name = "parcels-dev"
+platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
+
+[tool.pixi.tasks]
+tests = "pytest"
+tests-notebooks = "pytest -v -s --nbval-lax -k 'not documentation and not tutorial_periodic_boundaries'" # TODO v4: Re-enable `tutorial_periodic_boundaries` notebook
+coverage = "coverage run -m pytest && coverage html"
+typing = "mypy parcels"
+pre-commit = "pre-commit run --all-files"
+docs = 'sphinx-autobuild --ignore "*.zip" docs docs/_build'
+
+# TODO v4: Remove v4 specific tasks
+tests-short = "pytest tests/test_advection.py"
+tests-exclude-v4 = "pytest -m 'not v4alpha and not v4future and not v4remove'"
+
+[tool.pixi.dependencies] #! Keep in sync with environment.yml
+python = ">=3.10"
+ffmpeg = ">=3.2.3"
+jupyter = "*"
+matplotlib-base = ">=2.0.2"
+netcdf4 = ">=1.1.9"
+numpy = ">=1.9.1"
+platformdirs = "*"
+psutil = "*"
+pymbolic = "*"
+scipy = ">=0.16.0"
+tqdm = "*"
+xarray = ">=0.10.8"
+cftime = ">=1.3.1"
+dask = ">=2.0"
+scikit-learn = "*"
+zarr = ">=2.11.0,!=2.18.0,<3"
+
+# Notebooks
+trajan = "*"
+
+# Testing
+nbval = "*"
+pytest = "*"
+pytest-html = "*"
+coverage = "*"
+
+# Typing
+mypy = "*"
+types-tqdm = "*"
+types-psutil = "*"
+
+# Linting
+pre_commit = "*"
+
+# Docs
+ipython = "*"
+numpydoc = "*"
+nbsphinx = "*"
+sphinx = "*"
+pandoc = "*"
+pydata-sphinx-theme = "*"
+sphinx-autobuild = "*"
+myst-parser = "*"
+sphinxcontrib-mermaid = "*"
+
+[tool.pixi.pypi-dependencies]
+parcels = { path = ".", editable = true }
+
 [tool.setuptools]
 packages = ["parcels"]
 


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->
Adding Pixi for development (haven't made any changes to our CI setup - that will continue as is). Only downside with this is that there is now duplication between `environment.yml` and `pyproject.toml`

@erikvansebille :
- would you mind trying the new dev setup instructions to make sure its clear?
- thoughts on the `[tool.pixi.tasks]` section? (should we add any more here that would be useful for v4 dev?)

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- Fixes #1912 
- [x] Added documentation
