### PR TITLE
Add testing tooling to help compare array outputs between commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,13 @@
 build/*
 docs/_build/*
 docs/_downloads
-lib/
-bin/
-parcels_examples
 
-*.so
 *.log
 *.nc
 *.nc4
 !*testfields*.nc
 out-*
-*.c
 *.pyc
-*.dSYM/*
 **/*.zarr/*
 .DS_store
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import struct
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -133,3 +134,16 @@ def assert_valid_field_data(data: xr.DataArray, grid: XGrid):
         if ax_actual is None:
             continue  # None is ok
         assert ax_actual == ax_expected, f"Expected axis {ax_expected} for dimension '{dim}', got {ax_actual}"
+
+
+def hash_float_array(arr):
+    # Adapted from https://cs.stackexchange.com/a/37965
+    h = 1
+    for f in arr:
+        # Mimic Float.floatToIntBits: converts float to 4-byte binary, then interprets as int
+        float_as_int = struct.unpack("!i", struct.pack("!f", f))[0]
+        h = 31 * h + float_as_int
+
+    # Mimic Java's HashMap hash transformation
+    h ^= (h >> 20) ^ (h >> 12)
+    return h ^ (h >> 7) ^ (h >> 4)


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->
Also updated gitignore to remove old entries.


- [x] Chose the correct base branch (`v4-dev` for v4 changes)
- [x] Contributes to  #2111

Example usage:
```py
from tests import utils
def test_something():
    fieldset = ....
    pset = ...
    pset.execute(...)
    assert utils.hash_float_array([p.lon for p in pset]) == 1165396086
    assert utils.hash_float_array([p.lat for p in pset]) == 1142124776
```
This wouldn't show exactly what values changed, but is useful if you want to assert things are exactly the same as they were before. If the change is expected, the hash can be updated.