### PR TITLE
Also using _assert_same_function_signature for Kernels

### DIFF
--- a/docs/community/v4-migration.md
+++ b/docs/community/v4-migration.md
@@ -11,7 +11,8 @@ Version 4 of Parcels is unreleased at the moment. The information in this migrat
 - Sharing state between kernels must be done via the particle data (as the kernels are not combined under the hood anymore).
 - `particl_dlon`, `particle_dlat` etc have been renamed to `particle.dlon` and `particle.dlat`.
 - `particle.dt` is a np.timedelta64 object; be careful when multiplying `particle.dt` with a velocity, as its value may be cast to nanoseconds.
-- The `time` argument in the Kernel signature is now standard `None` (and may be removed in the Kernel API before release of v4), so can't be used. Use `particle.time` instead.
+- The `time` argument in the Kernel signature has been removed in the Kernel API, so can't be used. Use `particle.time` instead.
+- The `particle` argument in the Kernel signature has been renamed to `particles`.
 - `math` functions should be replaced with array compatible equivalents (e.g., `math.sin` -> `np.sin`). Instead of `ParcelsRandom` you should use numpy's random functions.
 
 ## FieldSet

--- a/parcels/application_kernels/advection.py
+++ b/parcels/application_kernels/advection.py
@@ -16,96 +16,96 @@ __all__ = [
 ]
 
 
-def AdvectionRK4(particle, fieldset, time):  # pragma: no cover
+def AdvectionRK4(particles, fieldset):  # pragma: no cover
     """Advection of particles using fourth-order Runge-Kutta integration."""
-    dt = particle.dt / np.timedelta64(1, "s")  # TODO: improve API for converting dt to seconds
-    (u1, v1) = fieldset.UV[particle]
-    lon1, lat1 = (particle.lon + u1 * 0.5 * dt, particle.lat + v1 * 0.5 * dt)
-    (u2, v2) = fieldset.UV[particle.time + 0.5 * particle.dt, particle.depth, lat1, lon1, particle]
-    lon2, lat2 = (particle.lon + u2 * 0.5 * dt, particle.lat + v2 * 0.5 * dt)
-    (u3, v3) = fieldset.UV[particle.time + 0.5 * particle.dt, particle.depth, lat2, lon2, particle]
-    lon3, lat3 = (particle.lon + u3 * dt, particle.lat + v3 * dt)
-    (u4, v4) = fieldset.UV[particle.time + particle.dt, particle.depth, lat3, lon3, particle]
-    particle.dlon += (u1 + 2 * u2 + 2 * u3 + u4) / 6.0 * dt
-    particle.dlat += (v1 + 2 * v2 + 2 * v3 + v4) / 6.0 * dt
+    dt = particles.dt / np.timedelta64(1, "s")  # TODO: improve API for converting dt to seconds
+    (u1, v1) = fieldset.UV[particles]
+    lon1, lat1 = (particles.lon + u1 * 0.5 * dt, particles.lat + v1 * 0.5 * dt)
+    (u2, v2) = fieldset.UV[particles.time + 0.5 * particles.dt, particles.depth, lat1, lon1, particles]
+    lon2, lat2 = (particles.lon + u2 * 0.5 * dt, particles.lat + v2 * 0.5 * dt)
+    (u3, v3) = fieldset.UV[particles.time + 0.5 * particles.dt, particles.depth, lat2, lon2, particles]
+    lon3, lat3 = (particles.lon + u3 * dt, particles.lat + v3 * dt)
+    (u4, v4) = fieldset.UV[particles.time + particles.dt, particles.depth, lat3, lon3, particles]
+    particles.dlon += (u1 + 2 * u2 + 2 * u3 + u4) / 6.0 * dt
+    particles.dlat += (v1 + 2 * v2 + 2 * v3 + v4) / 6.0 * dt
 
 
-def AdvectionRK4_3D(particle, fieldset, time):  # pragma: no cover
+def AdvectionRK4_3D(particles, fieldset):  # pragma: no cover
     """Advection of particles using fourth-order Runge-Kutta integration including vertical velocity."""
