### PR TITLE
Fixing the error message for `update_dt_dtype`

### DIFF
--- a/parcels/_core/particleset.py
+++ b/parcels/_core/particleset.py
@@ -521,7 +521,7 @@ class ParticleSet:
             self._data["dt"][:] = dt
         else:
             raise ValueError(
-                f"The dtype of dt ({dt.dtype}) is coarser than the dtype of the particle dt ({self._data['dt'].dtype}). Please use ParticleSet.set_dt_dtype() to provide a dt with at least the same precision as the particle dt."
+                f"The dtype of dt ({dt.dtype}) is coarser than the dtype of the particle dt ({self._data['dt'].dtype}). Please use ParticleSet.update_dt_dtype() to provide a dt with at least the same precision as the particle dt."
             )
 
         if runtime is not None:


### PR DESCRIPTION
The error message in #2242 referred to `set_dt_dtype()`, while the method has been renamed to `update_dt_dtype`. This PR fixed the error message