### PR TITLE
MAINT: Update version of pixi-lock action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       pixi-version: ${{ steps.pixi-lock.outputs.pixi-version }}
     steps:
       - uses: actions/checkout@v4
-      - uses: Parcels-code/pixi-lock/create-and-cache@2b823a4a804631370fbde7e6088ee5db71a26c60 # TODO: Update to action in prefix-dev once available
+      - uses: Parcels-code/pixi-lock/create-and-cache@9a2866f8258b87a3c616d5ad7d51c6cd853df78b # TODO: Update to action in prefix-dev once available
         id: pixi-lock
         with:
           pixi-version: ${{env.PIXI_VERSION}}
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Restore cached pixi lockfile
-        uses: Parcels-code/pixi-lock/restore@2b823a4a804631370fbde7e6088ee5db71a26c60 # TODO: Update to action in prefix-dev once available
+        uses: Parcels-code/pixi-lock/restore@9a2866f8258b87a3c616d5ad7d51c6cd853df78b # TODO: Update to action in prefix-dev once available
         with:
           cache-key: ${{ needs.cache-pixi-lock.outputs.cache-key }}
       - uses: prefix-dev/setup-pixi@v0.9.0
@@ -138,7 +138,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Restore cached pixi lockfile
-        uses: Parcels-code/pixi-lock/restore@2b823a4a804631370fbde7e6088ee5db71a26c60 # TODO: Update to action in prefix-dev once available
+        uses: Parcels-code/pixi-lock/restore@9a2866f8258b87a3c616d5ad7d51c6cd853df78b # TODO: Update to action in prefix-dev once available
         with:
           cache-key: ${{ needs.cache-pixi-lock.outputs.cache-key }}
       - uses: prefix-dev/setup-pixi@v0.9.0
@@ -183,7 +183,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Restore cached pixi lockfile
-        uses: Parcels-code/pixi-lock/restore@2b823a4a804631370fbde7e6088ee5db71a26c60 # TODO: Update to action in prefix-dev once available
+        uses: Parcels-code/pixi-lock/restore@9a2866f8258b87a3c616d5ad7d51c6cd853df78b # TODO: Update to action in prefix-dev once available
         with:
           cache-key: ${{ needs.cache-pixi-lock.outputs.cache-key }}
       - uses: prefix-dev/setup-pixi@v0.9.0


### PR DESCRIPTION
There have been a few improvements to the action since last time.

Doing a git log...

```
commit 9a2866f8258b87a3c616d5ad7d51c6cd853df78b
Author: Nick Hodgskin <36369090+VeckoTheGecko@users.noreply.github.com>
Date:   Thu Jan 22 15:21:08 2026 +0100

    MAINT: Add clear-cache job (#12)

commit db461d0c51291113d871d597ae4702135b892d2f
Author: Nick Hodgskin <36369090+VeckoTheGecko@users.noreply.github.com>
Date:   Thu Jan 22 14:43:20 2026 +0100

    bugfix: Enable crossOsArchive when checking for existing cache (#11)

commit 82087290114bffa037dc527b2afc3d1c797eda8f
Author: Nick Hodgskin <36369090+VeckoTheGecko@users.noreply.github.com>
Date:   Tue Jan 20 17:15:32 2026 +0100

    Update README (#10)

commit 36b222f41a5b8e6a2efd83de9dc3eb37f535882f
Author: Nick Hodgskin <36369090+VeckoTheGecko@users.noreply.github.com>
Date:   Tue Jan 20 17:11:41 2026 +0100

    Disallow empty cache-key (#8)

commit 79d515de8aa310366c51987054450dd83758da18
Author: Nick Hodgskin <36369090+VeckoTheGecko@users.noreply.github.com>
Date:   Tue Jan 20 17:11:28 2026 +0100

    Update README (#9)

commit 249335d92109b0d797341cbfee3af8d07489ade9
Author: Nick Hodgskin <36369090+VeckoTheGecko@users.noreply.github.com>
Date:   Tue Jan 20 14:09:11 2026 +0100

    Add sha pins (#7)

commit 5cbd7a155fa24aa0711ec0a9aad9ede0819e84a1
Author: Vecko <36369090+VeckoTheGecko@users.noreply.github.com>
Date:   Tue Jan 20 10:05:10 2026 +0100

    Update README

```