### PR TITLE
Relax metadata requirements

### DIFF
--- a/src/parcels/_core/field.py
+++ b/src/parcels/_core/field.py
@@ -418,15 +418,6 @@ def _assert_valid_uxdataarray(data: ux.UxDataArray):
             "This attribute is required for xarray.DataArray objects."
         )
 
-    # Validate attributes
-    required_keys = ["location", "mesh"]
-    for key in required_keys:
-        if key not in data.attrs.keys():
-            raise ValueError(
-                f"Field is missing a '{key}' attribute in the field's metadata. "
-                "This attribute is required for xarray.DataArray objects."
-            )
-
 
 def _assert_compatible_combination(data: xr.DataArray | ux.UxDataArray, grid: UxGrid | XGrid):
     if isinstance(data, ux.UxDataArray):


### PR DESCRIPTION
In testing ICON datasets, some do not have the `location` or `mesh` attributes defined in the generated uxarray datasets. Initially, I was thinking these attributes would be used for selecting default interpolation methods and would therefor be required. However, we've implemented interpolation method selection based of the combination of vertical and lateral dimension names and requiring these attributes is no longer necessary

This is related to https://github.com/Parcels-code/parcels-benchmarks/issues/38