### PR TITLE
Link github signup

### DIFF
--- a/docs/community/contributing.rst
+++ b/docs/community/contributing.rst
@@ -45,7 +45,7 @@ There are many ways that you can contribute to Parcels. You can:
 - Suggest improvements to `documentation <../index.rst>`_
 - Write code (fix bugs, implement features, codebase improvements, etc)
 
-All of these require you to make an account on GitHub, so that should be your first step.
+All of these require you to [make an account on GitHub](https://github.com/signup), so that should be your first step.
 
 If you want to suggest quick edits to the documentation, it's as easy as going to the page and clicking "Edit on GitHub" in the righthand panel. For other changes, it's a matter of looking through the `issue tracker <https://github.com/OceanParcels/parcels/issues>`_ which documents tasks that are being considered. Pay particular attention to `issues tagged with "good first issue" <https://github.com/OceanParcels/parcels/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22>`_, as these are tasks that don't require deep familiarity with the codebase. Once you've chosen an issue you would like to contribute towards, comment on it to flag your interest in working on it. This allows the community to know who's interested, and provide any guidance in its implementation (maybe the scope has changed since the issue was last updated).
 


### PR DESCRIPTION
Makes sure account generation link is provided.

Supercedes #2265 