### PR TITLE
Refactor param handling of `pset.execute` 

### DIFF
--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -508,7 +508,7 @@ class ParticleSet:
 
         if (dt is not None) and (not isinstance(dt, np.timedelta64)):
             raise TypeError("dt must be a np.timedelta64 object")
-        if dt is None or np.isnat(dt):
+        if dt is None:
             dt = np.timedelta64(1, "s")
         self._data["dt"][:] = dt
         sign_dt = np.sign(dt).astype(int)

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -506,14 +506,13 @@ class ParticleSet:
         if output_file:
             output_file.metadata["parcels_kernels"] = self._kernel.name
 
-        if (dt is not None) and (not isinstance(dt, np.timedelta64)):
-            raise TypeError("dt must be a np.timedelta64 object")
         if dt is None:
             dt = np.timedelta64(1, "s")
+
+        if not isinstance(dt, np.timedelta64) or np.isnat(dt) or (sign_dt := np.sign(dt).astype(int)) not in [-1, 1]:
+            raise ValueError(f"dt must be a positive or negative np.timedelta64 object, got {dt=!r}")
+
         self._data["dt"][:] = dt
-        sign_dt = np.sign(dt).astype(int)
-        if sign_dt not in [-1, 1]:
-            raise ValueError("dt must be a positive or negative np.timedelta64 object")
 
         if self.fieldset.time_interval is None:
             start_time = np.timedelta64(0, "s")  # For the execution loop, we need a start time as a timedelta object

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -625,7 +625,7 @@ def _get_simulation_start_and_end_times(
                 "provided endtime, or change your release timing."
                 "Important info:\n"
                 f"    First particle release: {first_release_time!r}\n"
-                f"    {runtime=!r}\n"
+                f"    runtime: {runtime!r}\n"
                 f"    (calculated) endtime: {endtime!r}"
             )
             raise ValueError(msg)

--- a/tests/v4/test_particleset.py
+++ b/tests/v4/test_particleset.py
@@ -130,10 +130,10 @@ def test_pset_starttime_not_multiple_dt(fieldset):
     "runtime, expectation",
     [
         (np.timedelta64(5, "s"), does_not_raise()),
-        (5.0, pytest.raises(TypeError)),
-        (timedelta(seconds=2), pytest.raises(TypeError)),
-        (np.datetime64("2001-01-02T00:00:00"), pytest.raises(TypeError)),
-        (datetime(2000, 1, 2, 0, 0, 0), pytest.raises(TypeError)),
+        (5.0, pytest.raises(ValueError)),
+        (timedelta(seconds=2), pytest.raises(ValueError)),
+        (np.datetime64("2001-01-02T00:00:00"), pytest.raises(ValueError)),
+        (datetime(2000, 1, 2, 0, 0, 0), pytest.raises(ValueError)),
     ],
 )
 def test_particleset_runtime_type(fieldset, runtime, expectation):
@@ -146,10 +146,10 @@ def test_particleset_runtime_type(fieldset, runtime, expectation):
     "endtime, expectation",
     [
         (np.datetime64("2000-01-02T00:00:00"), does_not_raise()),
-        (5.0, pytest.raises(TypeError)),
-        (np.timedelta64(5, "s"), pytest.raises(TypeError)),
-        (timedelta(seconds=2), pytest.raises(TypeError)),
-        (datetime(2000, 1, 2, 0, 0, 0), pytest.raises(TypeError)),
+        (5.0, pytest.raises(ValueError)),
+        (np.timedelta64(5, "s"), pytest.raises(ValueError)),
+        (timedelta(seconds=2), pytest.raises(ValueError)),
+        (datetime(2000, 1, 2, 0, 0, 0), pytest.raises(ValueError)),
     ],
 )
 def test_particleset_endtime_type(fieldset, endtime, expectation):

--- a/tests/v4/test_particleset.py
+++ b/tests/v4/test_particleset.py
@@ -126,38 +126,6 @@ def test_pset_starttime_not_multiple_dt(fieldset):
     assert np.allclose([p.lon_nextloop for p in pset], [8 - t for t in times])
 
 
-@pytest.mark.parametrize(
-    "runtime, expectation",
-    [
-        (np.timedelta64(5, "s"), does_not_raise()),
-        (5.0, pytest.raises(ValueError)),
-        (timedelta(seconds=2), pytest.raises(ValueError)),
-        (np.datetime64("2001-01-02T00:00:00"), pytest.raises(ValueError)),
-        (datetime(2000, 1, 2, 0, 0, 0), pytest.raises(ValueError)),
-    ],
-)
-def test_particleset_runtime_type(fieldset, runtime, expectation):
-    pset = ParticleSet(fieldset, lon=[0.2], lat=[5.0], depth=[50.0], pclass=Particle)
-    with expectation:
-        pset.execute(runtime=runtime, dt=np.timedelta64(10, "s"), pyfunc=DoNothing)
-
-
-@pytest.mark.parametrize(
-    "endtime, expectation",
-    [
-        (np.datetime64("2000-01-02T00:00:00"), does_not_raise()),
-        (5.0, pytest.raises(ValueError)),
-        (np.timedelta64(5, "s"), pytest.raises(ValueError)),
-        (timedelta(seconds=2), pytest.raises(ValueError)),
-        (datetime(2000, 1, 2, 0, 0, 0), pytest.raises(ValueError)),
-    ],
-)
-def test_particleset_endtime_type(fieldset, endtime, expectation):
-    pset = ParticleSet(fieldset, lon=[0.2], lat=[5.0], depth=[50.0], pclass=Particle)
-    with expectation:
-        pset.execute(endtime=endtime, dt=np.timedelta64(10, "m"), pyfunc=DoNothing)
-
-
 def test_pset_add_explicit(fieldset):
     npart = 11
     lon = np.linspace(0, 1, npart)

