### PR TITLE
Pixi: move deps to run-dependencies section

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -26,9 +26,8 @@ docs = { features = ["docs"], solve-group = "docs" }
 typing = { features = ["typing"], solve-group = "typing" }
 pre-commit = { features = ["pre-commit"], no-default-feature = true }
 
-[dependencies] # keep section in sync with pyproject.toml dependencies
+[package.run-dependencies] # keep section in sync with pyproject.toml dependencies
 python = ">=3.11"
-parcels = { path = "." }
 netcdf4 = ">=1.7.2"
 numpy = ">=2.1.0"
 tqdm = ">=4.50.0"
@@ -40,6 +39,9 @@ xgcm = ">=0.9.0"
 cf_xarray = ">=0.8.6"
 cftime = ">=1.6.3"
 pooch = ">=1.8.0"
+
+[dependencies]
+parcels = { path = "." }
 
 [feature.minimum.dependencies]
 python = "==3.11"


### PR DESCRIPTION
When defining Parcels as a source dependency, e.g.,

```toml
[dependencies]
virtualship = { path = "." }
parcels = {path="./Parcels"}
# ...
```
you need to define the run dependencies in `package.run-dependencies` not in `[dependencies]`  (which is workspace dependencies). Otherwise the dependencies aren't properly installed.

This makes it much clearer how installing Parcels as a development dependency works (allowing benchmarking, and people define manifests in their scientific project that use an unreleased version of Parcels).

xref: [discord](https://discord.com/channels/1082332781146800168/1082338253925003385/1430913526196736092)