-    dt = particle.dt / np.timedelta64(1, "s")
-    (u1, v1, w1) = fieldset.UVW[particle]
-    lon1 = particle.lon + u1 * 0.5 * dt
-    lat1 = particle.lat + v1 * 0.5 * dt
-    dep1 = particle.depth + w1 * 0.5 * dt
-    (u2, v2, w2) = fieldset.UVW[particle.time + 0.5 * particle.dt, dep1, lat1, lon1, particle]
-    lon2 = particle.lon + u2 * 0.5 * dt
-    lat2 = particle.lat + v2 * 0.5 * dt
-    dep2 = particle.depth + w2 * 0.5 * dt
-    (u3, v3, w3) = fieldset.UVW[particle.time + 0.5 * particle.dt, dep2, lat2, lon2, particle]
-    lon3 = particle.lon + u3 * dt
-    lat3 = particle.lat + v3 * dt
-    dep3 = particle.depth + w3 * dt
-    (u4, v4, w4) = fieldset.UVW[particle.time + particle.dt, dep3, lat3, lon3, particle]
-    particle.dlon += (u1 + 2 * u2 + 2 * u3 + u4) / 6 * dt
-    particle.dlat += (v1 + 2 * v2 + 2 * v3 + v4) / 6 * dt
-    particle.ddepth += (w1 + 2 * w2 + 2 * w3 + w4) / 6 * dt
+    dt = particles.dt / np.timedelta64(1, "s")
+    (u1, v1, w1) = fieldset.UVW[particles]
+    lon1 = particles.lon + u1 * 0.5 * dt
+    lat1 = particles.lat + v1 * 0.5 * dt
+    dep1 = particles.depth + w1 * 0.5 * dt
+    (u2, v2, w2) = fieldset.UVW[particles.time + 0.5 * particles.dt, dep1, lat1, lon1, particles]
+    lon2 = particles.lon + u2 * 0.5 * dt
+    lat2 = particles.lat + v2 * 0.5 * dt
+    dep2 = particles.depth + w2 * 0.5 * dt
+    (u3, v3, w3) = fieldset.UVW[particles.time + 0.5 * particles.dt, dep2, lat2, lon2, particles]
+    lon3 = particles.lon + u3 * dt
+    lat3 = particles.lat + v3 * dt
+    dep3 = particles.depth + w3 * dt
+    (u4, v4, w4) = fieldset.UVW[particles.time + particles.dt, dep3, lat3, lon3, particles]
+    particles.dlon += (u1 + 2 * u2 + 2 * u3 + u4) / 6 * dt
+    particles.dlat += (v1 + 2 * v2 + 2 * v3 + v4) / 6 * dt
+    particles.ddepth += (w1 + 2 * w2 + 2 * w3 + w4) / 6 * dt
 
 
-def AdvectionRK4_3D_CROCO(particle, fieldset, time):  # pragma: no cover
+def AdvectionRK4_3D_CROCO(particles, fieldset):  # pragma: no cover
     """Advection of particles using fourth-order Runge-Kutta integration including vertical velocity.
     This kernel assumes the vertical velocity is the 'w' field from CROCO output and works on sigma-layers.
     """
-    dt = particle.dt / np.timedelta64(1, "s")  # TODO: improve API for converting dt to seconds
-    sig_dep = particle.depth / fieldset.H[particle.time, 0, particle.lat, particle.lon]
+    dt = particles.dt / np.timedelta64(1, "s")  # TODO: improve API for converting dt to seconds
+    sig_dep = particles.depth / fieldset.H[particles.time, 0, particles.lat, particles.lon]
 
-    (u1, v1, w1) = fieldset.UVW[particle.time, particle.depth, particle.lat, particle.lon, particle]
-    w1 *= sig_dep / fieldset.H[particle.time, 0, particle.lat, particle.lon]
-    lon1 = particle.lon + u1 * 0.5 * dt
-    lat1 = particle.lat + v1 * 0.5 * dt
+    (u1, v1, w1) = fieldset.UVW[particles.time, particles.depth, particles.lat, particles.lon, particles]
+    w1 *= sig_dep / fieldset.H[particles.time, 0, particles.lat, particles.lon]
+    lon1 = particles.lon + u1 * 0.5 * dt
+    lat1 = particles.lat + v1 * 0.5 * dt
     sig_dep1 = sig_dep + w1 * 0.5 * dt
-    dep1 = sig_dep1 * fieldset.H[particle.time, 0, lat1, lon1]
+    dep1 = sig_dep1 * fieldset.H[particles.time, 0, lat1, lon1]
 
-    (u2, v2, w2) = fieldset.UVW[particle.time + 0.5 * particle.dt, dep1, lat1, lon1, particle]
-    w2 *= sig_dep1 / fieldset.H[particle.time, 0, lat1, lon1]
-    lon2 = particle.lon + u2 * 0.5 * dt
-    lat2 = particle.lat + v2 * 0.5 * dt
+    (u2, v2, w2) = fieldset.UVW[particles.time + 0.5 * particles.dt, dep1, lat1, lon1, particles]
+    w2 *= sig_dep1 / fieldset.H[particles.time, 0, lat1, lon1]
+    lon2 = particles.lon + u2 * 0.5 * dt
+    lat2 = particles.lat + v2 * 0.5 * dt
     sig_dep2 = sig_dep + w2 * 0.5 * dt
-    dep2 = sig_dep2 * fieldset.H[particle.time, 0, lat2, lon2]
+    dep2 = sig_dep2 * fieldset.H[particles.time, 0, lat2, lon2]
 
-    (u3, v3, w3) = fieldset.UVW[particle.time + 0.5 * particle.dt, dep2, lat2, lon2, particle]
-    w3 *= sig_dep2 / fieldset.H[particle.time, 0, lat2, lon2]
-    lon3 = particle.lon + u3 * dt
-    lat3 = particle.lat + v3 * dt
+    (u3, v3, w3) = fieldset.UVW[particles.time + 0.5 * particles.dt, dep2, lat2, lon2, particles]
+    w3 *= sig_dep2 / fieldset.H[particles.time, 0, lat2, lon2]
+    lon3 = particles.lon + u3 * dt
+    lat3 = particles.lat + v3 * dt
     sig_dep3 = sig_dep + w3 * dt
-    dep3 = sig_dep3 * fieldset.H[particle.time, 0, lat3, lon3]
+    dep3 = sig_dep3 * fieldset.H[particles.time, 0, lat3, lon3]
 
