### PR TITLE
Assert that Fields in FieldSet have the same calendar for their time domain

### DIFF
--- a/parcels/_core/utils/time.py
+++ b/parcels/_core/utils/time.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import cftime
 import numpy as np
 
 T = TypeVar("T", datetime, cftime.datetime)
+
+if TYPE_CHECKING:
+    from parcels._typing import DatetimeLike
 
 
 class TimeInterval:
@@ -70,3 +73,28 @@ def is_compatible(t1: datetime | cftime.datetime, t2: datetime | cftime.datetime
         return False
     else:
         return True
+
+
+def get_datetime_type_calendar(
+    example_datetime: DatetimeLike,
+) -> tuple[type, str | None]:
+    """Get the type and calendar of a datetime object.
+
+    Parameters
+    ----------
+    example_datetime : datetime, cftime.datetime, or np.datetime64
+        The datetime object to check.
+
+    Returns
+    -------
+    tuple[type, str | None]
+        A tuple containing the type of the datetime object and its calendar.
+        The calendar will be None if the datetime object is not a cftime datetime object.
+    """
+    calendar = None
+    try:
+        calendar = example_datetime.calendar
+    except AttributeError:
+        # datetime isn't a cftime datetime object
+        pass
+    return type(example_datetime), calendar

--- a/parcels/_typing.py
+++ b/parcels/_typing.py
@@ -8,7 +8,11 @@ used for runtime parameter validation (to ensure users are only using the right 
 
 import os
 from collections.abc import Callable
+from datetime import datetime
 from typing import Any, Literal, get_args
+
+import numpy as np
+from cftime import datetime as cftime_datetime
 
 InterpMethodOption = Literal[
     "linear",
@@ -30,7 +34,7 @@ Mesh = Literal["spherical", "flat"]  # corresponds with `mesh`
 VectorType = Literal["3D", "3DSigma", "2D"] | None  # corresponds with `vector_type`
 GridIndexingType = Literal["pop", "mom5", "mitgcm", "nemo", "croco"]  # corresponds with `gridindexingtype`
 NetcdfEngine = Literal["netcdf4", "xarray", "scipy"]
-
+DatetimeLike = datetime | cftime_datetime | np.datetime64
 
 KernelFunction = Callable[..., None]
 

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -166,7 +166,13 @@ class Field:
         self.name = name
         self.data = data
         self.grid = grid
-        self.time_interval = get_time_interval(data)
+        try:
+            self.time_interval = get_time_interval(data)
+        except ValueError as e:
+            e.add_note(
+                f"Error getting time interval for field {name!r}. Are you sure that the time dimension on the xarray dataset is stored as datetime or cftime datetime objects?"
+            )
+            raise e
 
         # For compatibility with parts of the codebase that rely on v3 definition of Grid.
         # Should be worked to be removed in v4
@@ -531,6 +537,13 @@ class VectorField:
         self.V = V
         self.W = W
 
+        if W is None:
+            assert_same_time_interval((U, V))
+        else:
+            assert_same_time_interval((U, V, W))
+
+        self.time_interval = U.time_interval
+
         if self.W:
             self.vector_type = "3D"
         else:
@@ -670,3 +683,16 @@ def get_time_interval(data: xr.DataArray | ux.UxDataArray) -> TimeInterval | Non
         return None
 
     return TimeInterval(data.time.values[0], data.time.values[-1])
+
+
+def assert_same_time_interval(fields: list[Field]) -> None:
+    if len(fields) == 0:
+        return
+
+    reference_time_interval = fields[0].time_interval
+
+    for field in fields[1:]:
+        if field.time_interval != reference_time_interval:
+            raise ValueError(
+                f"Fields must have the same time domain. {fields[0].name}: {reference_time_interval}, {field.name}: {field.time_interval}"
+            )

--- a/tests/v4/test_field.py
+++ b/tests/v4/test_field.py
@@ -105,6 +105,11 @@ def test_field_time_interval(data, grid):
     assert field.time_interval.right == np.datetime64("2001-01-01")
 
 
+def test_vectorfield_init_different_time_intervals():
+    # Tests that a VectorField raises a ValueError if the component fields have different time domains.
+    ...
+
+
 def test_field_unstructured_grid_creation(): ...
 
 

--- a/tests/v4/test_field.py
+++ b/tests/v4/test_field.py
@@ -72,8 +72,8 @@ def test_field_init_structured_grid(data, grid):
 
 
 @pytest.mark.parametrize("numpy_dtype", ["timedelta64[s]", "float64"])
-def test_field_init_fail_on_bad_timebase(numpy_dtype):
-    """Tests that field initialisation fails when the timebase isn't given as datetime object (i.e., is float or timedelta)."""
+def test_field_init_fail_on_bad_time_type(numpy_dtype):
+    """Tests that field initialisation fails when the time isn't given as datetime object (i.e., is float or timedelta)."""
     ds = datasets_structured["ds_2d_left"].copy()
     ds["time"] = np.arange(0, T_structured, dtype=numpy_dtype)
 

--- a/tests/v4/test_field.py
+++ b/tests/v4/test_field.py
@@ -5,8 +5,8 @@ import xarray as xr
 
 from parcels import Field
 from parcels._datasets.structured.generic import T as T_structured
-from parcels._datasets.structured.generic import datasets as structured_datasets
-from parcels._datasets.unstructured.generic import datasets as unstructured_datasets
+from parcels._datasets.structured.generic import datasets as datasets_structured
+from parcels._datasets.unstructured.generic import datasets as datasets_unstructured
 from parcels.v4.grid import Grid
 
 
@@ -37,7 +37,7 @@ def test_field_init_param_types():
         pytest.param(ux.UxDataArray(), Grid(xr.Dataset()), id="uxdata-grid"),
         pytest.param(
             xr.DataArray(),
-            unstructured_datasets["stommel_gyre_delaunay"].uxgrid,
+            datasets_unstructured["stommel_gyre_delaunay"].uxgrid,
             id="xarray-uxgrid",
         ),
     ],
@@ -55,7 +55,7 @@ def test_field_incompatible_combination(data, grid):
     "data,grid",
     [
         pytest.param(
-            structured_datasets["ds_2d_left"]["data_g"], Grid(structured_datasets["ds_2d_left"]), id="ds_2d_left"
+            datasets_structured["ds_2d_left"]["data_g"], Grid(datasets_structured["ds_2d_left"]), id="ds_2d_left"
         ),  # TODO: Perhaps this test should be expanded to cover more datasets?
     ],
 )
@@ -74,7 +74,7 @@ def test_field_init_structured_grid(data, grid):
 @pytest.mark.parametrize("numpy_dtype", ["timedelta64[s]", "float64"])
 def test_field_init_fail_on_bad_timebase(numpy_dtype):
     """Tests that field initialisation fails when the timebase isn't given as datetime object (i.e., is float or timedelta)."""
-    ds = structured_datasets["ds_2d_left"].copy()
+    ds = datasets_structured["ds_2d_left"].copy()
     ds["time"] = np.arange(0, T_structured, dtype=numpy_dtype)
 
     data = ds["data_g"]
@@ -94,7 +94,7 @@ def test_field_init_fail_on_bad_timebase(numpy_dtype):
     "data,grid",
     [
         pytest.param(
-            structured_datasets["ds_2d_left"]["data_g"], Grid(structured_datasets["ds_2d_left"]), id="ds_2d_left"
+            datasets_structured["ds_2d_left"]["data_g"], Grid(datasets_structured["ds_2d_left"]), id="ds_2d_left"
         ),
     ],
 )

