### PR TITLE
MAINT: Add Zizmor as GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,3 +243,17 @@ jobs:
           done
         env:
           PREFIX_API_KEY: ${{ secrets.PREFIX_API_KEY }} # zizmor: ignore[secrets-outside-env]
+
+  zizmor:
+    name: GHA Security Analysis using Zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: v1.23.1
     hooks:
       - id: zizmor
+        args: ["--offline"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.9
     hooks:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None

The changes in the CI are copy paste from their docs

https://docs.zizmor.sh/integrations/#via-zizmorcorezizmor-action

---

This change is because the pre-commit context does not have access to a GitHub Token - which is used by Zizmor (e.g., to validate that projects have the same SHA pin as the version in the comment next to the pin)