### PR TITLE
Remove Field.set_depth_from_field() and using `not_yet_set` in dimensions dict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,9 @@ jobs:
         with:
           environment-file: environment.yml
       - name: Integration test
-        run: | # TODO v4: Re-enable `tutorial_periodic_boundaries` notebook
-          coverage run -m pytest -v -s --nbval-lax -k "not documentation and not tutorial_periodic_boundaries" --html="${{ matrix.os }}_${{ matrix.python-version }}_integration_test_report.html" --self-contained-html docs/examples
+        # TODO v4: Re-enable `tutorial_periodic_boundaries` and `tutorial_timevaryingdepthdimensions` notebooks
+        run: |
+          coverage run -m pytest -v -s --nbval-lax -k "not documentation and not tutorial_periodic_boundaries and not tutorial_timevaryingdepthdimensions" --html="${{ matrix.os }}_${{ matrix.python-version }}_integration_test_report.html" --self-contained-html docs/examples
           coverage xml
       - name: Codecov
         uses: codecov/codecov-action@v5.3.1

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -234,12 +234,6 @@ class Field:
         self._dataFiles = kwargs.pop("dataFiles", None)
         self._netcdf_engine = kwargs.pop("netcdf_engine", "netcdf4")
         self._creation_log = kwargs.pop("creation_log", "")
-        self.grid.depth_field = kwargs.pop("depth_field", None)
-
-        if self.grid.depth_field == "not_yet_set":
-            assert (
-                self.grid._z4d
-            ), "Providing the depth dimensions from another field data is only available for 4d S grids"
 
         # data_full_zdim is the vertical dimension of the complete field data, ignoring the indices.
         # (data_full_zdim = grid.zdim if no indices are used, for A- and C-grids and for some B-grids). It is used for the B-grid,
@@ -498,11 +492,7 @@ class Field:
                 gridindexingtype=gridindexingtype,
             ) as filebuffer:
                 filebuffer.name = variable[1]
-                if dimensions["depth"] == "not_yet_set":
-                    depth = filebuffer.depth_dimensions
-                    kwargs["depth_field"] = "not_yet_set"
-                else:
-                    depth = filebuffer.depth
+                depth = filebuffer.depth
                 data_full_zdim = filebuffer.data_full_zdim
         else:
             indices["depth"] = [0]
@@ -689,19 +679,6 @@ class Field:
             raise NotImplementedError(f"Scaling factor for field {self.name} already defined.")
         self._scaling_factor = factor
         self.data *= factor
-
-    def set_depth_from_field(self, field):
-        """Define the depth dimensions from another (time-varying) field.
-
-        Notes
-        -----
-        See `this tutorial <../examples/tutorial_timevaryingdepthdimensions.ipynb>`__
-        for a detailed explanation on how to set up time-evolving depth dimensions.
-
-        """
-        self.grid.depth_field = field
-        if self.grid != field.grid:
-            field.grid.depth_field = field
 
     def _search_indices(self, time, z, y, x, ti, particle=None, search2D=False):
         if self.grid._gtype in [GridType.RectilinearSGrid, GridType.RectilinearZGrid]:

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -290,13 +290,6 @@ class FieldSet:
         for f in self.get_fields():
             if isinstance(f, (VectorField, NestedField)) or f._dataFiles is None:
                 continue
-            if f.grid.depth_field is not None:
-                if f.grid.depth_field == "not_yet_set":
-                    raise ValueError(
-                        "If depth dimension is set at 'not_yet_set', it must be added later using Field.set_depth_from_field(field)"
-                    )
-                depth_data = f.grid.depth_field.data
-                f.grid._depth = depth_data if isinstance(depth_data, np.ndarray) else np.array(depth_data)
         self._completed = True
 
     @classmethod
@@ -433,8 +426,6 @@ class FieldSet:
                 if procdims == dims and procinds == inds:
                     possibly_samegrid = True
                     if not possibly_samegrid:
-                        break
-                    if "depth" in dims and dims["depth"] == "not_yet_set":
                         break
                     processedGrid = False
                     if (not isinstance(filenames, dict)) or filenames[procvar] == filenames[var]:

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -67,7 +67,6 @@ class Grid:
         self._lonlat_minmax = np.array(
             [np.nanmin(lon), np.nanmax(lon), np.nanmin(lat), np.nanmax(lat)], dtype=np.float32
         )
-        self.depth_field = None
 
     def __repr__(self):
         with np.printoptions(threshold=5, suppress=True, linewidth=120, formatter={"float": "{: 0.2f}".format}):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 
 [tool.pixi.tasks]
 tests = "pytest"
-tests-notebooks = "pytest -v -s --nbval-lax -k 'not documentation and not tutorial_periodic_boundaries'" # TODO v4: Re-enable `tutorial_periodic_boundaries` notebook
+tests-notebooks = "pytest -v -s --nbval-lax -k 'not documentation and not tutorial_periodic_boundaries and not tutorial_timevaryingdepthdimensions'" # TODO v4: Re-enable `tutorial_periodic_boundaries` and `tutorial_timevaryingdepthdimensions` notebooks
 coverage = "coverage run -m pytest && coverage html"
 typing = "mypy parcels"
 pre-commit = "pre-commit run --all-files"


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->

> Remove Field.set_depth_from_field() and using `not_yet_set` in dimensions dict

This was the mechanism that was used for setting timevarying fields. This will be implemented in a different way in v4 - so this is not a complete removal of 4D depth grids.

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- xref #1914

