### PR TITLE
Update Rattler Build recipe

### DIFF
--- a/.github/ci/recipe.yaml
+++ b/.github/ci/recipe.yaml
@@ -4,7 +4,7 @@
 # Adapted from the conda forge recipe
 context:
   name: parcels
-  version: 4.0.0alpha0 # The last number here needs to be bumped for each new alpha release
+  version: 4.0.0alpha1 # The last number here needs to be bumped for each new alpha release
 
 package:
   name: ${{ name|lower }}
@@ -40,6 +40,8 @@ requirements:
     - trajan
     - tqdm
     - xarray >=0.10.8
+    - cf_xarray
+    - xgcm
     - zarr >=2.11.0,!=2.18.0,<3
     - uxarray>=2025.3.0
     - pyogrio # needed for geopandas (uxarray -> geoviews -> geopandas -> pyogrio, but for some reason conda doesn't pick it up automatically)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,3 +1,5 @@
+name: Publish alpha version of Parcels
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
The Rattler build recipe didn't reflect the dependency changes that we made since the previous alpha release. Updated the recipe here and will then do a new alpha release.