-    (u4, v4, w4) = fieldset.UVW[particle.time + particle.dt, dep3, lat3, lon3, particle]
-    w4 *= sig_dep3 / fieldset.H[particle.time, 0, lat3, lon3]
-    lon4 = particle.lon + u4 * dt
-    lat4 = particle.lat + v4 * dt
+    (u4, v4, w4) = fieldset.UVW[particles.time + particles.dt, dep3, lat3, lon3, particles]
+    w4 *= sig_dep3 / fieldset.H[particles.time, 0, lat3, lon3]
+    lon4 = particles.lon + u4 * dt
+    lat4 = particles.lat + v4 * dt
     sig_dep4 = sig_dep + w4 * dt
-    dep4 = sig_dep4 * fieldset.H[particle.time, 0, lat4, lon4]
+    dep4 = sig_dep4 * fieldset.H[particles.time, 0, lat4, lon4]
 
-    particle.dlon += (u1 + 2 * u2 + 2 * u3 + u4) / 6 * dt
-    particle.dlat += (v1 + 2 * v2 + 2 * v3 + v4) / 6 * dt
-    particle.ddepth += (
-        (dep1 - particle.depth) * 2
-        + 2 * (dep2 - particle.depth) * 2
-        + 2 * (dep3 - particle.depth)
+    particles.dlon += (u1 + 2 * u2 + 2 * u3 + u4) / 6 * dt
+    particles.dlat += (v1 + 2 * v2 + 2 * v3 + v4) / 6 * dt
+    particles.ddepth += (
+        (dep1 - particles.depth) * 2
+        + 2 * (dep2 - particles.depth) * 2
+        + 2 * (dep3 - particles.depth)
         + dep4
-        - particle.depth
+        - particles.depth
     ) / 6
 
 
-def AdvectionEE(particle, fieldset, time):  # pragma: no cover
+def AdvectionEE(particles, fieldset):  # pragma: no cover
     """Advection of particles using Explicit Euler (aka Euler Forward) integration."""
-    dt = particle.dt / np.timedelta64(1, "s")  # TODO: improve API for converting dt to seconds
-    (u1, v1) = fieldset.UV[particle]
-    particle.dlon += u1 * dt
-    particle.dlat += v1 * dt
+    dt = particles.dt / np.timedelta64(1, "s")  # TODO: improve API for converting dt to seconds
+    (u1, v1) = fieldset.UV[particles]
+    particles.dlon += u1 * dt
+    particles.dlat += v1 * dt
 
 
-def AdvectionRK45(particle, fieldset, time):  # pragma: no cover
+def AdvectionRK45(particles, fieldset):  # pragma: no cover
     """Advection of particles using adaptive Runge-Kutta 4/5 integration.
 
     Note that this kernel requires a Particle Class that has an extra Variable 'next_dt'
@@ -115,7 +115,7 @@ def AdvectionRK45(particle, fieldset, time):  # pragma: no cover
     Time-step dt is halved if error is larger than fieldset.RK45_tol,
     and doubled if error is smaller than 1/10th of tolerance.
     """
-    dt = particle.dt / np.timedelta64(1, "s")  # TODO: improve API for converting dt to seconds
+    dt = particles.dt / np.timedelta64(1, "s")  # TODO: improve API for converting dt to seconds
 
     c = [1.0 / 4.0, 3.0 / 8.0, 12.0 / 13.0, 1.0, 1.0 / 2.0]
     A = [
@@ -128,29 +128,29 @@ def AdvectionRK45(particle, fieldset, time):  # pragma: no cover
     b4 = [25.0 / 216.0, 0.0, 1408.0 / 2565.0, 2197.0 / 4104.0, -1.0 / 5.0]
     b5 = [16.0 / 135.0, 0.0, 6656.0 / 12825.0, 28561.0 / 56430.0, -9.0 / 50.0, 2.0 / 55.0]
 
-    (u1, v1) = fieldset.UV[particle]
-    lon1, lat1 = (particle.lon + u1 * A[0][0] * dt, particle.lat + v1 * A[0][0] * dt)
-    (u2, v2) = fieldset.UV[particle.time + c[0] * particle.dt, particle.depth, lat1, lon1, particle]
+    (u1, v1) = fieldset.UV[particles]
+    lon1, lat1 = (particles.lon + u1 * A[0][0] * dt, particles.lat + v1 * A[0][0] * dt)
+    (u2, v2) = fieldset.UV[particles.time + c[0] * particles.dt, particles.depth, lat1, lon1, particles]
     lon2, lat2 = (
-        particle.lon + (u1 * A[1][0] + u2 * A[1][1]) * dt,
-        particle.lat + (v1 * A[1][0] + v2 * A[1][1]) * dt,
+        particles.lon + (u1 * A[1][0] + u2 * A[1][1]) * dt,
+        particles.lat + (v1 * A[1][0] + v2 * A[1][1]) * dt,
     )
-    (u3, v3) = fieldset.UV[particle.time + c[1] * particle.dt, particle.depth, lat2, lon2, particle]
+    (u3, v3) = fieldset.UV[particles.time + c[1] * particles.dt, particles.depth, lat2, lon2, particles]
     lon3, lat3 = (
-        particle.lon + (u1 * A[2][0] + u2 * A[2][1] + u3 * A[2][2]) * dt,
-        particle.lat + (v1 * A[2][0] + v2 * A[2][1] + v3 * A[2][2]) * dt,
+        particles.lon + (u1 * A[2][0] + u2 * A[2][1] + u3 * A[2][2]) * dt,
+        particles.lat + (v1 * A[2][0] + v2 * A[2][1] + v3 * A[2][2]) * dt,
     )
-    (u4, v4) = fieldset.UV[particle.time + c[2] * particle.dt, particle.depth, lat3, lon3, particle]
+    (u4, v4) = fieldset.UV[particles.time + c[2] * particles.dt, particles.depth, lat3, lon3, particles]
     lon4, lat4 = (
-        particle.lon + (u1 * A[3][0] + u2 * A[3][1] + u3 * A[3][2] + u4 * A[3][3]) * dt,
-        particle.lat + (v1 * A[3][0] + v2 * A[3][1] + v3 * A[3][2] + v4 * A[3][3]) * dt,
+        particles.lon + (u1 * A[3][0] + u2 * A[3][1] + u3 * A[3][2] + u4 * A[3][3]) * dt,
+        particles.lat + (v1 * A[3][0] + v2 * A[3][1] + v3 * A[3][2] + v4 * A[3][3]) * dt,
     )
-    (u5, v5) = fieldset.UV[particle.time + c[3] * particle.dt, particle.depth, lat4, lon4, particle]
+    (u5, v5) = fieldset.UV[particles.time + c[3] * particles.dt, particles.depth, lat4, lon4, particles]
     lon5, lat5 = (
-        particle.lon + (u1 * A[4][0] + u2 * A[4][1] + u3 * A[4][2] + u4 * A[4][3] + u5 * A[4][4]) * dt,
-        particle.lat + (v1 * A[4][0] + v2 * A[4][1] + v3 * A[4][2] + v4 * A[4][3] + v5 * A[4][4]) * dt,
+        particles.lon + (u1 * A[4][0] + u2 * A[4][1] + u3 * A[4][2] + u4 * A[4][3] + u5 * A[4][4]) * dt,
+        particles.lat + (v1 * A[4][0] + v2 * A[4][1] + v3 * A[4][2] + v4 * A[4][3] + v5 * A[4][4]) * dt,
     )
-    (u6, v6) = fieldset.UV[particle.time + c[4] * particle.dt, particle.depth, lat5, lon5, particle]
+    (u6, v6) = fieldset.UV[particles.time + c[4] * particles.dt, particles.depth, lat5, lon5, particles]
 
     lon_4th = (u1 * b4[0] + u2 * b4[1] + u3 * b4[2] + u4 * b4[3] + u5 * b4[4]) * dt
     lat_4th = (v1 * b4[0] + v2 * b4[1] + v3 * b4[2] + v4 * b4[3] + v5 * b4[4]) * dt
@@ -160,31 +160,31 @@ def AdvectionRK45(particle, fieldset, time):  # pragma: no cover
     kappa = np.sqrt(np.pow(lon_5th - lon_4th, 2) + np.pow(lat_5th - lat_4th, 2))
 
     good_particles = (kappa <= fieldset.RK45_tol) | (np.fabs(dt) <= np.fabs(fieldset.RK45_min_dt))
-    particle.dlon += np.where(good_particles, lon_5th, 0)
-    particle.dlat += np.where(good_particles, lat_5th, 0)
+    particles.dlon += np.where(good_particles, lon_5th, 0)
+    particles.dlat += np.where(good_particles, lat_5th, 0)
 
     increase_dt_particles = (
         good_particles & (kappa <= fieldset.RK45_tol / 10) & (np.fabs(dt * 2) <= np.fabs(fieldset.RK45_max_dt))
     )
-    particle.dt = np.where(increase_dt_particles, particle.dt * 2, particle.dt)
-    particle.dt = np.where(
-        particle.dt > fieldset.RK45_max_dt * np.timedelta64(1, "s"),
+    particles.dt = np.where(increase_dt_particles, particles.dt * 2, particles.dt)
+    particles.dt = np.where(
+        particles.dt > fieldset.RK45_max_dt * np.timedelta64(1, "s"),
         fieldset.RK45_max_dt * np.timedelta64(1, "s"),
-        particle.dt,
+        particles.dt,
     )
-    particle.state = np.where(good_particles, StatusCode.Success, particle.state)
+    particles.state = np.where(good_particles, StatusCode.Success, particles.state)
 
     repeat_particles = np.invert(good_particles)
-    particle.dt = np.where(repeat_particles, particle.dt / 2, particle.dt)
-    particle.dt = np.where(
-        particle.dt < fieldset.RK45_min_dt * np.timedelta64(1, "s"),
+    particles.dt = np.where(repeat_particles, particles.dt / 2, particles.dt)
+    particles.dt = np.where(
+        particles.dt < fieldset.RK45_min_dt * np.timedelta64(1, "s"),
         fieldset.RK45_min_dt * np.timedelta64(1, "s"),
-        particle.dt,
+        particles.dt,
     )
-    particle.state = np.where(repeat_particles, StatusCode.Repeat, particle.state)
+    particles.state = np.where(repeat_particles, StatusCode.Repeat, particles.state)
 
 
-def AdvectionAnalytical(particle, fieldset, time):  # pragma: no cover
+def AdvectionAnalytical(particles, fieldset):  # pragma: no cover
     """Advection of particles using 'analytical advection' integration.
 
     Based on Ariane/TRACMASS algorithm, as detailed in e.g. Doos et al (https://doi.org/10.5194/gmd-10-1733-2017).
@@ -197,17 +197,17 @@ def AdvectionAnalytical(particle, fieldset, time):  # pragma: no cover
 
     tol = 1e-10
     I_s = 10  # number of intermediate time steps
-    dt = particle.dt / np.timedelta64(1, "s")  # TODO improve API for converting dt to seconds
+    dt = particles.dt / np.timedelta64(1, "s")  # TODO improve API for converting dt to seconds
     direction = 1.0 if dt > 0 else -1.0
     withW = True if "W" in [f.name for f in fieldset.fields.values()] else False
     withTime = True if len(fieldset.U.grid.time) > 1 else False
     tau, zeta, eta, xsi, ti, zi, yi, xi = fieldset.U._search_indices(
-        time, particle.depth, particle.lat, particle.lon, particle=particle
+        particles.depth, particles.lat, particles.lon, particles=particles
     )
     ds_t = dt
     if withTime:
         time_i = np.linspace(0, fieldset.U.grid.time[ti + 1] - fieldset.U.grid.time[ti], I_s)
-        ds_t = min(ds_t, time_i[np.where(time - fieldset.U.grid.time[ti] < time_i)[0][0]])
+        ds_t = min(ds_t, time_i[np.where(particles.time - fieldset.U.grid.time[ti] < time_i)[0][0]])
 
     if withW:
         if abs(xsi - 1) < tol:
@@ -232,7 +232,7 @@ def AdvectionAnalytical(particle, fieldset, time):  # pragma: no cover
                 yi += 1
                 eta = 0
 
-    particle.ei[:] = fieldset.U.ravel_index(zi, yi, xi)
+    particles.ei[:] = fieldset.U.ravel_index(zi, yi, xi)
 
     grid = fieldset.U.grid
     if grid._gtype < 2:
@@ -242,8 +242,8 @@ def AdvectionAnalytical(particle, fieldset, time):  # pragma: no cover
         px = np.array([grid.lon[yi, xi], grid.lon[yi, xi + 1], grid.lon[yi + 1, xi + 1], grid.lon[yi + 1, xi]])
         py = np.array([grid.lat[yi, xi], grid.lat[yi, xi + 1], grid.lat[yi + 1, xi + 1], grid.lat[yi + 1, xi]])
     if grid.mesh == "spherical":
-        px[0] = px[0] + 360 if px[0] < particle.lon - 225 else px[0]
-        px[0] = px[0] - 360 if px[0] > particle.lat + 225 else px[0]
+        px[0] = px[0] + 360 if px[0] < particles.lon - 225 else px[0]
+        px[0] = px[0] - 360 if px[0] > particles.lat + 225 else px[0]
         px[1:] = np.where(px[1:] - px[0] > 180, px[1:] - 360, px[1:])
         px[1:] = np.where(-px[1:] + px[0] > 180, px[1:] + 360, px[1:])
     if withW:
@@ -258,7 +258,7 @@ def AdvectionAnalytical(particle, fieldset, time):  # pragma: no cover
     c4 = i_u._geodetic_distance(py[3], py[0], px[3], px[0], grid.mesh, np.dot(i_u.phi2D_lin(eta, 0.0), py))
     rad = np.pi / 180.0
     deg2m = 1852 * 60.0
-    meshJac = (deg2m * deg2m * math.cos(rad * particle.lat)) if grid.mesh == "spherical" else 1
+    meshJac = (deg2m * deg2m * math.cos(rad * particles.lat)) if grid.mesh == "spherical" else 1
     dxdy = i_u._compute_jacobian_determinant(py, px, eta, xsi) * meshJac
 
     if withW:
@@ -333,26 +333,26 @@ def AdvectionAnalytical(particle, fieldset, time):  # pragma: no cover
     rs_x = compute_rs(xsi, B_x, delta_x, s_min)
     rs_y = compute_rs(eta, B_y, delta_y, s_min)
 
-    particle.dlon += (
+    particles.dlon += (
         (1.0 - rs_x) * (1.0 - rs_y) * px[0]
         + rs_x * (1.0 - rs_y) * px[1]
         + rs_x * rs_y * px[2]
         + (1.0 - rs_x) * rs_y * px[3]
-        - particle.lon
+        - particles.lon
     )
-    particle.dlat += (
+    particles.dlat += (
         (1.0 - rs_x) * (1.0 - rs_y) * py[0]
         + rs_x * (1.0 - rs_y) * py[1]
         + rs_x * rs_y * py[2]
         + (1.0 - rs_x) * rs_y * py[3]
-        - particle.lat
+        - particles.lat
     )
 
     if withW:
         rs_z = compute_rs(zeta, B_z, delta_z, s_min)
-        particle.ddepth += (1.0 - rs_z) * pz[0] + rs_z * pz[1] - particle.depth
+        particles.ddepth += (1.0 - rs_z) * pz[0] + rs_z * pz[1] - particles.depth
 
-    if particle.dt > 0:
-        particle.dt = max(direction * s_min * (dxdy * dz), 1e-7).astype("timedelta64[s]")
+    if particles.dt > 0:
+        particles.dt = max(direction * s_min * (dxdy * dz), 1e-7).astype("timedelta64[s]")
     else:
-        particle.dt = min(direction * s_min * (dxdy * dz), -1e-7).astype("timedelta64[s]")
+        particles.dt = min(direction * s_min * (dxdy * dz), -1e-7).astype("timedelta64[s]")

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -115,22 +115,22 @@ class Kernel:
 
     def add_positionupdate_kernels(self):
         # Adding kernels that set and update the coordinate changes
-        def Setcoords(particle, fieldset, time):  # pragma: no cover
+        def Setcoords(particles, fieldset):  # pragma: no cover
             import numpy as np  # noqa
 
-            particle.dlon = 0
-            particle.dlat = 0
-            particle.ddepth = 0
-            particle.lon = particle.lon_nextloop
-            particle.lat = particle.lat_nextloop
-            particle.depth = particle.depth_nextloop
-            particle.time = particle.time_nextloop
+            particles.dlon = 0
+            particles.dlat = 0
+            particles.ddepth = 0
+            particles.lon = particles.lon_nextloop
+            particles.lat = particles.lat_nextloop
+            particles.depth = particles.depth_nextloop
+            particles.time = particles.time_nextloop
 
-        def Updatecoords(particle, fieldset, time):  # pragma: no cover
-            particle.lon_nextloop = particle.lon + particle.dlon
-            particle.lat_nextloop = particle.lat + particle.dlat
-            particle.depth_nextloop = particle.depth + particle.ddepth
-            particle.time_nextloop = particle.time + particle.dt
+        def Updatecoords(particles, fieldset):  # pragma: no cover
+            particles.lon_nextloop = particles.lon + particles.dlon
+            particles.lat_nextloop = particles.lat + particles.dlat
+            particles.depth_nextloop = particles.depth + particles.ddepth
+            particles.time_nextloop = particles.time + particles.dt
 
         self._pyfuncs = (Setcoords + self + Updatecoords)._pyfuncs
 
@@ -258,12 +258,12 @@ class Kernel:
             # run kernels for all particles that need to be evaluated
             evaluate_particles = (pset.state == StatusCode.Evaluate) & (pset.dt != 0)
             for f in self._pyfuncs:
-                f(pset[evaluate_particles], self._fieldset, None)
+                f(pset[evaluate_particles], self._fieldset)
 
                 # check for particles that have to be repeated
                 repeat_particles = pset.state == StatusCode.Repeat
                 while np.any(repeat_particles):
-                    f(pset[repeat_particles], self._fieldset, None)
+                    f(pset[repeat_particles], self._fieldset)
                     repeat_particles = pset.state == StatusCode.Repeat
 
             # revert to original dt (unless in RK45 mode)

--- a/parcels/kernel.py
+++ b/parcels/kernel.py
@@ -13,6 +13,7 @@ from parcels.application_kernels.advection import (
     AdvectionRK45,
 )
 from parcels.basegrid import GridType
+from parcels.tools._helpers import _assert_same_function_signature
 from parcels.tools.statuscodes import (
     StatusCode,
     _raise_field_interpolation_error,
@@ -23,6 +24,7 @@ from parcels.tools.statuscodes import (
     _raise_time_extrapolation_error,
 )
 from parcels.tools.warnings import KernelWarning
+from tests.common_kernels import DoNothing
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -67,6 +69,7 @@ class Kernel:
         for f in pyfuncs:
             if not isinstance(f, types.FunctionType):
                 raise TypeError(f"Argument pyfunc should be a function or list of functions. Got {type(f)}")
+            _assert_same_function_signature(f, ref=DoNothing, context="Kernel")
 
         if len(pyfuncs) == 0:
             raise ValueError("List of `pyfuncs` should have at least one function.")

--- a/parcels/tools/_helpers.py
+++ b/parcels/tools/_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import warnings
 from collections.abc import Callable
 from datetime import timedelta
@@ -75,3 +76,22 @@ def timedelta_to_float(dt: float | timedelta | np.timedelta64) -> float:
 def should_calculate_next_ti(ti: int, tau: float, tdim: int):
     """Check if the time is beyond the last time in the field"""
     return np.greater(tau, 0) and ti < tdim - 1
+
+
+def _assert_same_function_signature(f: Callable, *, ref: Callable, context: str) -> None:
+    """Ensures a function `f` has the same signature as the reference function `ref`."""
+    sig_ref = inspect.signature(ref)
+    sig = inspect.signature(f)
+
+    if len(sig_ref.parameters) != len(sig.parameters):
+        raise ValueError(
+            f"{context} function must have {len(sig_ref.parameters)} parameters, got {len(sig.parameters)}"
+        )
+
+    for (_name1, param1), (_name2, param2) in zip(sig_ref.parameters.items(), sig.parameters.items(), strict=False):
+        if param1.kind != param2.kind:
+            raise ValueError(
+                f"Parameter '{_name2}' has incorrect parameter kind. Expected {param1.kind}, got {param2.kind}"
+            )
+        if param1.name != param2.name:
+            raise ValueError(f"Parameter '{_name2}' has incorrect name. Expected '{param1.name}', got '{param2.name}'")

--- a/tests/common_kernels.py
+++ b/tests/common_kernels.py
@@ -1,18 +1,21 @@
 """Shared kernels between tests."""
 
+import numpy as np
 
-def DoNothing(particle, fieldset, time):  # pragma: no cover
+from parcels.tools.statuscodes import StatusCode
+
+
+def DoNothing(particles, fieldset):  # pragma: no cover
     pass
 
 
-def DeleteParticle(particle, fieldset, time):  # pragma: no cover
-    if particle.state >= 50:  # This captures all Errors
-        particle.delete()
+def DeleteParticle(particles, fieldset):  # pragma: no cover
+    particles.state = np.where(particles.state >= 50, StatusCode.Delete, particles.state)
 
 
-def MoveEast(particle, fieldset, time):  # pragma: no cover
-    particle.dlon += 0.1
+def MoveEast(particles, fieldset):  # pragma: no cover
+    particles.dlon += 0.1
 
 
-def MoveNorth(particle, fieldset, time):  # pragma: no cover
-    particle.dlat += 0.1
+def MoveNorth(particles, fieldset):  # pragma: no cover
+    particles.dlat += 0.1

--- a/tests/v4/test_advection.py
+++ b/tests/v4/test_advection.py
@@ -462,7 +462,7 @@ def test_nemo_curvilinear_fieldset():
     latp = np.linspace(-70, 88, npart)
     runtime = np.timedelta64(12, "h")  # TODO increase to 160 days
 
-    def periodicBC(particle, fieldSet, time):  # pragma: no cover
+    def periodicBC(particle, fieldset, time):  # pragma: no cover
         particle.dlon = np.where(particle.lon > 180, particle.dlon - 360, particle.dlon)
 
     pset = parcels.ParticleSet(fieldset, lon=lonp, lat=latp)

--- a/tests/v4/test_diffusion.py
+++ b/tests/v4/test_diffusion.py
@@ -102,9 +102,9 @@ def test_randomexponential(lambd):
 
     pset = ParticleSet(fieldset=fieldset, lon=np.zeros(npart), lat=np.zeros(npart), depth=np.zeros(npart))
 
-    def vertical_randomexponential(particle, fieldset, time):  # pragma: no cover
+    def vertical_randomexponential(particles, fieldset):  # pragma: no cover
         # Kernel for random exponential variable in depth direction
-        particle.depth = np.random.exponential(scale=1 / fieldset.lambd, size=len(particle))
+        particles.depth = np.random.exponential(scale=1 / fieldset.lambd, size=len(particles))
 
     pset.execute(vertical_randomexponential, runtime=np.timedelta64(1, "s"), dt=np.timedelta64(1, "s"))
 
@@ -130,8 +130,8 @@ def test_randomvonmises(mu, kappa):
         fieldset=fieldset, pclass=AngleParticle, lon=np.zeros(npart), lat=np.zeros(npart), depth=np.zeros(npart)
     )
 
-    def vonmises(particle, fieldset, time):  # pragma: no cover
-        particle.angle = np.array([random.vonmisesvariate(fieldset.mu, fieldset.kappa) for _ in range(len(particle))])
+    def vonmises(particles, fieldset):  # pragma: no cover
+        particles.angle = np.array([random.vonmisesvariate(fieldset.mu, fieldset.kappa) for _ in range(len(particles))])
 
     pset.execute(vonmises, runtime=np.timedelta64(1, "s"), dt=np.timedelta64(1, "s"))
 

--- a/tests/v4/test_kernel.py
+++ b/tests/v4/test_kernel.py
@@ -26,8 +26,8 @@ def fieldset() -> FieldSet:
 def test_unknown_var_in_kernel(fieldset):
     pset = ParticleSet(fieldset, lon=[0.5], lat=[0.5])
 
-    def ErrorKernel(particle, fieldset, time):  # pragma: no cover
-        particle.unknown_varname += 0.2
+    def ErrorKernel(particles, fieldset):  # pragma: no cover
+        particles.unknown_varname += 0.2
 
     with pytest.raises(KeyError, match="'unknown_varname'"):
         pset.execute(ErrorKernel, runtime=np.timedelta64(2, "s"))

--- a/tests/v4/test_particlefile.py
+++ b/tests/v4/test_particlefile.py
@@ -118,8 +118,8 @@ def test_pfile_array_remove_all_particles(fieldset, chunks_obs, tmp_zarrfile):
 
 @pytest.mark.skip(reason="TODO v4: stuck in infinite loop")
 def test_variable_write_double(fieldset, tmp_zarrfile):
-    def Update_lon(particle, fieldset, time):  # pragma: no cover
-        particle.dlon += 0.1
+    def Update_lon(particles, fieldset):  # pragma: no cover
+        particles.dlon += 0.1
 
     particle = get_default_particle(np.float64)
     pset = ParticleSet(fieldset, pclass=particle, lon=[0], lat=[0])
@@ -198,12 +198,12 @@ def test_pset_repeated_release_delayed_adding_deleting(fieldset, tmp_zarrfile, d
     )
     pfile = ParticleFile(tmp_zarrfile, outputdt=abs(dt), chunks=(1, 1))
 
-    def IncrLon(particle, fieldset, time):  # pragma: no cover
-        particle.sample_var += 1.0
-        particle.state = np.where(
-            particle.sample_var > fieldset.maxvar,
+    def IncrLon(particles, fieldset):  # pragma: no cover
+        particles.sample_var += 1.0
+        particles.state = np.where(
+            particles.sample_var > fieldset.maxvar,
             StatusCode.Delete,
-            particle.state,
+            particles.state,
         )
 
     for _ in range(npart):
@@ -224,9 +224,9 @@ def test_pset_repeated_release_delayed_adding_deleting(fieldset, tmp_zarrfile, d
 
 @pytest.mark.xfail(reason="need to fix backwards in time")
 def test_write_timebackward(fieldset, tmp_zarrfile):
-    def Update_lon(particle, fieldset, time):  # pragma: no cover
-        dt = particle.dt / np.timedelta64(1, "s")
-        particle.dlon -= 0.1 * dt
+    def Update_lon(particles, fieldset):  # pragma: no cover
+        dt = particles.dt / np.timedelta64(1, "s")
+        particles.dlon -= 0.1 * dt
 
     pset = ParticleSet(
         fieldset,
@@ -259,19 +259,19 @@ def test_write_xiyi(fieldset, tmp_zarrfile):
         ]
     )
 
-    def Get_XiYi(particle, fieldset, time):  # pragma: no cover
+    def Get_XiYi(particles, fieldset):  # pragma: no cover
         """Kernel to sample the grid indices of the particle.
         Note that this sampling should be done _before_ the advection kernel
         and that the first outputted value is zero.
         Be careful when using multiple grids, as the index may be different for the grids.
         """
-        particle.pxi0 = fieldset.U.unravel_index(particle.ei)[2]
-        particle.pxi1 = fieldset.P.unravel_index(particle.ei)[2]
-        particle.pyi = fieldset.U.unravel_index(particle.ei)[1]
+        particles.pxi0 = fieldset.U.unravel_index(particles.ei)[2]
+        particles.pxi1 = fieldset.P.unravel_index(particles.ei)[2]
+        particles.pyi = fieldset.U.unravel_index(particles.ei)[1]
 
-    def SampleP(particle, fieldset, time):  # pragma: no cover
-        if time > 5 * 3600:
-            _ = fieldset.P[particle]  # To trigger sampling of the P field
+    def SampleP(particles, fieldset):  # pragma: no cover
+        if np.any(particles.time > 5 * 3600):
+            _ = fieldset.P[particles]  # To trigger sampling of the P field
 
     pset = ParticleSet(fieldset, pclass=XiYiParticle, lon=[0, 0.2], lat=[0.2, 1])
     pfile = ParticleFile(tmp_zarrfile, outputdt=dt)
@@ -302,8 +302,8 @@ def test_reset_dt(fieldset, tmp_zarrfile):
     # Assert that p.dt gets reset when a write_time is not a multiple of dt
     # for p.dt=0.02 to reach outputdt=0.05 and endtime=0.1, the steps should be [0.2, 0.2, 0.1, 0.2, 0.2, 0.1], resulting in 6 kernel executions
 
-    def Update_lon(particle, fieldset, time):  # pragma: no cover
-        particle.dlon += 0.1
+    def Update_lon(particles, fieldset):  # pragma: no cover
+        particles.dlon += 0.1
 
     particle = get_default_particle(np.float64)
     pset = ParticleSet(fieldset, pclass=particle, lon=[0], lat=[0])
@@ -319,8 +319,8 @@ def test_reset_dt(fieldset, tmp_zarrfile):
 def test_correct_misaligned_outputdt_dt(fieldset, tmp_zarrfile):
     """Testing that outputdt does not need to be a multiple of dt."""
 
-    def Update_lon(particle, fieldset, time):  # pragma: no cover
-        particle.dlon += particle.dt / np.timedelta64(1, "s")
+    def Update_lon(particles, fieldset):  # pragma: no cover
+        particles.dlon += particles.dt / np.timedelta64(1, "s")
 
     particle = get_default_particle(np.float64)
     pset = ParticleSet(fieldset, pclass=particle, lon=[0], lat=[0])
@@ -470,8 +470,8 @@ def test_pfile_set_towrite_False(fieldset, tmp_zarrfile):
     pset.set_variable_write_status("lat", False)
     pfile = pset.ParticleFile(tmp_zarrfile, outputdt=1)
 
-    def Update_lon(particle, fieldset, time):  # pragma: no cover
-        particle.dlon += 0.1
+    def Update_lon(particles, fieldset):  # pragma: no cover
+        particles.dlon += 0.1
 
     pset.execute(Update_lon, runtime=10, output_file=pfile)
 

--- a/tests/v4/test_particleset.py
+++ b/tests/v4/test_particleset.py
@@ -119,8 +119,8 @@ def test_pset_starttime_not_multiple_dt(fieldset):
     datetimes = [fieldset.time_interval.left + np.timedelta64(t, "s") for t in times]
     pset = ParticleSet(fieldset, lon=[0] * len(times), lat=[0] * len(times), pclass=Particle, time=datetimes)
 
-    def Addlon(particle, fieldset, time):  # pragma: no cover
-        particle.dlon += particle.dt / np.timedelta64(1, "s")
+    def Addlon(particles, fieldset):  # pragma: no cover
+        particles.dlon += particles.dt / np.timedelta64(1, "s")
 
     pset.execute(Addlon, dt=np.timedelta64(2, "s"), runtime=np.timedelta64(8, "s"), verbose_progress=False)
     assert np.allclose([p.lon_nextloop for p in pset], [8 - t for t in times])


### PR DESCRIPTION
This PR updates the function signatures of Kernels from `(particle, fieldset, time)` to `(particles, fieldset)`, as part of the vectorisation work in v4

It also moves the `_assert_same_function_signature()` function to the `tool` directory (not sure if the `_helpers.py` file is the best place), so it can be used for testing signatures of Interpolation and Kernel functions

<!-- Feel free to remove list items that are not relevant for your changes. -->

- [x] Chose the correct base branch (`main` for v3 changes, `v4-dev` for v4 changes)
- [x] Fixes #2147
- [x] Added tests
- [x] Added documentation
