### PR TITLE
[v3] Update CI for Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos, ubuntu, windows]
-        python-version: ["3.13"]
+        python-version: ["3.14"]
         include:
           - os: ubuntu
             python-version: "3.10"
           - os: ubuntu
             python-version: "3.11"
           - os: ubuntu
-            python-version: "3.12"
+            python-version: "3.13"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Expands CI for Python version 3 to include Python 3.14.

xref #2321 