### PR TITLE
Update dependency metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,16 @@ classifiers = [
 dependencies = [
   "cgen",
   "cftime",
-  "numpy",
+  "numpy >=1.11",
   "dask",
   "psutil",
-  "netCDF4",
-  "zarr",
+  "netCDF4 >=1.1.9",
+  "zarr >=2.11.0,!=2.18.0,<3",
   "tqdm",
   "pymbolic",
   "pytest",
-  "scipy",
-  "xarray",
+  "scipy >=0.16.0",
+  "xarray >=0.10.8",
 ]
 
 [project.urls]


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->

Our dependency metadata on pypi was out of date, as flagged by  https://github.com/conda-forge/parcels-feedstock/pull/133 . This PR fixes this metadata so that pypi builds correctly resolve dependencies
- [x] Chose the correct base branch (`main` for v3 changes)

