### PR TITLE
Remove outdated notebooks/scripts from the documentation page

### DIFF
--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -2,59 +2,64 @@
 
 Shown below are several documentation and tutorial Jupyter notebooks and scripts which go through various aspects of Parcels.
 
+```{note}
+The tutorials written for Parcels v3 are currently being updated for Parcels v4. Shown below are only the notebooks which have been updated.
+[Feel free to post a Discussion on GitHub](https://github.com/OceanParcels/Parcels/discussions/categories/ideas) if you feel like v4 needs a specific tutorial that wasn't in v3, or [post an issue](https://github.com/OceanParcels/Parcels/issues/new?template=01_feature.md) if you feel that the notebooks below can be improved!
+```
+
 ```{nbgallery}
 :caption: Overview
 :name: tutorial-overview
 
-../examples/tutorial_parcels_structure.ipynb
-../examples/parcels_tutorial.ipynb
-../examples/tutorial_output.ipynb
+<!-- ../examples/tutorial_parcels_structure.ipynb -->
+<!-- ../examples/parcels_tutorial.ipynb -->
+<!-- ../examples/tutorial_output.ipynb -->
 ```
 
 ```{nbgallery}
 :caption: Setting up FieldSets
 :name: tutorial-fieldsets
 
-../examples/documentation_indexing.ipynb
-../examples/tutorial_nemo_curvilinear.ipynb
-../examples/tutorial_nemo_3D.ipynb
-../examples/tutorial_croco_3D.ipynb
-../examples/tutorial_timevaryingdepthdimensions.ipynb
-../examples/tutorial_periodic_boundaries.ipynb
-../examples/tutorial_interpolation.ipynb
-../examples/tutorial_unitconverters.ipynb
+<!-- ../examples/documentation_indexing.ipynb -->
+<!-- ../examples/tutorial_nemo_curvilinear.ipynb -->
+<!-- ../examples/tutorial_nemo_3D.ipynb -->
+<!-- ../examples/tutorial_croco_3D.ipynb -->
+<!-- ../examples/tutorial_timevaryingdepthdimensions.ipynb -->
+<!-- ../examples/tutorial_periodic_boundaries.ipynb -->
+<!-- ../examples/tutorial_interpolation.ipynb -->
+<!-- ../examples/tutorial_unitconverters.ipynb -->
 ```
 
 ```{nbgallery}
 :caption: Creating ParticleSets
 :name: tutorial-particlesets
 
-../examples/tutorial_delaystart.ipynb
+<!-- ../examples/tutorial_delaystart.ipynb -->
 ```
 
 ```{nbgallery}
 :caption: Writing kernels to be executed on each particle
 :name: tutorial-kernels
 
-../examples/tutorial_diffusion.ipynb
-../examples/tutorial_sampling.ipynb
-../examples/tutorial_particle_field_interaction.ipynb
-../examples/tutorial_interaction.ipynb
-../examples/tutorial_analyticaladvection.ipynb
-../examples/tutorial_kernelloop.ipynb
+<!-- ../examples/tutorial_diffusion.ipynb -->
+<!-- ../examples/tutorial_sampling.ipynb -->
+<!-- ../examples/tutorial_particle_field_interaction.ipynb -->
+<!-- ../examples/tutorial_interaction.ipynb -->
+<!-- ../examples/tutorial_analyticaladvection.ipynb -->
+<!-- ../examples/tutorial_kernelloop.ipynb -->
 ```
 
 ```{nbgallery}
 :caption: Other tutorials
 :name: tutorial-other
 
-../examples/tutorial_peninsula_AvsCgrid.ipynb
-../examples/documentation_MPI.ipynb
-../examples/documentation_stuck_particles.ipynb
-../examples/documentation_unstuck_Agrid.ipynb
-../examples/documentation_LargeRunsOutput.ipynb
-../examples/documentation_geospatial.ipynb
-../examples/documentation_advanced_zarr.ipynb
+<!-- ../examples/tutorial_peninsula_AvsCgrid.ipynb -->
+<!-- ../examples/documentation_MPI.ipynb -->
+<!-- ../examples/documentation_stuck_particles.ipynb -->
+<!-- ../examples/documentation_unstuck_Agrid.ipynb -->
+<!-- ../examples/documentation_LargeRunsOutput.ipynb -->
+<!-- ../examples/documentation_geospatial.ipynb -->
+<!-- ../examples/documentation_advanced_zarr.ipynb -->
 ```
 
 ```{nbgallery}
@@ -62,11 +67,11 @@ Shown below are several documentation and tutorial Jupyter notebooks and scripts
 :name: tutorial-examples
 
 ../examples/tutorial_Argofloats.ipynb
-../examples/documentation_homepage_animation.ipynb
+<!-- ../examples/documentation_homepage_animation.ipynb -->
 ```
 
 ## Python Example Scripts
 
-```{toctree}
+<!-- ```{toctree}
 additional_examples
-```
+``` -->


### PR DESCRIPTION
Since there are people from the anniversary event interested in test driving version 4 of Parcels, I thought it would be good to avoid confusion and remove the notebooks that aren't yet converted from the gallery (people interested in v3 versions can always look at the v3 docs).

Updated page:

<img width="677" height="785" alt="image" src="https://github.com/user-attachments/assets/135e77f8-3ff1-44fe-913e-ae2154232da3" />



Once the notebooks are migrated (e.g., `parcels_tutorial.ipynb`), you can do:

````diff
```{nbgallery}
:caption: Overview
:name: tutorial-overview

<!-- ../examples/tutorial_parcels_structure.ipynb -->
-<!-- ../examples/parcels_tutorial.ipynb -->
+../examples/parcels_tutorial.ipynb
<!-- ../examples/tutorial_output.ipynb -->
```
````

which will display the notebook in the website, and

```diff
# in pixi.toml
[feature.test.tasks]
tests = "pytest"
-tests-notebooks = "pytest --nbval-lax -k 'argo' docs/examples"
+tests-notebooks = "pytest --nbval-lax -k 'argo or tutorial_output' docs/examples"
```
which will run the notebook during testing.

---
I think this is a nice workflow - @reint-fischer let me know what you think :)