### PR TITLE
TimeInterval helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ parcels.egg-info/*
 dist/parcels*.egg
 parcels/_version_setup.py
 .pytest_cache
+.hypothesis
 .coverage
 
 # pixi environments

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies: #! Keep in sync with [tool.pixi.dependencies] in pyproject.toml
   - pytest
   - pytest-html
   - coverage
+  - hypothesis
 
   # Typing
   - mypy

--- a/parcels/_core/utils/time.py
+++ b/parcels/_core/utils/time.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, TypeVar
+
+from cftime import datetime as cftime_datetime
+
+T = TypeVar("T", datetime, cftime_datetime)
+
+
+class TimeInterval:
+    def __init__(self, left: T, right: T, closed: Literal["right", "left", "both", "neither"] = "left") -> None:
+        if not isinstance(left, (datetime, cftime_datetime)):
+            raise ValueError(f"Expected left to be a datetime or cftime_datetime, got {type(left)}.")
+        if not isinstance(right, (datetime, cftime_datetime)):
+            raise ValueError(f"Expected right to be a datetime or cftime_datetime, got {type(right)}.")
+        if left >= right:
+            raise ValueError(f"Expected left to be strictly less than right, got left={left} and right={right}.")
+
+        if closed not in ["right", "left", "both", "neither"]:
+            raise ValueError(f"Invalid closed value: {closed}")
+
+        self.left = left
+        self.right = right
+        self.closed = closed
+
+    def __contains__(self, item: T) -> bool:
+        if self.closed == "left":
+            return self.left <= item < self.right
+        elif self.closed == "right":
+            return self.left < item <= self.right
+        elif self.closed == "both":
+            return self.left <= item <= self.right
+        elif self.closed == "neither":
+            return self.left < item < self.right
+        else:
+            raise ValueError(f"Invalid closed value: {self.closed}")
+
+    def __repr__(self) -> str:
+        return f"TimeInterval(left={self.left!r}, right={self.right!r}, closed={self.closed!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TimeInterval):
+            return False
+        return self.left == other.left and self.right == other.right and self.closed == other.closed
+
+    def __ne__(self, other: object) -> bool:
+        return not self.__eq__(other)
+
+    def intersection(self, other: TimeInterval) -> TimeInterval: ...

--- a/parcels/_core/utils/time.py
+++ b/parcels/_core/utils/time.py
@@ -30,7 +30,7 @@ class TimeInterval:
             raise ValueError(f"Expected right to be a datetime or cftime.datetime, got {type(right)}.")
         if left >= right:
             raise ValueError(f"Expected left to be strictly less than right, got left={left} and right={right}.")
-        if not _is_compatible(left, right):
+        if not is_compatible(left, right):
             raise ValueError(f"Expected left and right to be compatible, got left={left} and right={right}.")
 
         self.left = left
@@ -52,16 +52,16 @@ class TimeInterval:
 
     def intersection(self, other: TimeInterval) -> TimeInterval | None:
         """Return the intersection of two time intervals. Returns None if there is no overlap."""
-        try:
-            start = max(self.left, other.left)
-            end = min(self.right, other.right)
-        except Exception as e:
-            raise ValueError("TimeIntervals are not compatible.") from e
+        if not is_compatible(self.left, other.left):
+            raise ValueError("TimeIntervals are not compatible.")
+
+        start = max(self.left, other.left)
+        end = min(self.right, other.right)
 
         return TimeInterval(start, end) if start <= end else None
 
 
-def _is_compatible(t1: datetime | cftime.datetime, t2: datetime | cftime.datetime) -> bool:
+def is_compatible(t1: datetime | cftime.datetime, t2: datetime | cftime.datetime) -> bool:
     """Checks whether two (cftime.)datetime objects are compatible."""
     try:
         t1 - t2

--- a/parcels/_core/utils/time.py
+++ b/parcels/_core/utils/time.py
@@ -1,50 +1,71 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal, TypeVar
+from typing import TypeVar
 
-from cftime import datetime as cftime_datetime
+import cftime
 
-T = TypeVar("T", datetime, cftime_datetime)
+T = TypeVar("T", datetime, cftime.datetime)
 
 
 class TimeInterval:
-    def __init__(self, left: T, right: T, closed: Literal["right", "left", "both", "neither"] = "left") -> None:
-        if not isinstance(left, (datetime, cftime_datetime)):
-            raise ValueError(f"Expected left to be a datetime or cftime_datetime, got {type(left)}.")
-        if not isinstance(right, (datetime, cftime_datetime)):
-            raise ValueError(f"Expected right to be a datetime or cftime_datetime, got {type(right)}.")
+    """A class representing a time interval between two datetime objects.
+
+    Parameters
+    ----------
+    left : datetime or cftime.datetime
+        The left endpoint of the interval.
+    right : datetime or cftime.datetime
+        The right endpoint of the interval.
+
+    Notes
+    -----
+    For the purposes of this codebase, the interval can be thought of as closed on the left and right.
+    """
+
+    def __init__(self, left: T, right: T) -> None:
+        if not isinstance(left, (datetime, cftime.datetime)):
+            raise ValueError(f"Expected left to be a datetime or cftime.datetime, got {type(left)}.")
+        if not isinstance(right, (datetime, cftime.datetime)):
+            raise ValueError(f"Expected right to be a datetime or cftime.datetime, got {type(right)}.")
         if left >= right:
             raise ValueError(f"Expected left to be strictly less than right, got left={left} and right={right}.")
-
-        if closed not in ["right", "left", "both", "neither"]:
-            raise ValueError(f"Invalid closed value: {closed}")
+        if not _is_compatible(left, right):
+            raise ValueError(f"Expected left and right to be compatible, got left={left} and right={right}.")
 
         self.left = left
         self.right = right
-        self.closed = closed
 
     def __contains__(self, item: T) -> bool:
-        if self.closed == "left":
-            return self.left <= item < self.right
-        elif self.closed == "right":
-            return self.left < item <= self.right
-        elif self.closed == "both":
-            return self.left <= item <= self.right
-        elif self.closed == "neither":
-            return self.left < item < self.right
-        else:
-            raise ValueError(f"Invalid closed value: {self.closed}")
+        return self.left <= item <= self.right
 
     def __repr__(self) -> str:
-        return f"TimeInterval(left={self.left!r}, right={self.right!r}, closed={self.closed!r})"
+        return f"TimeInterval(left={self.left!r}, right={self.right!r})"
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TimeInterval):
             return False
-        return self.left == other.left and self.right == other.right and self.closed == other.closed
+        return self.left == other.left and self.right == other.right
 
     def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
-    def intersection(self, other: TimeInterval) -> TimeInterval: ...
+    def intersection(self, other: TimeInterval) -> TimeInterval | None:
+        """Return the intersection of two time intervals. Returns None if there is no overlap."""
+        try:
+            start = max(self.left, other.left)
+            end = min(self.right, other.right)
+        except Exception as e:
+            raise ValueError("TimeIntervals are not compatible.") from e
+
+        return TimeInterval(start, end) if start <= end else None
+
+
+def _is_compatible(t1: datetime | cftime.datetime, t2: datetime | cftime.datetime) -> bool:
+    """Checks whether two (cftime.)datetime objects are compatible."""
+    try:
+        t1 - t2
+    except Exception:
+        return False
+    else:
+        return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ trajan = "*"
 # Testing
 nbval = "*"
 pytest = "*"
+hypothesis = "*"
 pytest-html = "*"
 coverage = "*"
 

--- a/tests/v4/test_gridadapter.py
+++ b/tests/v4/test_gridadapter.py
@@ -10,18 +10,18 @@ from parcels.tools.converters import TimeConverter
 from parcels.v4.grid import Grid as NewGrid
 from parcels.v4.gridadapter import GridAdapter
 
-TestCase = namedtuple("TestCase", ["Grid", "attr", "expected"])
+GridTestCase = namedtuple("GridTestCase", ["Grid", "attr", "expected"])
 
 test_cases = [
-    TestCase(datasets["ds_2d_left"], "lon", datasets["ds_2d_left"].XG.values),
-    TestCase(datasets["ds_2d_left"], "lat", datasets["ds_2d_left"].YG.values),
-    TestCase(datasets["ds_2d_left"], "depth", datasets["ds_2d_left"].ZG.values),
-    TestCase(datasets["ds_2d_left"], "time", datasets["ds_2d_left"].time.values),
-    TestCase(datasets["ds_2d_left"], "xdim", N),
-    TestCase(datasets["ds_2d_left"], "ydim", 2 * N),
-    TestCase(datasets["ds_2d_left"], "zdim", 3 * N),
-    TestCase(datasets["ds_2d_left"], "tdim", T),
-    TestCase(datasets["ds_2d_left"], "time_origin", TimeConverter(datasets["ds_2d_left"].time.values[0])),
+    GridTestCase(datasets["ds_2d_left"], "lon", datasets["ds_2d_left"].XG.values),
+    GridTestCase(datasets["ds_2d_left"], "lat", datasets["ds_2d_left"].YG.values),
+    GridTestCase(datasets["ds_2d_left"], "depth", datasets["ds_2d_left"].ZG.values),
+    GridTestCase(datasets["ds_2d_left"], "time", datasets["ds_2d_left"].time.values),
+    GridTestCase(datasets["ds_2d_left"], "xdim", N),
+    GridTestCase(datasets["ds_2d_left"], "ydim", 2 * N),
+    GridTestCase(datasets["ds_2d_left"], "zdim", 3 * N),
+    GridTestCase(datasets["ds_2d_left"], "tdim", T),
+    GridTestCase(datasets["ds_2d_left"], "time_origin", TimeConverter(datasets["ds_2d_left"].time.values[0])),
 ]
 
 

--- a/tests/v4/utils/test_time.py
+++ b/tests/v4/utils/test_time.py
@@ -23,9 +23,9 @@ def cftime_datetime_strategy(draw, calendar=None):
 
 
 @st.composite
-def cftime_interval_strategy(draw, left=None):
+def cftime_interval_strategy(draw, left=None, calendar=None):
     if left is None:
-        left = draw(cftime_datetime_strategy())
+        left = draw(cftime_datetime_strategy(calendar=calendar))
     right = left + draw(
         st.timedeltas(
             min_value=timedelta(seconds=1),
@@ -62,6 +62,16 @@ def test_time_interval_contains(interval):
     assert left in interval
     assert right in interval
     assert middle in interval
+
+
+@given(cftime_interval_strategy(calendar="365_day"), cftime_interval_strategy(calendar="365_day"))
+def test_time_interval_intersection_commutative(interval1, interval2):
+    assert interval1.intersection(interval2) == interval2.intersection(interval1)
+
+
+@given(cftime_interval_strategy())
+def test_time_interval_intersection_with_self(interval):
+    assert interval.intersection(interval) == interval
 
 
 def test_time_interval_repr():

--- a/tests/v4/utils/test_time.py
+++ b/tests/v4/utils/test_time.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from cftime import datetime as cftime_datetime
+from hypothesis import given
+from hypothesis import strategies as st
+
+from parcels._core.utils.time import TimeInterval
+
+calendar_strategy = st.sampled_from(["gregorian", "proleptic_gregorian", "365_day", "360_day", "julian", "366_day"])
+closed_strategy = st.sampled_from(["right", "left", "both", "neither"])
+
+
+@st.composite
+def cftime_datetime_strategy(draw, calendar=None):
+    year = draw(st.integers(1900, 2100))
+    month = draw(st.integers(1, 12))
+    day = draw(st.integers(1, 28))
+    if calendar is None:
+        calendar = draw(calendar_strategy)
+    return cftime_datetime(year, month, day, calendar=calendar)
+
+
+@st.composite
+def cftime_interval_strategy(draw, left=None):
+    if left is None:
+        left = draw(cftime_datetime_strategy())
+    right = left + draw(
+        st.timedeltas(
+            min_value=timedelta(seconds=1),
+            max_value=timedelta(days=100 * 365),
+        )
+    )
+    closed = draw(closed_strategy)
+    return TimeInterval(left, right, closed)
+
+
+@pytest.mark.parametrize("closed", ["right", "left", "both", "neither"])
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        (cftime_datetime(2023, 1, 1, calendar="gregorian"), cftime_datetime(2023, 1, 2, calendar="gregorian")),
+        (cftime_datetime(2023, 6, 1, calendar="365_day"), cftime_datetime(2023, 6, 2, calendar="365_day")),
+        (cftime_datetime(2023, 12, 1, calendar="360_day"), cftime_datetime(2023, 12, 2, calendar="360_day")),
+    ],
+)
+def test_time_interval_initialization(left, right, closed):
+    """Test that TimeInterval can be initialized with valid inputs."""
+    interval = TimeInterval(left, right, closed)
+    assert interval.left == left
+    assert interval.right == right
+    assert interval.closed == closed
+
+    with pytest.raises(ValueError):
+        TimeInterval(right, left, closed)
+
+
+def test_time_interval_invalid_closed():
+    """Test that TimeInterval raises ValueError for invalid closed values."""
+    left = datetime(2023, 1, 1)
+    right = datetime(2023, 1, 2)
+    with pytest.raises(ValueError):
+        TimeInterval(left, right, closed="invalid")
+
+
+@given(cftime_interval_strategy())
+def test_time_interval_contains(interval):
+    left = interval.left
+    right = interval.right
+    middle = left + (right - left) / 2
+
+    if interval.closed in ["left", "both"]:
+        assert left in interval
+    if interval.closed in ["right", "both"]:
+        assert right in interval
+
+    assert middle in interval
+
+
+def test_time_interval_repr():
+    """Test the string representation of TimeInterval."""
+    interval = TimeInterval(datetime(2023, 1, 1, 12, 0), datetime(2023, 1, 2, 12, 0), "both")
+    expected = "TimeInterval(left=datetime.datetime(2023, 1, 1, 12, 0), right=datetime.datetime(2023, 1, 2, 12, 0), closed='both')"
+    assert repr(interval) == expected
+
+
+@given(cftime_interval_strategy())
+def test_time_interval_equality(interval):
+    assert interval == interval


### PR DESCRIPTION
This PR adds a TimeInterval helper class that will be used in the particleset execution. This class is compatible with datetime objects from `datetime` and `cftime`.

This PR also adds [Hypothesis](https://hypothesis.readthedocs.io/en/latest/), a package to do [property based testing](https://medium.com/@keployio/property-based-testing-ensuring-robust-software-with-comprehensive-test-scenarios-1edb5ee9650a). These tests take longer to run, but end up being more robust than unit tests. Happy to hear thoughts on that.

- [x] Chose the correct base branch (`v4-dev` for v4 changes)
- [x] xref https://github.com/OceanParcels/Parcels/issues/1988#issuecomment-2835176520
- [x] Added tests
- [x] Added documentation
