### PR TITLE
Update structured Field data ingestion transposing to 4D (TZYX) and add `XGrid.from_dataset()` 

### DIFF
--- a/parcels/field.py
+++ b/parcels/field.py
@@ -189,6 +189,10 @@ class Field:
         else:
             raise ValueError("Unsupported mesh type in data array attributes. Choose either: 'spherical' or 'flat'")
 
+        if self.data.shape[0] > 1:
+            if "time" not in self.data.coords:
+                raise ValueError("Field data is missing a 'time' coordinate.")
+
     @property
     def units(self):
         return self._units

--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -132,7 +132,6 @@ class FieldSet:
         """
         da = xr.DataArray(
             data=np.full((1, 1, 1, 1), value),
-            dims=["time", "ZG", "YG", "XG"],
         )
         grid = XGrid(xgcm.Grid(da))
         self.add_field(

--- a/parcels/xgrid.py
+++ b/parcels/xgrid.py
@@ -1,4 +1,4 @@
-from collections.abc import Hashable, Mapping
+from collections.abc import Hashable, Mapping, Sequence
 from functools import cached_property
 from typing import Literal, cast
 
@@ -10,12 +10,15 @@ from parcels import xgcm
 from parcels._index_search import _search_indices_curvilinear_2d
 from parcels.basegrid import BaseGrid
 
-_XGRID_AXES_ORDERING = "ZYX"
 _XGRID_AXES = Literal["X", "Y", "Z"]
+_XGRID_AXES_ORDERING: Sequence[_XGRID_AXES] = "ZYX"
 
 _XGCM_AXIS_DIRECTION = Literal["X", "Y", "Z", "T"]
 _XGCM_AXIS_POSITION = Literal["center", "left", "right", "inner", "outer"]
 _XGCM_AXES = Mapping[_XGCM_AXIS_DIRECTION, xgcm.Axis]
+
+_FIELD_DATA_ORDERING: Sequence[_XGCM_AXIS_DIRECTION] = "TZYX"
+
 _DEFAULT_XGCM_KWARGS = {"periodic": False}
 
 
@@ -35,13 +38,46 @@ def _get_xgrid_axes(grid: xgcm.Grid) -> list[_XGRID_AXES]:
     return sorted(spatial_axes, key=_XGRID_AXES_ORDERING.index)
 
 
-def drop_field_data(ds: xr.Dataset) -> xr.Dataset:
+def _drop_field_data(ds: xr.Dataset) -> xr.Dataset:
     """
     Removes DataArrays from the dataset that are associated with field data so that
     when passed to the XGCM grid, the object only functions as an in memory representation
     of the grid.
     """
     return ds.drop_vars(ds.data_vars)
+
+
+def _transpose_xfield_data_to_tzyx(da: xr.DataArray, xgcm_grid: xgcm.Grid) -> xr.DataArray:
+    """
+    Transpose a DataArray of any shape into a 4D array of order TZYX. Uses xgcm to determine
+    the axes, and inserts dummy dimensions of size 1 for any axes not present in the DataArray.
+    """
+    ax_dims = [(get_axis_from_dim_name(xgcm_grid.axes, dim), dim) for dim in da.dims]
+
+    if all(ax_dim[0] is None for ax_dim in ax_dims):
+        # Assuming its a 1D constant field (hence has no axes)
+        assert da.shape == (1, 1, 1, 1)
+        return da.rename({old_dim: f"dummy{axis}" for old_dim, axis in zip(da.dims, _FIELD_DATA_ORDERING, strict=True)})
+
+    # All dimensions must be associated with an axis in the grid
+    if any(ax_dim[0] is None for ax_dim in ax_dims):
+        raise ValueError(
+            f"DataArray {da.name!r} with dims {da.dims} has dimensions that are not associated with a direction on the provided grid."
+        )
+
+    axes_not_in_field = set(_FIELD_DATA_ORDERING) - set(ax_dim[0] for ax_dim in ax_dims)
+
+    dummy_dims_to_create = {}
+    for ax in axes_not_in_field:
+        dummy_dims_to_create[f"dummy{ax}"] = 1
+        ax_dims.append((ax, f"dummy{ax}"))
+
+    if dummy_dims_to_create:
+        da = da.expand_dims(dummy_dims_to_create, create_index_for_new_dim=False)
+
+    ax_dims = sorted(ax_dims, key=lambda x: _FIELD_DATA_ORDERING.index(x[0]))
+
+    return da.transpose(*[ax_dim[1] for ax_dim in ax_dims])
 
 
 class XGrid(BaseGrid):
@@ -71,7 +107,7 @@ class XGrid(BaseGrid):
 
         xgcm_kwargs = {**_DEFAULT_XGCM_KWARGS, **xgcm_kwargs}
 
-        ds = drop_field_data(ds)
+        ds = _drop_field_data(ds)
         grid = xgcm.Grid(ds, **xgcm_kwargs)
         return cls(grid, mesh=mesh)
 

--- a/parcels/xgrid.py
+++ b/parcels/xgrid.py
@@ -50,14 +50,14 @@ def _drop_field_data(ds: xr.Dataset) -> xr.Dataset:
 def _transpose_xfield_data_to_tzyx(da: xr.DataArray, xgcm_grid: xgcm.Grid) -> xr.DataArray:
     """
     Transpose a DataArray of any shape into a 4D array of order TZYX. Uses xgcm to determine
