### PR TITLE
Removing Field.to_write and FieldSet.to_write methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,13 @@ jobs:
         with:
           environment-file: environment.yml
       - name: Integration test
-        # TODO v4: Re-enable `tutorial_periodic_boundaries`, `tutorial_timevaryingdepthdimensions` and `tutorial_croco_3D` notebooks
-        # TODO v4: Re-enable `tutorial_nemo_3D` notebook once 3D grids are implemented (https://github.com/OceanParcels/Parcels/pull/1936#issuecomment-2717666705)
+        # TODO v4: Re-enable `tutorial_periodic_boundaries`
+        # TODO v4: Re-enable `tutorial_timevaryingdepthdimensions`
+        # TODO v4: Re-enable `tutorial_particle_field_interaction`
+        # TODO v4: Re-enable `tutorial_croco_3D`
+        # TODO v4: Re-enable `tutorial_nemo_3D` (https://github.com/OceanParcels/Parcels/pull/1936#issuecomment-2717666705)
         run: |
-          coverage run -m pytest -v -s --nbval-lax -k "not documentation and not tutorial_periodic_boundaries and not tutorial_timevaryingdepthdimensions and not tutorial_croco_3D and not tutorial_nemo_3D" --html="${{ matrix.os }}_${{ matrix.python-version }}_integration_test_report.html" --self-contained-html docs/examples
+          coverage run -m pytest -v -s --nbval-lax -k "not documentation and not tutorial_periodic_boundaries and not tutorial_timevaryingdepthdimensions and not tutorial_particle_field_interaction and not tutorial_croco_3D and not tutorial_nemo_3D" --html="${{ matrix.os }}_${{ matrix.python-version }}_integration_test_report.html" --self-contained-html docs/examples
           coverage xml
       - name: Codecov
         uses: codecov/codecov-action@v5.3.1

--- a/docs/examples/example_decaying_moving_eddy.py
+++ b/docs/examples/example_decaying_moving_eddy.py
@@ -99,10 +99,8 @@ def test_rotation_example(tmpdir):
 
 
 def main():
-    fset_filename = "decaying_moving_eddy"
     outfile = "DecayingMovingParticle.zarr"
     fieldset = decaying_moving_eddy_fieldset()
-    fieldset.write(fset_filename)
 
     decaying_moving_example(fieldset, outfile)
 

--- a/docs/examples/example_peninsula.py
+++ b/docs/examples/example_peninsula.py
@@ -207,14 +207,6 @@ def test_peninsula_fieldset_AnalyticalAdvection(mesh, tmpdir):
     assert (err_adv <= 3.0e2).all()
 
 
-def fieldsetfile(mesh, tmpdir):
-    """Generate fieldset files for peninsula test."""
-    filename = tmpdir.join("peninsula")
-    fieldset = peninsula_fieldset(100, 50, mesh=mesh)
-    fieldset.write(filename)
-    return filename
-
-
 def test_peninsula_file(tmpdir):
     """Open fieldset files and execute."""
     data_folder = parcels.download_example_dataset("Peninsula_data")
