### PR TITLE
Structured grids barycentric coordinates

### DIFF
--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -352,7 +352,7 @@ def _search_indices_curvilinear_2d(
     if not ((0 <= xsi <= 1) and (0 <= eta <= 1)):
         _raise_field_sampling_error(y, x)
 
-    return (eta, xsi, yi, xi)
+    return (yi, eta, xi, xsi)
 
 
 ## TODO :  Still need to implement the search_indices_curvilinear

--- a/parcels/basegrid.py
+++ b/parcels/basegrid.py
@@ -38,8 +38,8 @@ class BaseGrid(ABC):
             A dictionary mapping spatial axis names to tuples of (index, barycentric_coordinates).
             The returned axes depend on the grid dimensionality and type:
 
-            - 3D structured grid: {"X": (xi, xsi), "Y": (yi, eta), "Z": (zi, zeta)}
-            - 2D structured grid: {"X": (xi, xsi), "Y": (yi, eta)}
+            - 3D structured grid: {"Z": (zi, zeta), "Y": (yi, eta), "X": (xi, xsi)}
+            - 2D structured grid: {"Y": (yi, eta), "X": (xi, xsi)}
             - 1D structured grid (depth): {"Z": (zi, zeta)}
             - Unstructured grid: {"Z": (zi, zeta), "FACE": (fi, bcoords)}
 
@@ -74,8 +74,8 @@ class BaseGrid(ABC):
             A dictionary mapping axis names to their corresponding indices.
             The expected keys depend on the grid dimensionality and type:
 
-            - 3D structured grid: {"X": xi, "Y": yi, "Z": zi}
-            - 2D structured grid: {"X": xi, "Y": yi}
+            - 3D structured grid: {"Z": zi, "Y": yi, "X": xi}
+            - 2D structured grid: {"Y": yi, "X": xi}
             - 1D structured grid: {"Z": zi}
             - Unstructured grid: {"Z": zi, "FACE": fi}
 
@@ -114,8 +114,8 @@ class BaseGrid(ABC):
             A dictionary mapping axis names to their corresponding indices.
             The returned keys depend on the grid dimensionality and type:
 
-            - 3D structured grid: {"X": xi, "Y": yi, "Z": zi}
-            - 2D structured grid: {"X": xi, "Y": yi}
+            - 3D structured grid: {"Z": zi, "Y": yi, "X": xi}
+            - 2D structured grid: {"Y": yi, "X": xi}
             - 1D structured grid: {"Z": zi}
             - Unstructured grid: {"Z": zi, "FACE": fi}
 

--- a/tests/v4/test_index_search.py
+++ b/tests/v4/test_index_search.py
@@ -30,7 +30,7 @@ def test_grid_indexing_fpoints(field_cone):
             x = grid.lon[yi_expected, xi_expected] + 0.00001
             y = grid.lat[yi_expected, xi_expected] + 0.00001
 
-            eta, xsi, yi, xi = _search_indices_curvilinear_2d(grid, y, x)
+            yi, eta, xi, xsi = _search_indices_curvilinear_2d(grid, y, x)
             if eta > 0.9:
                 yi_expected -= 1
             if xsi > 0.9:

--- a/tests/v4/test_xgrid.py
+++ b/tests/v4/test_xgrid.py
@@ -129,7 +129,7 @@ def test_xgrid_ravel_unravel_index():
     for xi in range(xdim):
         for yi in range(ydim):
             for zi in range(zdim):
-                axis_indices = {"X": xi, "Y": yi, "Z": zi}
+                axis_indices = {"Z": zi, "Y": yi, "X": xi}
                 ei = grid.ravel_index(axis_indices)
                 axis_indices_test = grid.unravel_index(ei)
                 assert axis_indices_test == axis_indices
@@ -155,7 +155,7 @@ def test_xgrid_search_cpoints(ds):
 
     for xi in range(grid.xdim - 1):
         for yi in range(grid.ydim - 1):
-            axis_indices = {"X": xi, "Y": yi, "Z": 0}
+            axis_indices = {"Z": 0, "Y": yi, "X": xi}
 
             lat, lon = lat_array[yi, xi], lon_array[yi, xi]
             axis_indices_bcoords = grid.search(0, lat, lon, ei=None)


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`v4-dev` for v4 changes)
- [x] Fixes #2035
- [x] Added tests
- [x] Added documentation


Changes:
- Require dataset to have lon lat grid of F points (and validates that this is the right format)
- Index search and barycentric coordinate calculation on these F-points (both for 1D and 2D lon and lat)
  - Assumes that depth is 1D
  - Uses algorithm from v3 (in future we're sure this can be optimised to be more robust and faster - but this is good for now)
- ravel and unravel method 

Here is a diagram to help visualise what's happening here:

![image](https://github.com/user-attachments/assets/2c4a2c67-e811-4e24-a789-00082abe11c6)

<details><summary>Diagram on NEMO/MITgcm indexing in general</summary>
<p>

![image](https://github.com/user-attachments/assets/96bcd28b-c469-4a5c-91a1-54ba34907b5e)


</p>
</details> 

Note that result from the `search()` method is wrt. the red points (i.e., `yi, xi = 0, 0`, `eta, xsi = 0.5, 0.5` means the particle is in the cell centre with lower left being red point at `(0, 0)`.

One thing to note: Particles on the edge of the model grid are not representable in the F-points (in the diagram, this is evident in the NEMO model for the lower left edge of the grid). In the periodic case, the grid has a halo anyway so this is a non-issue. _The grid is not patched to be a "full grid" on initialisation - we instead work close to the original dataset._

If we have a particle in tracer cell `(yi, xi) = 0,0`, then the relevant velocities for interpolation are:
- NEMO:
  - `U[y, x] -> U[1,0] and U[1,1]`
  - `V[y, x] -> V[0,1] and V[1,1]`
- MITgcm
  - `U[y, x] -> U[0,0] and U[0,1]`
  - `V[y, x] -> V[0,0] and V[1,0]`

The lining up of these indices with on-disk representation will be handled in the interpolator itself (in a future PR).
