### PR TITLE
Remove allow_time_extrapolation attribute on Field

### DIFF
--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     # from .grid import Grid
 
 
-def _search_time_index(field: Field, time: datetime, allow_time_extrapolation=True):
+def _search_time_index(field: Field, time: datetime):
     """Find and return the index and relative coordinate in the time array associated with a given time.
 
     Parameters
@@ -37,8 +37,9 @@ def _search_time_index(field: Field, time: datetime, allow_time_extrapolation=Tr
     Note that we normalize to either the first or the last index
     if the sampled value is outside the time value range.
     """
-    if not allow_time_extrapolation and (time < field.data.time[0] or time > field.data.time[-1]):
+    if (len(field.data.time)) > 1 and (time < field.data.time[0] or time > field.data.time[-1]):
         _raise_time_extrapolation_error(time, field=None)
+
     time_index = field.data.time <= time
 
     if time_index.all():

--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -37,7 +37,7 @@ def _search_time_index(field: Field, time: datetime):
     Note that we normalize to either the first or the last index
     if the sampled value is outside the time value range.
     """
-    if (len(field.data.time)) > 1 and (time < field.data.time[0] or time > field.data.time[-1]):
+    if field.time_interval is not None and time in field.time_interval:
         _raise_time_extrapolation_error(time, field=None)
 
     time_index = field.data.time <= time

--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -37,7 +37,10 @@ def _search_time_index(field: Field, time: datetime):
     Note that we normalize to either the first or the last index
     if the sampled value is outside the time value range.
     """
-    if field.time_interval is not None and time in field.time_interval:
+    if field.time_interval is None:
+        return 0
+
+    if time in field.time_interval:
         _raise_time_extrapolation_error(time, field=None)
 
     time_index = field.data.time <= time

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -204,9 +204,7 @@ class Field:
 
         # Check if time is in self.data.dims
         if "time" not in self.data.dims:
-            # Add time dimension of length 1 if not present
-            # While the choice of actual date is arbitrary, it should be a datetime object
-            self.data = self.data.expand_dims({"time": [datetime.strptime("2015-09-27", "%Y-%m-%d")]})
+            raise ValueError("Field is missing a 'time' dimension. ")
 
     def __repr__(self):
         return field_repr(self)
