### PR TITLE
DOC: Add descriptions to the Pixi tasks

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -63,8 +63,8 @@ pytest-html = "*"
 pytest-cov = "*"
 
 [feature.test.tasks]
-tests = "pytest"
-tests-notebooks = "pytest --nbval-lax docs/user_guide/examples"
+tests = { cmd = "pytest", description = "Run the test suite." }
+tests-notebooks = { cmd = "pytest --nbval-lax docs/user_guide/examples", description = "Run the user guide example notebooks as tests." }
 
 
 [feature.notebooks.dependencies]
@@ -87,21 +87,21 @@ sphinx-design = "*"
 sphinx-autoapi = "*"
 
 [feature.docs.tasks]
-docs = "sphinx-build docs docs/_build"
-docs-watch = 'sphinx-autobuild docs docs/_build'
-docs-linkcheck = "sphinx-build -b linkcheck docs/ docs/_build/linkcheck"
+docs = { cmd = "sphinx-build docs docs/_build", description = "Build the documentation." }
+docs-watch = { cmd = "sphinx-autobuild docs docs/_build", description = "Build and auto-rebuild the documentation on changes." }
+docs-linkcheck = { cmd = "sphinx-build -b linkcheck docs/ docs/_build/linkcheck", description = "Verify all links in documentation don't 404." }
 
 [feature.pre-commit.dependencies]
 pre_commit = "*"
 
 [feature.pre-commit.tasks]
-lint = "pre-commit run --all-files"
+lint = { cmd = "pre-commit run --all-files", description = "Run all pre-commit linting hooks." }
 
 [feature.numpydoc.dependencies]
 numpydoc = "*"
 
 [feature.numpydoc.tasks]
-numpydoc-lint = "python tools/numpydoc-public-api.py"
+numpydoc-lint = { cmd = "python tools/numpydoc-public-api.py", description = "Lint public API docstrings with numpydoc." }
 
 [feature.typing.dependencies]
 mypy = "*"
@@ -109,7 +109,7 @@ lxml = "*" # in CI
 types-tqdm = "*"
 
 [feature.typing.tasks]
-typing = "mypy src/parcels --install-types"
+typing = { cmd = "mypy src/parcels --install-types", description = "Run static type checking with mypy." }
 
 
 [environments]


### PR DESCRIPTION
Fixes None

Before:
```
❯ pixi task list           
Tasks that can run on this machine:
-----------------------------------
docs, docs-linkcheck, docs-watch, lint, numpydoc-lint, tests, tests-notebooks, typing
Task  Description
```
After:
```
❯ pixi task list
Tasks that can run on this machine:
-----------------------------------
docs, docs-linkcheck, docs-watch, lint, numpydoc-lint, tests, tests-notebooks, typing
Task             Description
docs             Build the documentation.
docs-linkcheck   Verify all links in documentation don't 404.
docs-watch       Build and auto-rebuild the documentation on changes.
lint             Run all pre-commit linting hooks.
numpydoc-lint    Lint public API docstrings with numpydoc.
tests            Run the test suite.
tests-notebooks  Run the user guide example notebooks as tests.
typing           Run static type checking with mypy.
```

Feel free to make any edits @erikvansebille  - I feel like this makes things a lot more accessible for new devs :) 