-    the axes, and inserts dummy dimensions of size 1 for any axes not present in the DataArray.
+    the axes, and inserts mock dimensions of size 1 for any axes not present in the DataArray.
     """
     ax_dims = [(get_axis_from_dim_name(xgcm_grid.axes, dim), dim) for dim in da.dims]
 
     if all(ax_dim[0] is None for ax_dim in ax_dims):
         # Assuming its a 1D constant field (hence has no axes)
         assert da.shape == (1, 1, 1, 1)
-        return da.rename({old_dim: f"dummy{axis}" for old_dim, axis in zip(da.dims, _FIELD_DATA_ORDERING, strict=True)})
+        return da.rename({old_dim: f"mock{axis}" for old_dim, axis in zip(da.dims, _FIELD_DATA_ORDERING, strict=True)})
 
     # All dimensions must be associated with an axis in the grid
     if any(ax_dim[0] is None for ax_dim in ax_dims):
@@ -67,13 +67,13 @@ def _transpose_xfield_data_to_tzyx(da: xr.DataArray, xgcm_grid: xgcm.Grid) -> xr
 
     axes_not_in_field = set(_FIELD_DATA_ORDERING) - set(ax_dim[0] for ax_dim in ax_dims)
 
-    dummy_dims_to_create = {}
+    mock_dims_to_create = {}
     for ax in axes_not_in_field:
-        dummy_dims_to_create[f"dummy{ax}"] = 1
-        ax_dims.append((ax, f"dummy{ax}"))
+        mock_dims_to_create[f"mock{ax}"] = 1
+        ax_dims.append((ax, f"mock{ax}"))
 
-    if dummy_dims_to_create:
-        da = da.expand_dims(dummy_dims_to_create, create_index_for_new_dim=False)
+    if mock_dims_to_create:
+        da = da.expand_dims(mock_dims_to_create, create_index_for_new_dim=False)
 
     ax_dims = sorted(ax_dims, key=lambda x: _FIELD_DATA_ORDERING.index(x[0]))
 

--- a/parcels/xgrid.py
+++ b/parcels/xgrid.py
@@ -101,7 +101,7 @@ class XGrid(BaseGrid):
 
     @classmethod
     def from_dataset(cls, ds: xr.Dataset, mesh="flat", xgcm_kwargs=None):
-        """WARNING: unstable API, subject to change in future versions."""
+        """WARNING: unstable API, subject to change in future versions."""  # TODO v4: make private or remove warning on v4 release
         if xgcm_kwargs is None:
             xgcm_kwargs = {}
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,12 +1,19 @@
 """General helper functions and utilies for test suite."""
 
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import xarray as xr
 
 import parcels
 from parcels import FieldSet
+from parcels.xgrid import _FIELD_DATA_ORDERING, get_axis_from_dim_name
+
+if TYPE_CHECKING:
+    from parcels.xgrid import XGrid
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 TEST_ROOT = PROJECT_ROOT / "tests"
@@ -116,3 +123,13 @@ def create_fieldset_zeros_simple(xdim=40, ydim=100, withtime=False):
 
 def assert_empty_folder(path: Path):
     assert [p.name for p in path.iterdir()] == []
+
+
+def assert_valid_field_data(data: xr.DataArray, grid: XGrid):
+    assert len(data.shape) == 4, f"Field data should have 4 dimensions (time, depth, lat, lon), got {len(data.shape)}"
+
+    for ax_expected, dim in zip(_FIELD_DATA_ORDERING, data.dims, strict=True):
+        ax_actual = get_axis_from_dim_name(grid.xgcm_grid.axes, dim)
+        if ax_actual is None:
+            continue  # None is ok
+        assert ax_actual == ax_expected, f"Expected axis {ax_expected} for dimension '{dim}', got {ax_actual}"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -126,7 +126,7 @@ def assert_empty_folder(path: Path):
 
 
 def assert_valid_field_data(data: xr.DataArray, grid: XGrid):
-    assert len(data.shape) == 4, f"Field data should have 4 dimensions (time, depth, lat, lon), got {len(data.shape)}"
+    assert len(data.shape) == 4, f"Field data should have 4 dimensions (time, depth, lat, lon), got dims {data.dims}"
 
     for ax_expected, dim in zip(_FIELD_DATA_ORDERING, data.dims, strict=True):
         ax_actual = get_axis_from_dim_name(grid.xgcm_grid.axes, dim)

--- a/tests/v4/test_datasets.py
+++ b/tests/v4/test_datasets.py
@@ -1,11 +1,11 @@
+from parcels import xgcm
 from parcels._datasets.structured.generic import datasets
-from parcels.xgcm import Grid
 
 
 def test_left_indexed_dataset():
     """Checks that 'ds_2d_left' is right indexed on all variables."""
     ds = datasets["ds_2d_left"]
-    grid = Grid(ds)
+    grid = xgcm.Grid(ds)
 
     for _axis_name, axis in grid.axes.items():
         for pos, _dim_name in axis.coords.items():
@@ -15,7 +15,7 @@ def test_left_indexed_dataset():
 def test_right_indexed_dataset():
     """Checks that 'ds_2d_right' is right indexed on all variables."""
     ds = datasets["ds_2d_right"]
-    grid = Grid(ds)
+    grid = xgcm.Grid(ds)
     for _axis_name, axis in grid.axes.items():
         for pos, _dim_name in axis.coords.items():
             assert pos in ["center", "right"]

--- a/tests/v4/test_field.py
+++ b/tests/v4/test_field.py
@@ -5,7 +5,7 @@ import pytest
 import uxarray as ux
 import xarray as xr
 
-from parcels import Field, UXPiecewiseConstantFace, UXPiecewiseLinearNode, VectorField, xgcm
+from parcels import Field, UXPiecewiseConstantFace, UXPiecewiseLinearNode, VectorField
 from parcels._datasets.structured.generic import T as T_structured
 from parcels._datasets.structured.generic import datasets as datasets_structured
 from parcels._datasets.unstructured.generic import datasets as datasets_unstructured
@@ -15,7 +15,7 @@ from parcels.xgrid import XGrid
 
 def test_field_init_param_types():
     data = datasets_structured["ds_2d_left"]
-    grid = XGrid(xgcm.Grid(data))
+    grid = XGrid.from_dataset(data)
     with pytest.raises(ValueError, match="Expected `name` to be a string"):
         Field(name=123, data=data["data_g"], grid=grid)
 
@@ -32,7 +32,7 @@ def test_field_init_param_types():
 @pytest.mark.parametrize(
     "data,grid",
     [
-        pytest.param(ux.UxDataArray(), XGrid(xgcm.Grid(datasets_structured["ds_2d_left"])), id="uxdata-grid"),
+        pytest.param(ux.UxDataArray(), XGrid.from_dataset(datasets_structured["ds_2d_left"]), id="uxdata-grid"),
         pytest.param(
             xr.DataArray(),
             UxGrid(
@@ -57,7 +57,7 @@ def test_field_incompatible_combination(data, grid):
     [
         pytest.param(
             datasets_structured["ds_2d_left"]["data_g"],
-            XGrid(xgcm.Grid(datasets_structured["ds_2d_left"])),
+            XGrid.from_dataset(datasets_structured["ds_2d_left"]),
             id="ds_2d_left",
         ),  # TODO: Perhaps this test should be expanded to cover more datasets?
     ],
@@ -80,10 +80,10 @@ def test_field_init_fail_on_float_time_dim():
     (users are expected to use timedelta64 or datetime).
     """
     ds = datasets_structured["ds_2d_left"].copy()
