### PR TITLE
Performance boost: calling numpy data in particle.__setattr__

### DIFF
--- a/parcels/particle.py
+++ b/parcels/particle.py
@@ -115,7 +115,7 @@ class Particle:
         self._index = index
 
     def __getattr__(self, name):
-        return self._data[name].values[self._index]
+        return self._data[name].data[self._index]
 
     def __setattr__(self, name, value):
         if name in ["_data", "_index"]:


### PR DESCRIPTION
This simple change improves the performance of the Kernel loop by a factor 6, as updating the particle values seems to be the bottle neck in performance for the Kernel loop now

<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- [ ] Fixes #
- [ ] Added tests
- [ ] Added documentation
