### PR TITLE
Adding both an xarray.dataset and a dict-of-numpy-arrays for the particle-data

### DIFF
--- a/tests/v4/test_particleset_execute.py
+++ b/tests/v4/test_particleset_execute.py
@@ -116,6 +116,20 @@ def test_execution_fail_python_exception(fieldset, npart=10):
     assert all([time == fieldset.time_interval.left + np.timedelta64(0, "s") for time in pset.time[1:]])
 
 
+def test_pset_update_particle(fieldset, npart=10):
+    lon_start = np.linspace(0, 1, npart)
+    lat_start = np.linspace(1, 0, npart)
+    pset = ParticleSet(fieldset, lon=np.linspace(0, 1, npart), lat=np.linspace(1, 0, npart))
+
+    def UpdateParticle(particle, fieldset, time):  # pragma: no cover
+        particle.lon += 0.1
+        particle.lat -= 0.1
+
+    pset.execute(pset.Kernel(UpdateParticle), runtime=np.timedelta64(10, "s"), dt=np.timedelta64(1, "s"))
+    assert np.allclose(pset.lon, lon_start + 1, atol=1e-5)
+    assert np.allclose(pset.lat, lat_start - 1, atol=1e-5)
+
+
 @pytest.mark.parametrize("verbose_progress", [True, False])
 def test_uxstommelgyre_pset_execute(verbose_progress):
     ds = datasets_unstructured["stommel_gyre_delaunay"]


### PR DESCRIPTION
This PR builds on #2094, following @VeckoTheGecko's suggestion at https://github.com/OceanParcels/parcels-benchmarks/pull/1#issuecomment-3089184625 to keep the ParticleData in both an xarray.DataSet structure (`ParticleSet._ds`) _and_ a dict-of-numpy-arrays (`ParticleSet._data`). 

This new branch has the same performance as #2094 (see https://github.com/OceanParcels/parcels-benchmarks/pull/1#issuecomment-3089060453), but advantage is that users can also access the data as a `xarray.DataSet`. 

This will be useful e.g. in the `__repr__` (to be implemented) and the new implementation of `ParticleFile`

<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`particledata_as_dict`)
- [x] Added tests

