### PR TITLE
Update Pixi parcels installation method back to pypi

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -43,7 +43,7 @@ cftime = ">=1.6.3"
 pooch = ">=1.8.0"
 
 [pypi-dependencies]
-parcels = {path = ".", editable = true}
+parcels = { path = ".", editable = true }
 
 [feature.minimum.dependencies]
 python = "==3.11"


### PR DESCRIPTION
Revert from pixi-build-python to pip editable install due to failed builds on HPC https://github.com/prefix-dev/pixi-build-backends/issues/411

Mostly reverts #2305 for the timebeing