-    ds["time"] = np.arange(0, T_structured, dtype="float64")
+    ds["time"] = (ds["time"].dims, np.arange(0, T_structured, dtype="float64"), ds["time"].attrs)
 
     data = ds["data_g"]
-    grid = XGrid(xgcm.Grid(ds))
+    grid = XGrid.from_dataset(ds)
     with pytest.raises(
         ValueError,
         match="Error getting time interval.*. Are you sure that the time dimension on the xarray dataset is stored as timedelta, datetime or cftime datetime objects\?",
@@ -100,7 +100,7 @@ def test_field_init_fail_on_float_time_dim():
     [
         pytest.param(
             datasets_structured["ds_2d_left"]["data_g"],
-            XGrid(xgcm.Grid(datasets_structured["ds_2d_left"])),
+            XGrid.from_dataset(datasets_structured["ds_2d_left"]),
             id="ds_2d_left",
         ),
     ],
@@ -119,7 +119,7 @@ def test_vectorfield_init_different_time_intervals():
 
 def test_field_invalid_interpolator():
     ds = datasets_structured["ds_2d_left"]
-    grid = XGrid(xgcm.Grid(ds))
+    grid = XGrid.from_dataset(ds)
 
     def invalid_interpolator_wrong_signature(self, ti, position, tau, t, z, y, invalid):
         return 0.0
@@ -131,7 +131,7 @@ def test_field_invalid_interpolator():
 
 def test_vectorfield_invalid_interpolator():
     ds = datasets_structured["ds_2d_left"]
-    grid = XGrid(xgcm.Grid(ds))
+    grid = XGrid.from_dataset(ds)
 
     def invalid_interpolator_wrong_signature(self, ti, position, tau, t, z, y, invalid):
         return 0.0

--- a/tests/v4/test_fieldset.py
+++ b/tests/v4/test_fieldset.py
@@ -92,7 +92,7 @@ def test_fieldset_time_interval():
     field1 = Field("field1", ds["U (A grid)"], grid1, mesh_type="flat")
 
     ds2 = ds.copy()
-    ds2["time"] = ds2["time"] + np.timedelta64(timedelta(days=1))
+    ds2["time"] = (ds2["time"].dims, ds2["time"].data + np.timedelta64(timedelta(days=1)), ds2["time"].attrs)
     grid2 = XGrid.from_dataset(ds2)
     field2 = Field("field2", ds2["U (A grid)"], grid2, mesh_type="flat")
 
@@ -113,7 +113,11 @@ def test_fieldset_time_interval_constant_fields():
 
 def test_fieldset_init_incompatible_calendars():
     ds1 = ds.copy()
-    ds1["time"] = xr.date_range("2000", "2001", T_structured, calendar="365_day", use_cftime=True)
+    ds1["time"] = (
+        ds1["time"].dims,
+        xr.date_range("2000", "2001", T_structured, calendar="365_day", use_cftime=True),
+        ds1["time"].attrs,
+    )
 
     grid = XGrid.from_dataset(ds1)
     U = Field("U", ds1["U (A grid)"], grid, mesh_type="flat")
@@ -121,7 +125,11 @@ def test_fieldset_init_incompatible_calendars():
     UV = VectorField("UV", U, V)
 
     ds2 = ds.copy()
-    ds2["time"] = xr.date_range("2000", "2001", T_structured, calendar="360_day", use_cftime=True)
+    ds2["time"] = (
+        ds2["time"].dims,
+        xr.date_range("2000", "2001", T_structured, calendar="360_day", use_cftime=True),
+        ds2["time"].attrs,
+    )
     grid2 = XGrid.from_dataset(ds2)
     incompatible_calendar = Field("test", ds2["data_g"], grid2, mesh_type="flat")
 
@@ -131,7 +139,11 @@ def test_fieldset_init_incompatible_calendars():
 
 def test_fieldset_add_field_incompatible_calendars(fieldset):
     ds_test = ds.copy()
-    ds_test["time"] = xr.date_range("2000", "2001", T_structured, calendar="360_day", use_cftime=True)
+    ds_test["time"] = (
+        ds_test["time"].dims,
+        xr.date_range("2000", "2001", T_structured, calendar="360_day", use_cftime=True),
+        ds_test["time"].attrs,
+    )
     grid = XGrid.from_dataset(ds_test)
     field = Field("test_field", ds_test["data_g"], grid, mesh_type="flat")
 
@@ -139,7 +151,11 @@ def test_fieldset_add_field_incompatible_calendars(fieldset):
         fieldset.add_field(field, "test_field")
 
     ds_test = ds.copy()
-    ds_test["time"] = np.linspace(0, 100, T_structured, dtype="timedelta64[s]")
+    ds_test["time"] = (
+        ds_test["time"].dims,
+        np.linspace(0, 100, T_structured, dtype="timedelta64[s]"),
+        ds_test["time"].attrs,
+    )
     grid = XGrid.from_dataset(ds_test)
     field = Field("test_field", ds_test["data_g"], grid, mesh_type="flat")
 

--- a/tests/v4/test_fieldset.py
+++ b/tests/v4/test_fieldset.py
@@ -12,7 +12,8 @@ from parcels._datasets.structured.generic import T as T_structured
 from parcels._datasets.structured.generic import datasets as datasets_structured
 from parcels.field import Field, VectorField
 from parcels.fieldset import CalendarError, FieldSet, _datetime_to_msg
-from parcels.xgrid import _FIELD_DATA_ORDERING, XGrid, get_axis_from_dim_name
+from parcels.xgrid import XGrid
+from tests import utils
 
 ds = datasets_structured["ds_2d_left"]
 
@@ -95,15 +96,7 @@ def test_fieldset_from_structured_generic_datasets(ds):
 
     assert len(fieldset.fields) == len(ds.data_vars)
     for field in fieldset.fields.values():
-        assert (
-            len(field.data.shape) == 4
-        ), f"Field data should have 4 dimensions (time, depth, lat, lon), got {len(field.data.shape)}"
-
-        for ax_expected, dim in zip(_FIELD_DATA_ORDERING, field.data.dims, strict=True):
-            ax_actual = get_axis_from_dim_name(field.grid.xgcm_grid.axes, dim)
-            if ax_actual is None:
-                continue  # None is ok
-            assert ax_actual == ax_expected, f"Expected axis {ax_expected} for dimension '{dim}', got {ax_actual}"
+        utils.assert_valid_field_data(field.data, field.grid)
 
     assert len(fieldset.gridset) == 1
 

--- a/tests/v4/test_index_search.py
+++ b/tests/v4/test_index_search.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from parcels import xgcm
 from parcels._datasets.structured.generic import datasets
 from parcels._index_search import _search_indices_curvilinear_2d
 from parcels.field import Field
@@ -13,7 +12,7 @@ from parcels.xgrid import (
 @pytest.fixture
 def field_cone():
     ds = datasets["2d_left_unrolled_cone"]
-    grid = XGrid(xgcm.Grid(ds, periodic=False))
+    grid = XGrid.from_dataset(ds)
     field = Field(
         name="test_field",
         data=ds["data_g"],

--- a/tests/v4/test_kernel.py
+++ b/tests/v4/test_kernel.py
@@ -6,7 +6,6 @@ from parcels import (
     Field,
     FieldSet,
     ParticleSet,
-    xgcm,
 )
 from parcels._datasets.structured.generic import datasets as datasets_structured
 from parcels.xgrid import XGrid
@@ -16,7 +15,7 @@ from tests.common_kernels import MoveEast, MoveNorth
 @pytest.fixture
 def fieldset() -> FieldSet:
     ds = datasets_structured["ds_2d_left"]
-    grid = XGrid(xgcm.Grid(ds))
+    grid = XGrid.from_dataset(ds)
     U = Field("U", ds["U (A grid)"], grid, mesh_type="flat")
     V = Field("V", ds["V (A grid)"], grid, mesh_type="flat")
     return FieldSet([U, V])

--- a/tests/v4/test_particleset.py
+++ b/tests/v4/test_particleset.py
@@ -13,7 +13,6 @@ from parcels import (
     ParticleSet,
     ParticleSetWarning,
     Variable,
-    xgcm,
 )
 from parcels._datasets.structured.generic import datasets as datasets_structured
 from parcels.xgrid import XGrid
@@ -23,7 +22,7 @@ from tests.common_kernels import DoNothing
 @pytest.fixture
 def fieldset() -> FieldSet:
     ds = datasets_structured["ds_2d_left"]
-    grid = XGrid(xgcm.Grid(ds))
+    grid = XGrid.from_dataset(ds)
     U = Field("U", ds["U (A grid)"], grid, mesh_type="flat")
     V = Field("V", ds["V (A grid)"], grid, mesh_type="flat")
     return FieldSet([U, V])

--- a/tests/v4/test_particleset_execute.py
+++ b/tests/v4/test_particleset_execute.py
@@ -10,7 +10,6 @@ from parcels import (
     StatusCode,
     UXPiecewiseConstantFace,
     VectorField,
-    xgcm,
 )
 from parcels._datasets.structured.generic import datasets as datasets_structured
 from parcels._datasets.unstructured.generic import datasets as datasets_unstructured
@@ -22,7 +21,7 @@ from tests.common_kernels import DoNothing
 @pytest.fixture
 def fieldset() -> FieldSet:
     ds = datasets_structured["ds_2d_left"]
-    grid = XGrid(xgcm.Grid(ds))
+    grid = XGrid.from_dataset(ds)
     U = Field("U", ds["U (A grid)"], grid, mesh_type="flat")
     V = Field("V", ds["V (A grid)"], grid, mesh_type="flat")
     return FieldSet([U, V])

--- a/tests/v4/test_xgrid.py
+++ b/tests/v4/test_xgrid.py
@@ -7,7 +7,7 @@ import xarray as xr
 from numpy.testing import assert_allclose
 
 from parcels._datasets.structured.generic import X, Y, Z, datasets
-from parcels.xgrid import XGrid, _drop_field_data, _search_1d_array, _transpose_xfield_data_to_tzyx
+from parcels.xgrid import XGrid, _search_1d_array, _transpose_xfield_data_to_tzyx
 from tests import utils
 
 GridTestCase = namedtuple("GridTestCase", ["ds", "attr", "expected"])


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->

Changes:
- Add `XGrid.from_dataset` (rather than having to construct a xgcm grid first). This execution path drops all the Field data from the dataset before constructing the xgcm grid (and also makes it easier to call for devs as its 1 less import). Seeb73813c769aeaa92be181bf3fee1ba5275d317ce commit message for more info
- Update Field init to transpose data to 4D array, inserting additional dummy axes where necessary

- [x] Chose the correct base branch (`v4-dev` for v4 changes)
- [x] Fixes #2047 and works towards #2054
- [x] Added tests (for the transposing to 4D I didn't add a unit test, but added an integration test over all the generic datasets)
- [x] Added documentation

Will do a self review tomorrow then mark ready for review.
