### PR TITLE
MAINT: Rename main to v3-support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: ci
 on:
   push:
     branches:
-      - "main"
-      - "test-me/*"
+      - "v3-support"
+      - "test-v3-support/*"
   pull_request:
-  schedule:
-    - cron: "0 7 * * 1" # Run every Monday at 7:00 UTC
+    branches:
+      - "v3-support"
 
 concurrency:
   group: branch-${{ github.head_ref }}


### PR DESCRIPTION
xref https://github.com/Parcels-code/Parcels/issues/2487#issuecomment-3907807625

Also removes the cron schedule as that can only be on the default branch. See https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule