### PR TITLE
Misc CI improvements and refactors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Decide if we skip CI
         if: steps.check-skip.outputs.trigger-found == 'true' || contains(github.event.pull_request.labels.*.name, 'skip-ci')
         run: |
-          echo "Skipping CI due to [skip-ci] keyword or skip-ci label"
+          echo "Skipping CI."
           exit 1
 
   cache-pixi-lock:


### PR DESCRIPTION
I was chatting with Justus yesterday, and he mentioned improvements we can make to our CI setup. I've also wrapped a couple of my own in.

Changes
- Update `should-skip-ci` to `should-run-ci` , failing if we shouldn't (which implicitly skips the rest of the workflows)
- Update workflow graph to a chain (rather than directly depending on `should-skip-ci` and `cache-pixi-lock`)
- Update the `should-run-ci` and `cache-pixi-lock` to be run using slim instances (faster startup and lower resources)

