### PR TITLE
Time loading after morton

### DIFF
--- a/parcels/fieldset.py
+++ b/parcels/fieldset.py
@@ -82,6 +82,13 @@ class FieldSet:
             return None
         return functools.reduce(lambda x, y: x.intersection(y), time_intervals)
 
+    def _load_timesteps(self, time):
+        """Load the appropriate timesteps of all fields in the fieldset."""
+        for fldname in self.fields:
+            field = self.fields[fldname]
+            if isinstance(field, Field):
+                field._load_timesteps(time)
+
     def add_field(self, field: Field, name: str | None = None):
         """Add a :class:`parcels.field.Field` object to the FieldSet.
 

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -578,10 +578,13 @@ class ParticleSet:
 
         time = start_time
         while sign_dt * (time - end_time) < 0:
+            # Load the appropriate timesteps of the fieldset
+            self.fieldset._load_timesteps(self._data["time_nextloop"][0])
+
             if sign_dt > 0:
-                next_time = end_time  # TODO update to min(next_output, end_time) when ParticleFile works
+                next_time = min(time + dt, end_time)
             else:
-                next_time = end_time  # TODO update to max(next_output, end_time) when ParticleFile works
+                next_time = max(time - dt, end_time)
             self._kernel.execute(self, endtime=next_time, dt=dt)
 
             # TODO: Handle IO timing based of timedelta or datetime objects

--- a/parcels/spatialhash.py
+++ b/parcels/spatialhash.py
@@ -408,5 +408,5 @@ def _encode_morton3d(x, y, z, xmin, xmax, ymin, ymax, zmin, zmax):
     # Cast to a wide type before shifting/OR to be safe when arrays are used.
     code = (dz3 << 2) | (dy3 << 1) | dx3
 
-    # If you want a compact type, it fits in 30 bits; uint32 is enough.
+    # Since our compact type fits in 30 bits, uint32 is enough.
     return code.astype(np.uint32)


### PR DESCRIPTION
This PR is a reimplementation of #2098 but then for the vectorized version of the kernel, building also on the Morton encoding in #2158. It is mostly for performance testing purposes, see also https://github.com/OceanParcels/parcels-benchmarks/pull/7

<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
