### PR TITLE
MAINT: Set Pixi relative exclude-newer

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,9 +1,10 @@
 [workspace]
 name = "Parcels"
+exclude-newer = "5d" # security pre-caution against compromised packages
 preview = ["pixi-build"]
 channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
-requires-pixi = ">=0.63.0"
+requires-pixi = ">=0.67.0"
 
 [package]
 name = "parcels"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

As of yesterday, https://github.com/prefix-dev/pixi/releases/tag/v0.67.0 now has support for relative exclude newer. E.g.,

```toml
exclude-newer = "5d"
```
will exclude all packages that have been released within the last 5 days. This better safeguards us against packages being compromised and posting malicious code (these packages are often taken down within a few days). This is particularly useful since we don't commit a lockfile. We often don't work right at the bleeding edge - requiring 'just-released' features - so this wont affect us noticeably.

In security lingo this is known as a "dependency cooldown" (blog: [We should all be using dependency cooldowns](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns)). Many packages are adopting this. We have already adopted it for our GitHub Actions.

Note that this would need to be revisited if we decide to add a nightly testing environment in future. See https://github.com/pydata/xarray/pull/11269#discussion_r3058545037 for more discussion on that topic.
