### PR TITLE
Fix pixi version within Pixi cache workflow

### DIFF
--- a/.github/workflows/cache-pixi-lock.yml
+++ b/.github/workflows/cache-pixi-lock.yml
@@ -2,6 +2,9 @@ name: Generate and cache Pixi lockfile
 
 on:
   workflow_call:
+    inputs:
+      pixi-version:
+        type: string
     outputs:
       cache-id:
         description: "The lock file contents"
@@ -30,7 +33,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.0
         if: ${{ !steps.restore.outputs.cache-hit }}
         with:
-          pixi-version: v0.56.0
+          pixi-version: ${{ inputs.pixi-version }}
           run-install: false
       - name: Run pixi lock
         if: ${{ !steps.restore.outputs.cache-hit }}


### PR DESCRIPTION
Was experiencing some workflow failures in #2349 https://github.com/Parcels-code/Parcels/actions/runs/18939417196 with the following error
```
pixi install --locked -vv
DEBUG pixi_config: Loading config from /etc/pixi/config.toml
DEBUG pixi_config: Loading config from /Users/Hodgs004/Library/Application Support/pixi/config.toml
DEBUG pixi_config: Loading config from /Users/Hodgs004/.pixi/config.toml
DEBUG pixi_config: Loading config from /Users/Hodgs004/coding/repos/parcels/.pixi/config.toml
DEBUG pixi_config: Failed to load local config: /Users/Hodgs004/coding/repos/parcels/.pixi/config.toml (error: no file was found at /Users/Hodgs004/coding/repos/parcels/.pixi/config.toml)
DEBUG pixi_core::environment: verifying prefix location is unchanged, with prefix file: /Users/Hodgs004/coding/repos/parcels/.pixi/envs/conda-meta/pixi_env_prefix
 INFO pixi_core::lock_file::outdated: the dependencies of environment 'default' for platform osx-64 are out of date because the input hash for '.' (0b650f0ee24ff13cf341174e601a1ec2f34ae3a1d0fdb019aa04a751d77a45bc) does not match the hash in the lock-file (daaab279ba6596bc88d946c78c7771fde36864a6ac3bfeead722d4e41c3d1024)
...
Error:   × lock-file not up-to-date with the workspace
```

Due to a version desync between the lock file caching and the pixi version used in other workflows