### PR TITLE
Enable Ruff rule T100

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ select = [
     "RUF", # ruff
     "ISC001", # single-line-implicit-string-concatenation
     "TID", # flake8-tidy-imports
+    "T100", # Checks for the presence of debugger calls and imports
 ]
 
 ignore = [


### PR DESCRIPTION
<!-- Feel free to remove list items that are not relevant for your changes. -->

Adds [Ruff T100](https://docs.astral.sh/ruff/rules/debugger/) - prevents the comitting of `breakpoint()` statements.



- [x] Chose the correct base branch ( `v4-dev` for v4 changes)
- [x] Fixes none