### PR TITLE
Add AI development policy

### DIFF
--- a/docs/development/policies.md
+++ b/docs/development/policies.md
@@ -10,7 +10,7 @@ We accept that Parcels developers have their own motivation for using (or not us
 
 Remember that reviews are done by human maintainers - asking us to review code that an AI wrote but you don't understand isn't kind to these maintainers.
 
-Furthermore, we also have an [AI agents policy](/CLAUDE.md) that states how we expect AI agents to engage with Parcels on GitHub.
+The [CLAUDE.md](/CLAUDE.md) file in the repository has additional instructions for AI agents to follow when contributing to Parcels.
 
 ## Versioning
 


### PR DESCRIPTION
This PR adds an AI policy for developers, to ward off contributions like https://github.com/CLAM-community/CLAM-community.github.io/pull/8 for Parcels.