--- a/tests/v4/test_fieldset.py
+++ b/tests/v4/test_fieldset.py
@@ -91,7 +91,7 @@ def test_fieldset_time_interval():
     assert fieldset.time_interval.right == np.datetime64("2001-01-01")
 
 
-def test_fieldset_init_incompatible_timebases():
+def test_fieldset_init_incompatible_calendars():
     ds1 = ds.copy()
     ds1["time"] = xr.date_range("2000", "2001", T_structured, calendar="365_day", use_cftime=True)
 
@@ -103,13 +103,13 @@ def test_fieldset_init_incompatible_timebases():
     ds2 = ds.copy()
     ds2["time"] = xr.date_range("2000", "2001", T_structured, calendar="360_day", use_cftime=True)
     grid2 = Grid(ds2)
-    incompatible_timebase = Field("test", ds2["data_g"], grid2, mesh_type="flat")
+    incompatible_calendar = Field("test", ds2["data_g"], grid2, mesh_type="flat")
 
     with pytest.raises(ValueError):
-        FieldSet([U, V, UV, incompatible_timebase])
+        FieldSet([U, V, UV, incompatible_calendar])
 
 
-def test_fieldset_add_field_incompatible_timebases(fieldset):
+def test_fieldset_add_field_incompatible_calendars(fieldset):
     ds_test = ds.copy()
     ds_test["time"] = xr.date_range("2000", "2001", T_structured, calendar="360_day", use_cftime=True)
     grid = Grid(ds_test)


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`v4-dev` for v4 changes)
- [x] Fixes None (related to #1988)
- [x] Added tests
- [x] Added documentation

For a given FieldSet, all Fields need to define time in the same way. It doesn't make sense to run a simulation where one Field is defined using a 365 day calendar while another is defined on a 360 day calendar as Parcels wouldn't know what to do with the mismatched days.

This PR:
- adds to the FieldSet initialiser and `add_field` method assertions that the fields are on the same calendar (and also adds tests for this)
- adds `VectorField.time_interval` (which should have need done in #2000)

It is the users responsibility that they provide xarray datasets that have the same calendars. If their data doesn't have the same calendar, they can use xarray to modify them in place before providing them to Parcels.