### PR TITLE
Moving the _search_time_index function to _index_search.py

### DIFF
--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -43,7 +43,7 @@ def _search_time_index(grid: Grid, time: float, allow_time_extrapolation=True):
         # the first field frame without interpolation
         ti = 0
     else:
-        ti = time_index.argmin() - 1 if time_index.any() else 0
+        ti = int(time_index.argmin() - 1) if time_index.any() else 0
     if grid.tdim == 1:
         tau = 0
     elif ti == len(grid.time) - 1:

--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -14,6 +14,7 @@ from parcels.tools.statuscodes import (
     _raise_field_out_of_bound_error,
     _raise_field_out_of_bound_surface_error,
     _raise_field_sampling_error,
+    _raise_time_extrapolation_error,
 )
 
 from .grid import GridType
@@ -21,6 +22,35 @@ from .grid import GridType
 if TYPE_CHECKING:
     from .field import Field
     from .grid import Grid
+
+
+def _search_time_index(grid: Grid, time: float, allow_time_extrapolation=True):
+    """Find and return the index and relative coordinate in the time array associated with a given time.
+
+    Note that we normalize to either the first or the last index
+    if the sampled value is outside the time value range.
+    """
+    if not allow_time_extrapolation and (time < grid.time[0] or time > grid.time[-1]):
+        _raise_time_extrapolation_error(time, field=None)
+    time_index = grid.time <= time
+
+    if time_index.all():
+        # If given time > last known field time, use
+        # the last field frame without interpolation
+        ti = len(grid.time) - 1
+    elif np.logical_not(time_index).all():
+        # If given time < any time in the field, use
+        # the first field frame without interpolation
+        ti = 0
+    else:
+        ti = time_index.argmin() - 1 if time_index.any() else 0
+    if grid.tdim == 1:
+        tau = 0
+    elif ti == len(grid.time) - 1:
+        tau = 1
+    else:
+        tau = (time - grid.time[ti]) / (grid.time[ti + 1] - grid.time[ti]) if grid.time[ti] != grid.time[ti + 1] else 0
+    return tau, ti
 
 
 def search_indices_vertical_z(grid: Grid, gridindexingtype: GridIndexingType, z: float):

--- a/parcels/grid.py
+++ b/parcels/grid.py
@@ -58,6 +58,7 @@ class Grid:
         self._lon = lon
         self._lat = lat
         self.time = time
+        self.tdim = time.size
         self.time_full = self.time  # needed for deferred_loaded Fields
         self._time_origin = TimeConverter() if time_origin is None else time_origin
         assert isinstance(self.time_origin, TimeConverter), "time_origin needs to be a TimeConverter object"
@@ -183,7 +184,6 @@ class RectilinearGrid(Grid):
             assert len(time.shape) == 1, "time is not a vector"
 
         super().__init__(lon, lat, time, time_origin, mesh)
-        self.tdim = self.time.size
 
     @property
     def xdim(self):
@@ -327,7 +327,6 @@ class CurvilinearGrid(Grid):
         lon = lon.squeeze()
         lat = lat.squeeze()
         super().__init__(lon, lat, time, time_origin, mesh)
-        self.tdim = self.time.size
 
     @property
     def xdim(self):

--- a/parcels/tools/statuscodes.py
+++ b/parcels/tools/statuscodes.py
@@ -10,6 +10,7 @@ __all__ = [
     "_raise_field_out_of_bound_error",
     "_raise_field_out_of_bound_surface_error",
     "_raise_field_sampling_error",
+    "_raise_time_extrapolation_error",
 ]
 
 
@@ -75,6 +76,10 @@ class TimeExtrapolationError(RuntimeError):
             " Try setting allow_time_extrapolation to True."
         )
         super().__init__(message)
+
+
+def _raise_time_extrapolation_error(time: float, field=None):
+    raise TimeExtrapolationError(time, field)
 
 
 class KernelError(RuntimeError):

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -450,9 +450,11 @@ def test_fieldset_write(tmp_zarrfile):
     fieldset.U.to_write = True
 
     def UpdateU(particle, fieldset, time):  # pragma: no cover
+        from parcels._index_search import _search_time_index
+
         tmp1, tmp2 = fieldset.UV[particle]
         _, yi, xi = fieldset.U.unravel_index(particle.ei)
-        _, ti = fieldset.U._search_time_index(time)
+        _, ti = _search_time_index(fieldset.U.grid, time)
         fieldset.U.data[ti, yi, xi] += 1
         fieldset.U.grid.time[0] = time
 


### PR DESCRIPTION
This PR moves the `Field._search_time_index` method to its own function in `_index_search.py`, where I feel it would fit better 
<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
