### PR TITLE
Update particleset.py to make partition_function with repeatdt

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -199,7 +199,7 @@ class ParticleSet:
             if time[0] and not np.allclose(time, time[0]):
                 raise ValueError("All Particle.time should be the same when repeatdt is not None")
             self._repeatpclass = pclass
-            self._repeatkwargs = kwargs
+            self._repeatkwargs = kwargs.copy()
             self._repeatkwargs.pop("partition_function", None)
 
         ngrids = fieldset.gridset.size


### PR DESCRIPTION
There was a bug where deleting the partition_function from the _repeatkwargs property of the particleset class also removed from the kwargs for the initial particleset creation when the repeatdt option was used. This fixes that bug by making a shallow copy of kwargs when creating _repeatkwargs.

<!-- Feel free to remove list items that are not relevant for your changes. -->

- [ ] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- [ ] Fixes #
- [ ] Added tests
- [ ] Added documentation
