### PR TITLE
fix and standardize animation output in docs

### DIFF
--- a/docs/getting_started/tutorial_output.ipynb
+++ b/docs/getting_started/tutorial_output.ipynb
@@ -540,15 +540,9 @@
     "\n",
     "# Create animation\n",
     "anim = FuncAnimation(fig, animate, frames=nframes, interval=100)\n",
+    "plt.close(fig)\n",
     "anim"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/user_guide/examples/tutorial_delaystart.ipynb
+++ b/docs/user_guide/examples/tutorial_delaystart.ipynb
@@ -24,15 +24,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from datetime import timedelta\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import xarray as xr\n",
-    "from IPython.display import HTML\n",
     "from matplotlib.animation import FuncAnimation\n",
     "\n",
-    "import parcels"
+    "import parcels\n",
+    "\n",
+    "# for interactive display of animations\n",
+    "plt.rcParams[\"animation.html\"] = \"jshtml\""
    ]
   },
   {
@@ -138,8 +138,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "\n",
     "ds_particles = xr.open_zarr(\"delayparticle_time.zarr\")\n",
     "\n",
     "fig = plt.figure(figsize=(7, 5), constrained_layout=True)\n",
@@ -173,16 +171,9 @@
     "    )\n",
     "\n",
     "\n",
-    "anim = FuncAnimation(fig, animate, frames=len(timerange), interval=100)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "HTML(anim.to_jshtml())"
+    "anim = FuncAnimation(fig, animate, frames=len(timerange), interval=100)\n",
+    "plt.close()\n",
+    "anim"
    ]
   },
   {
@@ -261,13 +252,13 @@
    "outputs": [],
    "source": [
     "output_file = parcels.ParticleFile(\n",
-    "    \"delayparticle_releasedt.zarr\", outputdt=timedelta(hours=1)\n",
+    "    \"delayparticle_releasedt.zarr\", outputdt=np.timedelta64(1, \"h\")\n",
     ")\n",
     "\n",
     "pset.execute(\n",
     "    parcels.kernels.AdvectionRK4,\n",
-    "    runtime=timedelta(hours=24),\n",
-    "    dt=timedelta(minutes=5),\n",
+    "    runtime=np.timedelta64(24, \"h\"),\n",
+    "    dt=np.timedelta64(5, \"h\"),\n",
     "    output_file=output_file,\n",
     ")"
    ]
@@ -286,8 +277,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "\n",
     "ds_particles = xr.open_zarr(\"delayparticle_releasedt.zarr\")\n",
     "\n",
     "fig = plt.figure(figsize=(7, 5), constrained_layout=True)\n",
@@ -321,16 +310,9 @@
     "    )\n",
     "\n",
     "\n",
-    "anim = FuncAnimation(fig, animate, frames=len(timerange), interval=100)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "HTML(anim.to_jshtml())"
+    "anim = FuncAnimation(fig, animate, frames=len(timerange), interval=100)\n",
+    "plt.close(fig)\n",
+    "anim"
    ]
   },
   {


### PR DESCRIPTION
As pointed out by @erikvansebille, some animations in the docs printed an extra figure. This is fixed by adding `plt.close(fig)`. Also, all animations are now displayed interactively with `plt.rcParams["animation.html"] = “jshtml”`.