### PR TITLE
DOC: Fix v4 link in header

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ If you need more help with Parcels, try the `Discussions page on GitHub <https:/
    :hidden:
 
    Home <self>
-   v4 <https://docs.oceanparcels.org/en/v4-dev/v4>
+   v4 <https://docs.oceanparcels.org/en/main/v4>
    Installation <installation>
    Tutorials & Documentation <documentation/index>
    API reference <reference>


### PR DESCRIPTION
@j-atkins noticed that the link in our header  on the doc site was broken.

I have re-configured our RTD build process and updated this link. Everything should be working as expected.

Now in RTD:
- "latest" points to latest version of `v3-support`
- "stable" points to latest released version
- "main" points to main