### PR TITLE
Update pixi.toml to install Parcels from source

### DIFF
--- a/.github/workflows/cache-pixi-lock.yml
+++ b/.github/workflows/cache-pixi-lock.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.0
         if: ${{ !steps.restore.outputs.cache-hit }}
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.56.0
           run-install: false
       - name: Run pixi lock
         if: ${{ !steps.restore.outputs.cache-hit }}

--- a/.github/workflows/cache-pixi-lock.yml
+++ b/.github/workflows/cache-pixi-lock.yml
@@ -33,7 +33,7 @@ jobs:
           run-install: false
       - name: Run pixi lock
         if: ${{ !steps.restore.outputs.cache-hit }}
-        run: pixi lock -vv
+        run: pixi lock
       - uses: actions/cache/save@v4
         if: ${{ !steps.restore.outputs.cache-hit }}
         id: cache

--- a/.github/workflows/cache-pixi-lock.yml
+++ b/.github/workflows/cache-pixi-lock.yml
@@ -33,7 +33,7 @@ jobs:
           run-install: false
       - name: Run pixi lock
         if: ${{ !steps.restore.outputs.cache-hit }}
-        run: pixi lock
+        run: pixi lock -vv
       - uses: actions/cache/save@v4
         if: ${{ !steps.restore.outputs.cache-hit }}
         id: cache

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@ platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 [package]
 name = "parcels"
 version = "dynamic" # dynamic versioning needs better support in pixi https://github.com/prefix-dev/pixi/issues/2923#issuecomment-2598460666 . Putting `version = "dynamic"` here for now until pixi recommends something else.
-license = "MIT"
+license = "MIT" # can remove this once https://github.com/prefix-dev/pixi-build-backends/issues/397 is resolved
 
 [package.build]
 backend = { name = "pixi-build-python", version = "==0.4.0" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,9 +7,10 @@ platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 [package]
 name = "parcels"
 version = "dynamic" # dynamic versioning needs better support in pixi https://github.com/prefix-dev/pixi/issues/2923#issuecomment-2598460666 . Putting `version = "dynamic"` here for now until pixi recommends something else.
+license = "MIT"
 
 [package.build]
-backend = { name = "pixi-build-python", version = "==0.3.2" }
+backend = { name = "pixi-build-python", version = "==0.4.0" }
 
 [package.host-dependencies]
 setuptools = "*"
@@ -26,6 +27,7 @@ pre-commit = { features = ["pre-commit"], no-default-feature = true }
 
 [dependencies] # keep section in sync with pyproject.toml dependencies
 python = ">=3.11,<3.13"
+parcels = { path = "." }
 netcdf4 = ">=1.1.9"
 numpy = ">=1.9.1"
 tqdm = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -42,9 +42,6 @@ cftime = ">=1.3.1"
 scipy = ">=0.16.0" #? Not sure if we rely on scipy internally anymore...
 pooch = "*"
 
-[pypi-dependencies]
-parcels = { path = ".", editable = true }
-
 [feature.py311.dependencies]
 python = "3.11.*"
 


### PR DESCRIPTION
Fixes #2272

Before:
```sh
pixi run -e test-latest 'cd tests && python -c "import parcels"'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'parcels'
```

After:
```
pixi run -e test-latest 'cd tests && python -c "import parcels"'

```

This enables #2216 - how should we time that @erikvansebille to reduce disruption? After #2303 is merged?