### PR TITLE
DOC: Remove 10 year event announcement banner

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,7 +207,6 @@ html_theme_options = {
             "type": "fontawesome",
         }
     ],
-    "announcement": "Join the Parcels 10 year anniversary event 🎉 on 1-3 Oct 2025! See <a href='https://oceanparcels.org/10year-event'>our website</a> for details.",
 }
 
 html_context = {


### PR DESCRIPTION
This was on the latest documentation (i.e., `main`)