### PR TITLE
2017 fix search time indices

### DIFF
--- a/parcels/_datasets/unstructured/generic.py
+++ b/parcels/_datasets/unstructured/generic.py
@@ -172,7 +172,7 @@ def _fesom2_square_delaunay_uniform_z_coordinate():
         dims=["time", "nz", "n_node"],
         coords=dict(
             time=(["time"], date_array),
-            nz1=(["nz"], zf),
+            nz=(["nz"], zf),
         ),
         attrs=dict(
             description="vertical velocity", units="m/s", location="node", mesh="delaunay", Conventions="UGRID-1.0"

--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -62,8 +62,8 @@ def _search_time_index(field: Field, time: datetime):
         tau = 1
     else:
         tau = (
-            (time - field.data.time[ti]).total_seconds()
-            / (field.data.time[ti + 1] - field.data.time[ti]).total_seconds()
+            (time - field.data.time[ti].values).total_seconds()
+            / (field.data.time[ti + 1].values - field.data.time[ti].values).total_seconds()
             if field.data.time[ti] != field.data.time[ti + 1]
             else 0
         )

--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -40,7 +40,7 @@ def _search_time_index(field: Field, time: datetime):
     if field.time_interval is None:
         return 0
 
-    if time in field.time_interval:
+    if time not in field.time_interval:
         _raise_time_extrapolation_error(time, field=None)
 
     time_index = field.data.time <= time

--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -62,8 +62,8 @@ def _search_time_index(field: Field, time: datetime):
         tau = 1
     else:
         tau = (
-            (time - field.data.time[ti].values).total_seconds()
-            / (field.data.time[ti + 1].values - field.data.time[ti].values).total_seconds()
+            (time - field.data.time[ti]).dt.total_seconds()
+            / (field.data.time[ti + 1] - field.data.time[ti]).dt.total_seconds()
             if field.data.time[ti] != field.data.time[ti + 1]
             else 0
         )

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -286,13 +286,6 @@ class Field:
                 return 0
 
     @property
-    def n_face(self):
-        if type(self.data) is ux.uxDataArray:
-            return self.grid.n_face
-        else:
-            return 0  # TODO : Discuss what we want to return as n_face for dataarray obj
-
-    @property
     def interp_method(self):
         return self._interp_method
 
@@ -452,7 +445,7 @@ class Field:
         if type(self.data) is xr.DataArray:
             return xi + self.xdim * (yi + self.ydim * zi)
         else:
-            return xi + self.n_face * zi
+            return xi + self.grid.n_face * zi
 
     def unravel_index(self, ei):
         """Return the zi, yi, xi indices for a given flat index.
@@ -481,8 +474,8 @@ class Field:
             return zi, yi, xi
         else:
             _ei = ei[self.igrid]
-            zi = _ei // self.n_face
-            fi = _ei % self.n_face
+            zi = _ei // self.grid.n_face
+            fi = _ei % self.grid.n_face
             return zi, fi
 
     def __getattr__(self, key: str):

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -379,7 +379,7 @@ class Field:
     def _interpolate(self, time: datetime, z, y, x, ei):
         try:
             bcoords, _ei, tau, ti = self._search_indices(time, z, y, x, ei=ei)
-            val = self._interp_method(ti, _ei, bcoords, tau, time, z, y, x)
+            val = self._interp_method(self, ti, _ei, bcoords, tau, time, z, y, x)
 
             if np.isnan(val):
                 # Detect Out-of-bounds sampling and raise exception

--- a/tests/v4/test_uxarray_fieldset.py
+++ b/tests/v4/test_uxarray_fieldset.py
@@ -91,7 +91,6 @@ def test_fesom_channel(ds_fesom_channel, uvw_fesom_channel):
     pset.execute(endtime=timedelta(days=1), dt=timedelta(hours=1))
 
 
-@pytest.mark.skip(reason="_index_search.search_time_indices needs major refactoring")
 def test_fesom2_square_delaunay_uniform_z_coordinate_eval():
     """
     Test the evaluation of a fieldset with a FESOM2 square Delaunay grid and uniform z-coordinate.


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- [x] Fixes #2017
- [ ] Added tests
- [ ] Added documentation


Merge after #2010 . This PR resolves bugs in the `_search_time_indices` function. However, this does not fix the `test_fesom2_square_delaunay_uniform_z_coordinate_eval` test, since there are now issues cropping up in the spatial interpolation methods associated with indexing (will resolve this in a separate PR and will document with another issue).
