### PR TITLE
Remove Python upper pin and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           - os: ubuntu
             pixi-environment: "test-py311"
           - os: ubuntu
+            pixi-environment: "test-py313"
+          - os: ubuntu
             pixi-environment: "test-minimum"
     steps:
       - uses: actions/checkout@v4

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,14 +21,14 @@ platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 test-latest = { features = ["test"], solve-group = "test" }
 test-minimum = { features = ["test", "minimum"], solve-group = "test" }
 test-py311 = { features = ["test", "py311"] }
-test-py312 = { features = ["test", "py312"] }
+test-py313 = { features = ["test", "py313"] }
 test-notebooks = { features = ["test", "notebooks"], solve-group = "test" }
 docs = { features = ["docs"], solve-group = "docs" }
 typing = { features = ["typing"], solve-group = "typing" }
 pre-commit = { features = ["pre-commit"], no-default-feature = true }
 
 [dependencies] # keep section in sync with pyproject.toml dependencies
-python = ">=3.11,<3.13"
+python = ">=3.11"
 # parcels = { path = "." }
 netcdf4 = ">=1.7.2"
 numpy = ">=2.1.0"
@@ -62,8 +62,8 @@ pooch = "==1.8.0"
 [feature.py311.dependencies]
 python = "3.11.*"
 
-[feature.py312.dependencies]
-python = "3.12.*"
+[feature.py313.dependencies]
+python = "3.13.*"
 
 [feature.test.dependencies]
 nbval = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Framework for Lagrangian tracking of virtual ocean particles in t
 readme = "README.md"
 dynamic = ["version"]
 authors = [{ name = "Parcels team" }]
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.11"
 license = { file = "LICENSE.md" }
 classifiers = [
   "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
(in v4-dev) For #1977 we had Python pinned to `<3.13` - but I don't think that is necessary anymore from my understanding.

This PR removes this upper pin and expands the test matrix so that we are now testing against Python 3.11, 3.13, and (newly released) 3.14 . 

Fixes #2321 