@@ -666,7 +664,7 @@ def _assert_compatible_combination(data: xr.DataArray | ux.UxDataArray, grid: ux
 
 
 def get_time_interval(data: xr.DataArray | ux.UxDataArray) -> TimeInterval | None:
-    if "time" not in data.dims:
+    if len(data.time) == 1:
         return None
 
     return TimeInterval(data.time.values[0], data.time.values[-1])

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -208,7 +208,6 @@ class Field:
         else:
             raise ValueError("Unsupported mesh type in data array attributes. Choose either: 'spherical' or 'flat'")
 
-        # Check if time is in self.data.dims
         if "time" not in self.data.dims:
             raise ValueError("Field is missing a 'time' dimension. ")
 

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -206,8 +206,7 @@ class Field:
         if "time" not in self.data.dims:
             # Add time dimension of length 1 if not present
             # While the choice of actual date is arbitrary, it should be a datetime object
-            # Here, we use the current time
-            self.data = self.data.expand_dims({"time": [datetime.now()]})
+            self.data = self.data.expand_dims({"time": [datetime.strptime("2015-09-27", "%Y-%m-%d")]})
 
     def __repr__(self):
         return field_repr(self)

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -254,6 +254,10 @@ class CalendarError(Exception):  # TODO: Move to a parcels errors module
 
 def assert_compatible_calendars(fields: Iterable[Field]):
     time_intervals = [f.time_interval for f in fields if f.time_interval is not None]
+
+    if len(time_intervals) == 0:  # All time intervals are none
+        return
+
     reference_datetime_object = time_intervals[0].left
 
     for field in fields:

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -154,7 +154,7 @@ class FieldSet:
         """
         da = xr.DataArray(
             data=np.full((1, 1, 1, 1), value),
-            dims=["T", "ZG", "YG", "XG"],
+            dims=["time", "ZG", "YG", "XG"],
             coords={
                 "ZG": (["ZG"], np.arange(1), {"axis": "Z"}),
                 "YG": (["YG"], np.arange(1), {"axis": "Y"}),
@@ -162,6 +162,7 @@ class FieldSet:
                 "lon": (["XG"], np.arange(1), {"axis": "X"}),
                 "lat": (["YG"], np.arange(1), {"axis": "Y"}),
                 "depth": (["ZG"], np.arange(1), {"axis": "Z"}),
+                "time": (["time"], np.arange(1), {"axis": "T"}),
             },
         )
         grid = Grid(da)

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -151,7 +151,6 @@ class FieldSet:
                 name,
                 data,
                 interp_method=None,  # TODO : Need to define an interpolation method for constants
-                allow_time_extrapolation=True,
             )
         )
 

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -11,9 +11,9 @@ from scipy.spatial import KDTree
 from tqdm import tqdm
 
 from parcels._compat import MPI
+from parcels._core.utils.time import TimeInterval
 from parcels._reprs import particleset_repr
 from parcels.application_kernels.advection import AdvectionRK4
-from parcels.field import Field
 from parcels.grid import GridType
 from parcels.interaction.interactionkernel import InteractionKernel
 from parcels.interaction.neighborsearch import (
@@ -162,8 +162,8 @@ class ParticleSet:
             raise NotImplementedError("If fieldset.time_origin is not a date, time of a particle must be a double")
         time = np.array([self.time_origin.reltime(t) if _convert_to_reltime(t) else t for t in time])
         assert lon.size == time.size, "time and positions (lon, lat, depth) do not have the same lengths."
-        if isinstance(fieldset.U, Field) and (len(fieldset.U.data.time) > 1):
-            _warn_particle_times_outside_fieldset_time_bounds(time, fieldset.U.grid.time)
+        if fieldset.time_interval:
+            _warn_particle_times_outside_fieldset_time_bounds(time, fieldset.time_interval)
 
         if lonlatdepth_dtype is None:
             lonlatdepth_dtype = self.lonlatdepth_dtype_from_field_interp_method(fieldset.U)
@@ -1127,7 +1127,7 @@ def _warn_outputdt_release_desync(outputdt: float, starttime: float, release_tim
         )
 
 
-def _warn_particle_times_outside_fieldset_time_bounds(release_times: np.ndarray, time: np.ndarray):
+def _warn_particle_times_outside_fieldset_time_bounds(release_times: np.ndarray, time: np.ndarray | TimeInterval):
     if np.any(release_times):
         if np.any(release_times < time[0]):
             warnings.warn(

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -1130,7 +1130,7 @@ def _warn_particle_times_outside_fieldset_time_bounds(release_times: np.ndarray,
     if np.any(release_times):
         if np.any(release_times < time[0]):
             warnings.warn(
-                "Some particles are set to be released before the fieldset's first time and the fields are not constant in time.",
+                "Some particles are set to be released outside the FieldSet's executable time domain.",
                 ParticleSetWarning,
                 stacklevel=2,
             )

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -161,7 +161,7 @@ class ParticleSet:
             raise NotImplementedError("If fieldset.time_origin is not a date, time of a particle must be a double")
         time = np.array([self.time_origin.reltime(t) if _convert_to_reltime(t) else t for t in time])
         assert lon.size == time.size, "time and positions (lon, lat, depth) do not have the same lengths."
-        if isinstance(fieldset.U, Field) and (not fieldset.U.allow_time_extrapolation):
+        if isinstance(fieldset.U, Field) and (len(fieldset.U.data.time) > 1):
             _warn_particle_times_outside_fieldset_time_bounds(time, fieldset.U.grid.time)
 
         if lonlatdepth_dtype is None:
@@ -1130,13 +1130,13 @@ def _warn_particle_times_outside_fieldset_time_bounds(release_times: np.ndarray,
     if np.any(release_times):
         if np.any(release_times < time[0]):
             warnings.warn(
-                "Some particles are set to be released before the fieldset's first time and allow_time_extrapolation is set to False.",
+                "Some particles are set to be released before the fieldset's first time and the fields are not constant in time.",
                 ParticleSetWarning,
                 stacklevel=2,
             )
         if np.any(release_times > time[-1]):
             warnings.warn(
-                "Some particles are set to be released after the fieldset's last time and allow_time_extrapolation is set to False.",
+                "Some particles are set to be released after the fieldset's last time and the fields are not constant in time.",
                 ParticleSetWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
When a xarray or uxarray dataarray does not have a time dimension, one is added to the Field.data dataarray. When a field.data datarray has a time dimension that is length 1, we assume that extrapolation is allowed meaning that we just keep using the same single time-slice for that field.

- [ X ] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- [ X ] Fixes #1988 
