### PR TITLE
Update minimum-dependency policy

### DIFF
--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.26"
       - run: |
           uvx --from xarray-minimum-dependency-policy==2.0.0 \
           minimum-versions validate \


### PR DESCRIPTION
After doing some testing - workflow wasn't working properly anymore (likely due to a change in behaviour with the --from syntax as opposed to `uvx`)

uvx is more appropriate in this situation (i.e., this is a standalone tool we're running).

I also pinned the version of uv so we don't encounter this drift again.

This works locally, and I'm sure it will work in CI when the cron triggers it.