### PR TITLE
Adding float precision tolerance to time bounds check

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -1101,7 +1101,10 @@ class Field:
         if (
             not self.time_periodic
             and not self.allow_time_extrapolation
-            and (time < self.grid.time[0] or time > self.grid.time[-1])
+            and (
+                (time < self.grid.time[0] - np.finfo(np.float32).eps)
+                or (time > self.grid.time[-1] + np.finfo(np.float32).eps)
+            )
         ):
             raise TimeExtrapolationError(time, field=self)
         time_index = self.grid.time <= time

--- a/parcels/include/parcels.h
+++ b/parcels/include/parcels.h
@@ -447,7 +447,7 @@ static inline StatusCode temporal_interpolation_structured_grid(double time, typ
   int igrid = f->igrid;
 
   /* Find time index for temporal interpolation */
-  if (f->time_periodic == 0 && f->allow_time_extrapolation == 0 && (time < grid->time[0] || time > grid->time[grid->tdim-1])){
+  if (f->time_periodic == 0 && f->allow_time_extrapolation == 0 && ((time < grid->time[0] - FLT_EPSILON) || (time > grid->time[grid->tdim-1] + FLT_EPSILON))) {
     return ERRORTIMEEXTRAPOLATION;
   }
   status = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], f->time_periodic, grid->tfull_min, grid->tfull_max, grid->periods); CHECKSTATUS(status);
@@ -660,7 +660,7 @@ static inline StatusCode temporal_interpolationUV_c_grid(double time, type_coord
   int igrid = U->igrid;
 
   /* Find time index for temporal interpolation */
-  if (U->time_periodic == 0 && U->allow_time_extrapolation == 0 && (time < grid->time[0] || time > grid->time[grid->tdim-1])){
+  if (U->time_periodic == 0 && U->allow_time_extrapolation == 0 && ((time < grid->time[0] - FLT_EPSILON) || (time > grid->time[grid->tdim-1] + FLT_EPSILON))) {
     return ERRORTIMEEXTRAPOLATION;
   }
   status = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic, grid->tfull_min, grid->tfull_max, grid->periods); CHECKSTATUS(status);
@@ -882,7 +882,7 @@ static inline StatusCode temporal_interpolationUVW_c_grid(double time, type_coor
   int igrid = U->igrid;
 
   /* Find time index for temporal interpolation */
-  if (U->time_periodic == 0 && U->allow_time_extrapolation == 0 && (time < grid->time[0] || time > grid->time[grid->tdim-1])){
+  if (U->time_periodic == 0 && U->allow_time_extrapolation == 0 && ((time < grid->time[0] - FLT_EPSILON) || (time > grid->time[grid->tdim-1] + FLT_EPSILON))){
     return ERRORTIMEEXTRAPOLATION;
   }
   status = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic, grid->tfull_min, grid->tfull_max, grid->periods); CHECKSTATUS(status);
@@ -1103,7 +1103,7 @@ static inline StatusCode temporal_interpolation_slip(double time, type_coord z, 
   int igrid = U->igrid;
 
   /* Find time index for temporal interpolation */
-  if (U->time_periodic == 0 && U->allow_time_extrapolation == 0 && (time < grid->time[0] || time > grid->time[grid->tdim-1])){
+  if (U->time_periodic == 0 && U->allow_time_extrapolation == 0 && ((time < grid->time[0] - FLT_EPSILON) || (time > grid->time[grid->tdim-1] + FLT_EPSILON))) {
     return ERRORTIMEEXTRAPOLATION;
   }
   status = search_time_index(&time, grid->tdim, grid->time, &ti[igrid], U->time_periodic, grid->tfull_min, grid->tfull_max, grid->periods); CHECKSTATUS(status);


### PR DESCRIPTION
This fixes #2045 for fields with very high-precision `time` and very small `dt`

<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- [x] Fixes #2045
- [ ] Added tests
- [ ] Added documentation
