### PR TITLE
Internal renaming of `particle` to `particles`

### DIFF
--- a/parcels/basegrid.py
+++ b/parcels/basegrid.py
@@ -54,9 +54,9 @@ class BaseGrid(ABC):
             - Unstructured grid: {"Z": (zi, zeta), "FACE": (fi, bcoords)}
 
             Where:
-            - index (int): The cell position of a particle along the given axis
+            - index (int): The cell position of the particles along the given axis
             - barycentric_coordinates (float or np.ndarray): The coordinates defining
-              a particle's position within the grid cell. For structured grids, this
+              the particles positions within the grid cell. For structured grids, this
               is a single coordinate per axis; for unstructured grids, this can be
               an array of coordinates for the face polygon.
 

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -24,12 +24,12 @@ __all__ = ["ParticleSet"]
 
 
 class ParticleSet:
-    """Class for storing particle and executing kernel over them.
+    """Class for storing particles and executing kernel over them.
 
     Please note that this currently only supports fixed size particle sets, meaning that the particle set only
     holds the particles defined on construction. Individual particles can neither be added nor deleted individually,
-    and individual particles can only be deleted as a set procedurally (i.e. by 'particle.delete()'-call during
-    kernel execution).
+    and individual particles can only be deleted as a set procedurally (i.e. by changing their state to 'StatusCode.Delete'
+    during kernel execution).
 
     Parameters
     ----------

--- a/parcels/tools/statuscodes.py
+++ b/parcels/tools/statuscodes.py
@@ -110,10 +110,10 @@ def _raise_time_extrapolation_error(time: float, field=None):
 
 
 class KernelError(RuntimeError):
-    """General particle kernel error with optional custom message."""
+    """General particles kernel error with optional custom message."""
 
-    def __init__(self, particle, fieldset=None, msg=None):
-        message = f"{particle.state}\nParticle {particle}\nTime: {particle.time}\ntimestep dt: {particle.dt}\n"
+    def __init__(self, particles, fieldset=None, msg=None):
+        message = f"{particles.state}\nParticle {particles}\nTime: {particles.time}\ntimestep dt: {particles.dt}\n"
         if msg:
             message += msg
         super().__init__(message)

--- a/parcels/xgrid.py
+++ b/parcels/xgrid.py
@@ -508,7 +508,7 @@ def _search_1d_array(
     x: float,
 ) -> tuple[int, int]:
     """
-    Searches for the particle location in a 1D array and returns barycentric coordinate along dimension.
+    Searches for particle locations in a 1D array and returns barycentric coordinate along dimension.
 
     Assumptions:
     - array is strictly monotonically increasing.


### PR DESCRIPTION
This PR does some interbal renaming of `particle` to `particles` (mainly in the field and pasticleset) to stay consistent with the change in Kernel API, where we also changed form `particle` to `particles`