### PR TITLE
Use element indices `particle.ei` in curvilinear search

### DIFF
--- a/parcels/_index_search.py
+++ b/parcels/_index_search.py
@@ -75,20 +75,18 @@ def curvilinear_point_in_cell(grid, y: np.ndarray, x: np.ndarray, yi: np.ndarray
 
 
 def _search_indices_curvilinear_2d(
-    grid: XGrid, y: np.ndarray, x: np.ndarray, yi_guess: np.ndarray | None = None, xi_guess: np.ndarray | None = None
+    grid: XGrid, y: np.ndarray, x: np.ndarray, yi: np.ndarray | None = None, xi: np.ndarray | None = None
 ):
-    yi_guess = np.array(yi_guess)
-    xi_guess = np.array(xi_guess)
-    xi = np.full(len(x), GRID_SEARCH_ERROR, dtype=np.int32)
-    yi = np.full(len(y), GRID_SEARCH_ERROR, dtype=np.int32)
-    if np.any(xi_guess):
+    if np.any(xi):
         # If an initial guess is provided, we first perform a point in cell check for all guessed indices
-        is_in_cell, coords = curvilinear_point_in_cell(grid, y, x, yi_guess, xi_guess)
+        is_in_cell, coords = curvilinear_point_in_cell(grid, y, x, yi, xi)
         y_check = y[is_in_cell == 0]
         x_check = x[is_in_cell == 0]
         zero_indices = np.where(is_in_cell == 0)[0]
     else:
         # Otherwise, we need to check all points
+        yi = np.full(len(y), GRID_SEARCH_ERROR, dtype=np.int32)
+        xi = np.full(len(x), GRID_SEARCH_ERROR, dtype=np.int32)
         y_check = y
         x_check = x
         coords = -1.0 * np.ones((len(y), 2), dtype=np.float32)

--- a/parcels/basegrid.py
+++ b/parcels/basegrid.py
@@ -204,13 +204,13 @@ def _unravel(dims, ei):
     """
     strides = np.cumprod(dims[::-1])[::-1]
 
-    indices = np.empty(len(dims), dtype=int)
+    indices = np.empty((len(dims), len(ei)), dtype=int)
 
     for i in range(len(dims) - 1):
-        indices[i] = ei // strides[i + 1]
+        indices[i, :] = ei // strides[i + 1]
         ei = ei % strides[i + 1]
 
-    indices[-1] = ei
+    indices[-1, :] = ei
     return indices
 
 

--- a/parcels/field.py
+++ b/parcels/field.py
@@ -212,13 +212,14 @@ class Field:
         conversion to the result. Note that we defer to
         scipy.interpolate to perform spatial interpolation.
         """
-        # if particle is None:
-        _ei = None
-        # else:
-        #    _ei = particle.ei[self.igrid]
+        if particle is None:
+            _ei = None
+        else:
+            _ei = particle.ei[:, self.igrid]
 
         tau, ti = _search_time_index(self, time)
         position = self.grid.search(z, y, x, ei=_ei)
+        _update_particles_ei(particle, position, self)
         _update_particle_states_position(particle, position)
 
         value = self._interp_method(self, ti, position, tau, time, z, y, x)
@@ -251,6 +252,7 @@ class VectorField:
         self.V = V
         self.W = W
         self.grid = U.grid
+        self.igrid = U.igrid
 
         if W is None:
             _assert_same_time_interval((U, V))
@@ -294,13 +296,14 @@ class VectorField:
         conversion to the result. Note that we defer to
         scipy.interpolate to perform spatial interpolation.
         """
-        # if particle is None:
-        _ei = None
-        # else:
-        #    _ei = particle.ei[self.igrid]
+        if particle is None:
+            _ei = None
+        else:
+            _ei = particle.ei[:, self.igrid]
 
         tau, ti = _search_time_index(self.U, time)
         position = self.grid.search(z, y, x, ei=_ei)
+        _update_particles_ei(particle, position, self)
         _update_particle_states_position(particle, position)
 
         if self._vector_interp_method is None:
@@ -337,6 +340,18 @@ class VectorField:
                 return self.eval(*key)
         except tuple(AllParcelsErrorCodes.keys()) as error:
             return _deal_with_errors(error, key, vector_type=self.vector_type)
+
+
+def _update_particles_ei(particles, position, field):
+    """Update the element index (ei) of the particles"""
+    if particles is not None:
+        particles.ei[:, field.igrid] = field.grid.ravel_index(
+            {
+                "X": position["X"][0],
+                "Y": position["Y"][0],
+                "Z": position["Z"][0],
+            }
+        )
 
 
 def _update_particle_states_position(particle, position):

--- a/parcels/particleset.py
+++ b/parcels/particleset.py
@@ -6,13 +6,11 @@ from typing import Literal
 
 import numpy as np
 import xarray as xr
-from scipy.spatial import KDTree
 from tqdm import tqdm
 
 from parcels._core.utils.time import TimeInterval, maybe_convert_python_timedelta_to_numpy
 from parcels._reprs import particleset_repr
 from parcels.application_kernels.advection import AdvectionRK4
-from parcels.basegrid import GridType
 from parcels.kernel import Kernel
 from parcels.particle import KernelParticle, Particle, create_particle_data
 from parcels.tools.converters import convert_to_flat_array
@@ -308,28 +306,17 @@ class ParticleSet:
         neighbor_ids = self._data["trajectory"][neighbor_idx]
         return neighbor_ids
 
-    # TODO: This method is only tested in tutorial notebook. Add unit test?
     def populate_indices(self):
-        """Pre-populate guesses of particle ei (element id) indices using a kdtree.
-
-        This is only intended for curvilinear grids, where the initial index search
-        may be quite expensive.
-        """
+        """Pre-populate guesses of particle ei (element id) indices"""
         for i, grid in enumerate(self.fieldset.gridset):
-            if grid._gtype not in [GridType.CurvilinearZGrid, GridType.CurvilinearSGrid]:
-                continue
-
-            tree_data = np.stack((grid.lon.flat, grid.lat.flat), axis=-1)
-            IN = np.all(~np.isnan(tree_data), axis=1)
-            tree = KDTree(tree_data[IN, :])
-            # stack all the particle positions for a single query
-            pts = np.stack((self._data["lon"], self._data["lat"]), axis=-1)
-            # query datatype needs to match tree datatype
-            _, idx_nan = tree.query(pts.astype(tree_data.dtype))
-
-            idx = np.where(IN)[0][idx_nan]
-
-            self._data["ei"][:, i] = idx  # assumes that we are in the surface layer (zi=0)
+            position = grid.search(self.depth, self.lat, self.lon)
+            self._data["ei"][:, i] = grid.ravel_index(
+                {
+                    "X": position["X"][0],
+                    "Y": position["Y"][0],
+                    "Z": position["Z"][0],
+                }
+            )
 
     @classmethod
     def from_particlefile(cls, fieldset, pclass, filename, restart=True, restarttime=None, **kwargs):

--- a/tests/v4/test_particleset.py
+++ b/tests/v4/test_particleset.py
@@ -17,6 +17,7 @@ from parcels import (
 from parcels._datasets.structured.generic import datasets as datasets_structured
 from parcels.xgrid import XGrid
 from tests.common_kernels import DoNothing
+from tests.utils import round_and_hash_float_array
 
 
 @pytest.fixture
@@ -124,6 +125,13 @@ def test_pset_starttime_not_multiple_dt(fieldset):
 
     pset.execute(Addlon, dt=np.timedelta64(2, "s"), runtime=np.timedelta64(8, "s"), verbose_progress=False)
     assert np.allclose([p.lon_nextloop for p in pset], [8 - t for t in times])
+
+
+def test_populate_indices(fieldset):
+    npart = 11
+    pset = ParticleSet(fieldset, lon=np.linspace(0, 1, npart), lat=np.linspace(1, 0, npart))
+    pset.populate_indices()
+    np.testing.assert_equal(round_and_hash_float_array(pset.ei, decimals=0), 935996932384571063274191)
 
 
 def test_pset_add_explicit(fieldset):


### PR DESCRIPTION
While the Morton encoding for the curvilinear search (#2175)  is very fast, it turns out to be even faster to use the element indices (`particle.ei`) in the search.

Using the benchmark script in [OceanParcels/parcels-benchmarks@`9a39630` (#5)](https://github.com/OceanParcels/parcels-benchmarks/pull/5/commits/9a39630a6c03f12f445a842726daec17a85e186c), we get the following speed-up:

```
Running 4_999_696 particles with parcels v4
Execution time 1: 44 seconds
Execution time 2: 1 seconds
```

where execution 1 is with the Morton search (since `particle.ei = None`) and execution 2 is with the code in this PR to use the `particle.ei`. 

Note that this is the most optimal case where particles don't move between searches, but that is actually very often the case because
1. A Kernel loop requires multiple Field interpolations at the same location
2. Most particles move less than one grid cell between Kernel loops