--- a/tests/v4/test_particleset.py
+++ b/tests/v4/test_particleset.py
@@ -114,21 +114,6 @@ def test_pset_create_outside_time(fieldset):
         ParticleSet(fieldset, pclass=Particle, lon=[0] * len(time), lat=[0] * len(time), time=time)
 
 
-@pytest.mark.parametrize(
-    "dt, expectation",
-    [
-        (np.timedelta64(5, "s"), does_not_raise()),
-        (5.0, pytest.raises(TypeError)),
-        (np.datetime64("2000-01-02T00:00:00"), pytest.raises(TypeError)),
-        (timedelta(seconds=2), pytest.raises(TypeError)),
-    ],
-)
-def test_particleset_dt_type(fieldset, dt, expectation):
-    pset = ParticleSet(fieldset, lon=[0.2], lat=[5.0], depth=[50.0], pclass=Particle)
-    with expectation:
-        pset.execute(runtime=np.timedelta64(10, "s"), dt=dt, pyfunc=DoNothing)
-
-
 def test_pset_starttime_not_multiple_dt(fieldset):
     times = [0, 1, 2]
     datetimes = [fieldset.time_interval.left + np.timedelta64(t, "s") for t in times]

--- a/tests/v4/test_particleset_execute.py
+++ b/tests/v4/test_particleset_execute.py
@@ -41,6 +41,16 @@ def zonal_flow_fieldset() -> FieldSet:
     return FieldSet([U, V, UV])
 
 
+def test_pset_execute_implicit_dt_one_second(fieldset):
+    pset = ParticleSet(fieldset, lon=[0.2], lat=[5.0], pclass=Particle)
+    pset.execute(DoNothing, runtime=np.timedelta64(1, "s"))
+
+    time = pset.time.copy()
+
+    pset.execute(DoNothing, runtime=np.timedelta64(1, "s"))
+    np.testing.assert_array_equal(pset.time, time + np.timedelta64(1, "s"))
+
+
 def test_pset_remove_particle_in_kernel(fieldset):
     npart = 100
     pset = ParticleSet(fieldset, lon=np.linspace(0, 1, npart), lat=np.linspace(1, 0, npart))

--- a/tests/v4/test_particleset_execute.py
+++ b/tests/v4/test_particleset_execute.py
@@ -210,7 +210,8 @@ def test_execution_runtime(fieldset, starttime, runtime, dt, npart):
     starttime = fieldset.time_interval.left + np.timedelta64(starttime, "s")
     runtime = np.timedelta64(runtime, "s")
     sign_dt = 1 if dt is None else np.sign(dt)
-    dt = np.timedelta64(dt, "s")
+    if dt is not None:
+        dt = np.timedelta64(dt, "s")
     pset = ParticleSet(fieldset, time=starttime, lon=np.zeros(npart), lat=np.zeros(npart))
     pset.execute(DoNothing, runtime=runtime, dt=dt)
     assert all([abs(p.time_nextloop - starttime - runtime * sign_dt) < np.timedelta64(1, "ms") for p in pset])

--- a/tests/v4/test_particleset_execute.py
+++ b/tests/v4/test_particleset_execute.py
@@ -261,10 +261,10 @@ def test_some_particles_throw_outoftime(fieldset):
     pset = ParticleSet(fieldset, lon=np.zeros_like(time), lat=np.zeros_like(time), time=time)
 
     def FieldAccessOutsideTime(particle, fieldset, time):  # pragma: no cover
-        fieldset.U[particle.time + np.timedelta64(1, "D"), particle.depth, particle.lat, particle.lon, particle]
+        fieldset.U[particle.time + np.timedelta64(400, "D"), particle.depth, particle.lat, particle.lon, particle]
 
     with pytest.raises(TimeExtrapolationError):
-        pset.execute(FieldAccessOutsideTime, runtime=np.timedelta64(400, "D"), dt=np.timedelta64(10, "D"))
+        pset.execute(FieldAccessOutsideTime, runtime=np.timedelta64(1, "D"), dt=np.timedelta64(10, "D"))
 
 
 def test_execution_check_stopallexecution(fieldset):


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->
This PR refactors the body of `pset.execute` out into `_get_simulation_start_and_end_times` to help with code maintainability, and make things easier to parse. The execution flow in `_get_simulation_start_and_end_times` is also easier to follow, and tests have been added to help with informative error messaging.


- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- [x] Fixes None
- [x] Added tests
- [ ] Added documentation
  - @erikvansebille I'm happy to leave the updating of the docstrings so we can do them all at the same time if that's ok? Worth noting the part talking about using a timedelta instead for endtime is now wrong (runtime would be used)