@@ -294,24 +286,10 @@ Example of particle advection around an idealised peninsula"""
     )
     args = p.parse_args(args)
 
-    filename = "peninsula"
     if args.fieldset is not None:
         fieldset = peninsula_fieldset(args.fieldset[0], args.fieldset[1], mesh="flat")
     else:
         fieldset = peninsula_fieldset(100, 50, mesh="flat")
-    fieldset.write(filename)
-
-    # Open fieldset file set
-    filenames = {
-        "U": f"{filename}U.nc",
-        "V": f"{filename}V.nc",
-        "P": f"{filename}P.nc",
-    }
-    variables = {"U": "vozocrtx", "V": "vomecrty", "P": "P"}
-    dimensions = {"lon": "nav_lon", "lat": "nav_lat", "time": "time_counter"}
-    fieldset = parcels.FieldSet.from_netcdf(
-        filenames, variables, dimensions, allow_time_extrapolation=True
-    )
 
     outfile = "Peninsula"
 

--- a/docs/examples/example_radial_rotation.py
+++ b/docs/examples/example_radial_rotation.py
@@ -86,10 +86,7 @@ def test_rotation_example(tmpdir):
 
 
 def main():
-    filename = "radial_rotation"
     fieldset = radial_rotation_fieldset()
-    fieldset.write(filename)
-
     outfile = "RadialParticle"
     rotation_example(fieldset, outfile)
 

--- a/docs/examples/example_stommel.py
+++ b/docs/examples/example_stommel.py
@@ -101,16 +101,12 @@ def stommel_example(
     outfile="StommelParticle.zarr",
     repeatdt=None,
     maxage=None,
-    write_fields=True,
     custom_partition_function=False,
 ):
     parcels.timer.fieldset = parcels.timer.Timer(
         "FieldSet", parent=parcels.timer.stommel
     )
     fieldset = stommel_fieldset(grid_type=grid_type)
-    if write_fields:
-        filename = "stommel"
-        fieldset.write(filename)
     parcels.timer.fieldset.stop()
 
     parcels.timer.pset = parcels.timer.Timer("Pset", parent=parcels.timer.stommel)
@@ -184,14 +180,12 @@ def test_stommel_fieldset(grid_type, tmpdir):
         method=method["RK4"],
         grid_type=grid_type,
         outfile=outfile,
-        write_fields=False,
     )
     psetRK45 = stommel_example(
         1,
         method=method["RK45"],
         grid_type=grid_type,
         outfile=outfile,
-        write_fields=False,
     )
     assert np.allclose(psetRK4.lon, psetRK45.lon, rtol=1e-3)
     assert np.allclose(psetRK4.lat, psetRK45.lat, rtol=1.1e-3)
@@ -252,12 +246,6 @@ Example of particle advection in the steady-state solution of the Stommel equati
         help="max age of the particles (after which particles are deleted)",
     )
     p.add_argument(
-        "-wf",
-        "--write_fields",
-        default=True,
-        help="Write the hydrodynamic fields to NetCDF",
-    )
-    p.add_argument(
         "-cpf",
         "--custom_partition_function",
         default=False,
@@ -274,7 +262,6 @@ Example of particle advection in the steady-state solution of the Stommel equati
         outfile=args.outfile,
         repeatdt=args.repeatdt,
         maxage=args.maxage,
-        write_fields=args.write_fields,
         custom_partition_function=args.custom_partition_function,
     )
     parcels.timer.stommel.stop()

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -6,7 +6,6 @@ from glob import glob
 
 import numpy as np
 
-from parcels._compat import MPI
 from parcels._typing import GridIndexingType, InterpMethodOption, Mesh
 from parcels.field import Field, VectorField
 from parcels.grid import Grid
@@ -14,7 +13,6 @@ from parcels.gridset import GridSet
 from parcels.particlefile import ParticleFile
 from parcels.tools._helpers import fieldset_repr
 from parcels.tools.converters import TimeConverter
-from parcels.tools.loggers import logger
 from parcels.tools.warnings import FieldSetWarning
 
 __all__ = ["FieldSet"]
@@ -1002,26 +1000,6 @@ class FieldSet:
         `Periodic boundaries <../examples/tutorial_periodic_boundaries.ipynb>`__
         """
         setattr(self, name, value)
