### PR TITLE
Removing numpy import from Setcoords kernel

### DIFF
--- a/src/parcels/_core/kernel.py
+++ b/src/parcels/_core/kernel.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import math  # noqa: F401
-import random  # noqa: F401
 import types
 import warnings
 from typing import TYPE_CHECKING


### PR DESCRIPTION
Following on from https://github.com/Parcels-code/Parcels/pull/2248#discussion_r2417016084, this PR also removes the import statement from the `Setcoords` Kernel that gets prepended to all user kernels.