### PR TITLE
Fix typo in documentation_MPI.ipynb

### DIFF
--- a/docs/examples/documentation_MPI.ipynb
+++ b/docs/examples/documentation_MPI.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Parcels can be run in Parallel with MPI. To do this, you will need to also install the `mpich` and `mpi4py` packages (i.e., `conda install -c conda forge mpich mpi4py`).\n",
+    "Parcels can be run in Parallel with MPI. To do this, you will need to also install the `mpich` and `mpi4py` packages (i.e., `conda install -c conda-forge mpich mpi4py`).\n",
     "\n",
     "Note that MPI support is only for Linux and macOS. There is no Windows support.\n"
    ]


### PR DESCRIPTION
Missing hyphen in `conda install -c conda-forge ...` command for  `mipch` and `mpi4py`.