-
-    def write(self, filename):
-        """Write FieldSet to NetCDF file using NEMO convention.
-
-        Parameters
-        ----------
-        filename : str
-            Basename of the output fileset.
-        """
-        if MPI is None or MPI.COMM_WORLD.Get_rank() == 0:
-            logger.info(f"Generating FieldSet output with basename: {filename}")
-
-            if hasattr(self, "U"):
-                self.U.write(filename, varname="vozocrtx")
-            if hasattr(self, "V"):
-                self.V.write(filename, varname="vomecrty")
-
-            for v in self.get_fields():
-                if isinstance(v, Field) and (v.name != "U") and (v.name != "V"):
-                    v.write(filename)
 
     def computeTimeChunk(self, time=0.0, dt=1):
         """Load a chunk of three data time steps into the FieldSet.

--- a/parcels/tools/_helpers.py
+++ b/parcels/tools/_helpers.py
@@ -75,7 +75,6 @@ def field_repr(field: Field) -> str:
     grid            : {field.grid!r}
     extrapolate time: {field.allow_time_extrapolation!r}
     gridindexingtype: {field.gridindexingtype!r}
-    to_write        : {field.to_write!r}
 """
     return textwrap.dedent(out).strip()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 
 [tool.pixi.tasks]
 tests = "pytest"
-tests-notebooks = "pytest -v -s --nbval-lax -k 'not documentation and not tutorial_periodic_boundaries and not tutorial_timevaryingdepthdimensions and not tutorial_croco_3D and not tutorial_nemo_3D'" # TODO v4: Re-enable `tutorial_periodic_boundaries`, `tutorial_timevaryingdepthdimensions`, `tutorial_croco_3D`, `tutorial_nemo_3D` notebooks
+tests-notebooks = "pytest -v -s --nbval-lax -k 'not documentation and not tutorial_periodic_boundaries and not tutorial_timevaryingdepthdimensions and not tutorial_particle_field_interaction and not tutorial_croco_3D and not tutorial_nemo_3D'" # TODO v4: Mirror ci.yml for notebooks being run
 coverage = "coverage run -m pytest && coverage html"
 typing = "mypy parcels"
 pre-commit = "pre-commit run --all-files"

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -459,7 +459,6 @@ def test_stationary_eddy_vertical():
     pset.execute(AdvectionRK4_3D, dt=dt, endtime=endtime)
     exp_lon = [truth_stationary(x, z, pset[0].time)[0] for x, z in zip(lon, depth, strict=True)]
     exp_depth = [truth_stationary(x, z, pset[0].time)[1] for x, z in zip(lon, depth, strict=True)]
-    print(pset, exp_lon)
     assert np.allclose(pset.lon, exp_lon, rtol=1e-5)
     assert np.allclose(pset.lat, lat, rtol=1e-5)
     assert np.allclose(pset.depth, exp_depth, rtol=1e-5)

--- a/tests/test_mpirun.py
+++ b/tests/test_mpirun.py
@@ -19,10 +19,10 @@ def test_mpi_run(tmpdir, repeatdt, maxage, nump):
     outputNoMPI = tmpdir.join("StommelNoMPI.zarr")
 
     os.system(
-        f"mpirun -np 2 python {stommel_file} -p {nump} -o {outputMPI_partition_function} -r {repeatdt} -a {maxage} -wf False -cpf True"
+        f"mpirun -np 2 python {stommel_file} -p {nump} -o {outputMPI_partition_function} -r {repeatdt} -a {maxage} -cpf True"
     )
-    os.system(f"mpirun -np 2 python {stommel_file} -p {nump} -o {outputMPI} -r {repeatdt} -a {maxage} -wf False")
-    os.system(f"python {stommel_file} -p {nump} -o {outputNoMPI} -r {repeatdt} -a {maxage} -wf False")
+    os.system(f"mpirun -np 2 python {stommel_file} -p {nump} -o {outputMPI} -r {repeatdt} -a {maxage}")
+    os.system(f"python {stommel_file} -p {nump} -o {outputNoMPI} -r {repeatdt} -a {maxage}")
 
     ds2 = xr.open_zarr(outputNoMPI)
 


### PR DESCRIPTION
This PR removes the `Field.to_write` and `FieldSet.to_write` methods, as Field writing can be handled natively by xarray in v4

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
