### PR TITLE
Disable CI on mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, mac, windows]
+        os: [ubuntu, windows]
         pixi-environment: [test-latest]
         include:
           - os: ubuntu


### PR DESCRIPTION
Often got long hang times of
```
Requested labels: mac-latest
Job defined at: Parcels-code/Parcels/.github/workflows/ci.yml@refs/pull/2362/merge
Waiting for a runner to pick up this job...
```