### PR TITLE
Replace upload of mypy to codecov with artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
     needs:
       - unit-test
       - integration-test
+      - typechecking
     steps:
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4
@@ -116,13 +117,10 @@ jobs:
       - run: conda install lxml # dep for report generation
       - name: Typechecking
         run: |
-          mypy --install-types --non-interactive parcels --cobertura-xml-report mypy_report
-      - name: Upload mypy coverage to Codecov
-        uses: codecov/codecov-action@v5.3.1
-        if: ${{ always() }} # Upload even on error of mypy
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          mypy --install-types --non-interactive parcels --html-report mypy-report
+      - name: Upload test results
+        if: ${{ always() }} # Upload even on mypy error
+        uses: actions/upload-artifact@v4
         with:
-          file: mypy_report/cobertura.xml
-          flags: mypy
-          fail_ci_if_error: false
+          name: Mypy report
+          path: mypy-report

--- a/environment.yml
+++ b/environment.yml
@@ -30,6 +30,7 @@ dependencies: #! Keep in sync with [tool.pixi.dependencies] in pyproject.toml
 
   # Typing
   - mypy
+  - lxml # in CI
   - types-tqdm
   - types-psutil
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ coverage = "*"
 
 # Typing
 mypy = "*"
+lxml = "*" # in CI
 types-tqdm = "*"
 types-psutil = "*"
 


### PR DESCRIPTION
Uploading mypy coverage to codecov led to confusing output with the way codecov displayed it by default. Disabling the upload in favour of artifact upload. 

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)

This is a minor change that mainly affects active development - not worth adding to main as well in my opinion