### PR TITLE
Deal with search interpolation errors

### DIFF
--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -15,7 +15,7 @@ from parcels.tools.statuscodes import (
     FieldOutOfBoundSurfaceError,
     _raise_field_out_of_bound_error,
     _raise_field_out_of_bound_surface_error,
-    _raise_field_sampling_error,
+    _raise_grid_searching_error,
     _raise_time_extrapolation_error,
 )
 
@@ -243,7 +243,7 @@ def _search_indices_rectilinear(
         zi, zeta = -1, 0
 
     if not ((0 <= xsi <= 1) and (0 <= eta <= 1) and (0 <= zeta <= 1)):
-        _raise_field_sampling_error(z, y, x)
+        _raise_grid_searching_error(z, y, x)
 
     _ei = field.ravel_index(zi, yi, xi)
 
@@ -314,7 +314,7 @@ def _search_indices_curvilinear_2d(
     eta = np.where(eta < 0.0, 0.0, np.where(eta > 1.0, 1.0, eta))
 
     if np.any((xsi < 0) | (xsi > 1) | (eta < 0) | (eta > 1)):
-        _raise_field_sampling_error(y, x)
+        _raise_grid_searching_error(y, x)
     return (yi, eta, xi, xsi)
 
 
@@ -400,7 +400,7 @@ def _search_indices_curvilinear(field, time, z, y, x, ti, particle=None, search2
         zeta = 0
 
     if not ((0 <= xsi <= 1) and (0 <= eta <= 1) and (0 <= zeta <= 1)):
-        _raise_field_sampling_error(z, y, x)
+        _raise_grid_searching_error(z, y, x)
 
     if particle:
         particle.ei[field.igrid] = field.ravel_index(zi, yi, xi)

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -233,9 +233,11 @@ class Field:
 
         tau, ti = _search_time_index(self, time)
         position = self.grid.search(z, y, x, ei=_ei)
-        _update_particle_states(particle, position)
+        _update_particle_states_position(particle, position)
 
         value = self._interp_method(self, ti, position, tau, time, z, y, x)
+
+        _update_particle_states_interp_value(particle, value)
 
         if applyConversion:
             value = self.units.to_target(value, z, y, x)
@@ -313,15 +315,20 @@ class VectorField:
 
         tau, ti = _search_time_index(self.U, time)
         position = self.grid.search(z, y, x, ei=_ei)
-        _update_particle_states(particle, position)
+        _update_particle_states_position(particle, position)
 
         if self._vector_interp_method is None:
             u = self.U._interp_method(self.U, ti, position, tau, time, z, y, x)
             v = self.V._interp_method(self.V, ti, position, tau, time, z, y, x)
             if "3D" in self.vector_type:
                 w = self.W._interp_method(self.W, ti, position, tau, time, z, y, x)
+            else:
+                w = 0.0
         else:
             (u, v, w) = self._vector_interp_method(self, ti, position, time, z, y, x)
+
+        for vel in (u, v, w):
+            _update_particle_states_interp_value(particle, vel)
 
         if applyConversion:
             u = self.U.units.to_target(u, z, y, x)
@@ -344,14 +351,30 @@ class VectorField:
             return _deal_with_errors(error, key, vector_type=self.vector_type)
 
 
-def _update_particle_states(particle, position):
+def _update_particle_states_position(particle, position):
     """Update the particle states based on the position dictionary."""
     if particle and "X" in position:  # TODO also support uxgrid search
-        particle.state = np.where(position["X"][0] < 0, StatusCode.ErrorOutOfBounds, particle.state)
-        particle.state = np.where(position["Y"][0] < 0, StatusCode.ErrorOutOfBounds, particle.state)
-        particle.state = np.where(position["Z"][0] == RIGHT_OUT_OF_BOUNDS, StatusCode.ErrorOutOfBounds, particle.state)
-        particle.state = np.where(
-            position["Z"][0] == LEFT_OUT_OF_BOUNDS, StatusCode.ErrorThroughSurface, particle.state
+        particle.state = np.maximum(
+            np.where(position["X"][0] < 0, StatusCode.ErrorOutOfBounds, particle.state), particle.state
+        )
+        particle.state = np.maximum(
+            np.where(position["Y"][0] < 0, StatusCode.ErrorOutOfBounds, particle.state), particle.state
+        )
+        particle.state = np.maximum(
+            np.where(position["Z"][0] == RIGHT_OUT_OF_BOUNDS, StatusCode.ErrorOutOfBounds, particle.state),
+            particle.state,
+        )
+        particle.state = np.maximum(
+            np.where(position["Z"][0] == LEFT_OUT_OF_BOUNDS, StatusCode.ErrorThroughSurface, particle.state),
+            particle.state,
+        )
+
+
+def _update_particle_states_interp_value(particle, value):
+    """Update the particle states based on the interpolated value, but only if state is not an Error already."""
+    if particle:
+        particle.state = np.maximum(
+            np.where(np.isnan(value), StatusCode.ErrorInterpolation, particle.state), particle.state
         )
 
 

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -15,9 +15,11 @@ from parcels.application_kernels.advection import (
 from parcels.basegrid import GridType
 from parcels.tools.statuscodes import (
     StatusCode,
+    _raise_field_interpolation_error,
     _raise_field_out_of_bound_error,
     _raise_field_out_of_bound_surface_error,
-    _raise_field_sampling_error,
+    _raise_general_error,
+    _raise_grid_searching_error,
     _raise_time_extrapolation_error,
 )
 from parcels.tools.warnings import KernelWarning
@@ -274,7 +276,9 @@ class Kernel:
                 StatusCode.ErrorTimeExtrapolation: _raise_time_extrapolation_error,
                 StatusCode.ErrorOutOfBounds: _raise_field_out_of_bound_error,
                 StatusCode.ErrorThroughSurface: _raise_field_out_of_bound_surface_error,
-                StatusCode.Error: _raise_field_sampling_error,
+                StatusCode.ErrorInterpolation: _raise_field_interpolation_error,
+                StatusCode.ErrorGridSearching: _raise_grid_searching_error,
+                StatusCode.Error: _raise_general_error,
             }
 
             for error_code, error_func in errors_to_throw.items():

--- a/parcels/tools/statuscodes.py
+++ b/parcels/tools/statuscodes.py
@@ -7,9 +7,11 @@ __all__ = [
     "KernelError",
     "StatusCode",
     "TimeExtrapolationError",
+    "_raise_field_interpolation_error",
     "_raise_field_out_of_bound_error",
     "_raise_field_out_of_bound_surface_error",
-    "_raise_field_sampling_error",
+    "_raise_general_error",
+    "_raise_grid_searching_error",
     "_raise_time_extrapolation_error",
 ]
 
@@ -25,15 +27,20 @@ class StatusCode:
     StopAllExecution = 41
     Error = 50
     ErrorInterpolation = 51
+    ErrorGridSearching = 52
     ErrorOutOfBounds = 60
     ErrorThroughSurface = 61
     ErrorTimeExtrapolation = 70
 
 
-class FieldSamplingError(RuntimeError):
-    """Utility error class to propagate erroneous field sampling."""
+class FieldInterpolationError(RuntimeError):
+    """Utility error class to propagate NaN field interpolation."""
 
     pass
+
+
+def _raise_field_interpolation_error(z, y, x):
+    raise FieldInterpolationError(f"Field interpolation returned NaN at (depth={z}, lat={y}, lon={x})")
 
 
 class FieldOutOfBoundError(RuntimeError):
@@ -42,18 +49,14 @@ class FieldOutOfBoundError(RuntimeError):
     pass
 
 
+def _raise_field_out_of_bound_error(z, y, x):
+    raise FieldOutOfBoundError(f"Field sampled out-of-bound, at (depth={z}, lat={y}, lon={x})")
+
+
 class FieldOutOfBoundSurfaceError(RuntimeError):
     """Utility error class to propagate out-of-bound field sampling at the surface."""
 
     pass
-
-
-def _raise_field_sampling_error(z, y, x):
-    raise FieldSamplingError(f"Field sampled at (depth={z}, lat={y}, lon={x})")
-
-
-def _raise_field_out_of_bound_error(z, y, x):
-    raise FieldOutOfBoundError(f"Field sampled out-of-bound, at (depth={z}, lat={y}, lon={x})")
 
 
 def _raise_field_out_of_bound_surface_error(z: float | None, y: float | None, x: float | None) -> None:
@@ -63,6 +66,32 @@ def _raise_field_out_of_bound_surface_error(z: float | None, y: float | None, x:
     raise FieldOutOfBoundSurfaceError(
         f"Field sampled out-of-bound at the surface, at (depth={format_out(z)}, lat={format_out(y)}, lon={format_out(x)})"
     )
+
+
+class FieldSamplingError(RuntimeError):
+    """Utility error class to propagate field sampling errors."""
+
+    pass
+
+
+class GridSearchingError(RuntimeError):
+    """Utility error class to propagate grid searching errors."""
+
+    pass
+
+
+def _raise_grid_searching_error(z, y, x):
+    raise GridSearchingError(f"Grid searching failed at (depth={z}, lat={y}, lon={x})")
+
+
+class GeneralError(RuntimeError):
+    """Utility error class to propagate general errors."""
+
+    pass
+
+
+def _raise_general_error(z, y, x):
+    raise GeneralError(f"General error occurred at (depth={z}, lat={y}, lon={x})")
 
 
 class TimeExtrapolationError(RuntimeError):
@@ -91,9 +120,11 @@ class KernelError(RuntimeError):
 
 
 AllParcelsErrorCodes = {
-    FieldSamplingError: StatusCode.Error,
+    FieldInterpolationError: StatusCode.ErrorInterpolation,
     FieldOutOfBoundError: StatusCode.ErrorOutOfBounds,
     FieldOutOfBoundSurfaceError: StatusCode.ErrorThroughSurface,
+    GridSearchingError: StatusCode.ErrorGridSearching,
     TimeExtrapolationError: StatusCode.ErrorTimeExtrapolation,
     KernelError: StatusCode.Error,
+    GeneralError: StatusCode.Error,
 }

--- a/tests/v4/test_particleset_execute.py
+++ b/tests/v4/test_particleset_execute.py
@@ -14,7 +14,7 @@ from parcels import (
 from parcels._datasets.structured.generated import simple_UV_dataset
 from parcels._datasets.structured.generic import datasets as datasets_structured
 from parcels._datasets.unstructured.generic import datasets as datasets_unstructured
-from parcels.tools.statuscodes import FieldOutOfBoundError, TimeExtrapolationError
+from parcels.tools.statuscodes import FieldInterpolationError, FieldOutOfBoundError, TimeExtrapolationError
 from parcels.uxgrid import UxGrid
 from parcels.xgrid import XGrid
 from tests import utils
@@ -156,6 +156,19 @@ def test_some_particles_throw_outoftime(fieldset):
 
     with pytest.raises(TimeExtrapolationError):
         pset.execute(FieldAccessOutsideTime, runtime=np.timedelta64(400, "D"), dt=np.timedelta64(10, "D"))
+
+
+def test_errorinterpolation(fieldset):
+    def NaNInterpolator(field, ti, position, tau, t, z, y, x):  # pragma: no cover
+        return np.nan * np.zeros_like(x)
+
+    def SampleU(particle, fieldset, time):  # pragma: no cover
+        fieldset.U[particle.time, particle.depth, particle.lat, particle.lon, particle]
+
+    fieldset.U.interp_method = NaNInterpolator
+    pset = ParticleSet(fieldset, lon=[0, 2], lat=[0, 0])
+    with pytest.raises(FieldInterpolationError):
+        pset.execute(SampleU, runtime=np.timedelta64(2, "s"), dt=np.timedelta64(1, "s"))
 
 
 def test_execution_check_stopallexecution(fieldset):


### PR DESCRIPTION
This Pr cleans up some of the error coding in Parcels v4. Specifically, it throws an InterpolationError when the return value of an `Interpolator` is `np.nan`

<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- [ ] Fixes #2162 
- [x] Added tests
- [ ] Added documentation
